### PR TITLE
Add ltdc signals

### DIFF
--- a/dts/st/f4/stm32f429a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429a(g-i)hx-pinctrl.dtsi
@@ -1086,6 +1086,220 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
 			/* SDIO */
 
 			sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f429b(e-g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429b(e-g-i)tx-pinctrl.dtsi
@@ -1136,6 +1136,332 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* SDIO */
 
 			sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f429i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429i(e-g)tx-pinctrl.dtsi
@@ -1136,6 +1136,220 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
 			/* SDIO */
 
 			sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f429i(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429i(e-g-i)hx-pinctrl.dtsi
@@ -1136,6 +1136,220 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
 			/* SDIO */
 
 			sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f429iitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429iitx-pinctrl.dtsi
@@ -1136,6 +1136,220 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
 			/* SDIO */
 
 			sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f429n(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429n(e-g)hx-pinctrl.dtsi
@@ -1136,6 +1136,332 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* SDIO */
 
 			sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f429nihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429nihx-pinctrl.dtsi
@@ -1136,6 +1136,332 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* SDIO */
 
 			sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f429v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429v(e-g)tx-pinctrl.dtsi
@@ -689,6 +689,112 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
 			/* SDIO */
 
 			sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f429vitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429vitx-pinctrl.dtsi
@@ -689,6 +689,112 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
 			/* SDIO */
 
 			sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f429z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429z(e-g)tx-pinctrl.dtsi
@@ -927,6 +927,144 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
 			/* SDIO */
 
 			sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f429zgyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429zgyx-pinctrl.dtsi
@@ -927,6 +927,144 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
 			/* SDIO */
 
 			sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f429zitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429zitx-pinctrl.dtsi
@@ -927,6 +927,144 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
 			/* SDIO */
 
 			sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f429ziyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429ziyx-pinctrl.dtsi
@@ -927,6 +927,144 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
 			/* SDIO */
 
 			sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f439aihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439aihx-pinctrl.dtsi
@@ -1086,6 +1086,220 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
 			/* SDIO */
 
 			sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f439b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439b(g-i)tx-pinctrl.dtsi
@@ -1136,6 +1136,332 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* SDIO */
 
 			sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f439i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439i(g-i)hx-pinctrl.dtsi
@@ -1136,6 +1136,220 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
 			/* SDIO */
 
 			sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f439i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439i(g-i)tx-pinctrl.dtsi
@@ -1136,6 +1136,220 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
 			/* SDIO */
 
 			sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f439n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439n(g-i)hx-pinctrl.dtsi
@@ -1136,6 +1136,332 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* SDIO */
 
 			sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f439v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439v(g-i)tx-pinctrl.dtsi
@@ -689,6 +689,112 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
 			/* SDIO */
 
 			sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f439z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439z(g-i)tx-pinctrl.dtsi
@@ -927,6 +927,144 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
 			/* SDIO */
 
 			sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f439z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439z(g-i)yx-pinctrl.dtsi
@@ -927,6 +927,144 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
 			/* SDIO */
 
 			sdio_d4_pb8: sdio_d4_pb8 {

--- a/dts/st/f4/stm32f469a(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469a(e-g-i)hx-pinctrl.dtsi
@@ -871,6 +871,272 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f4/stm32f469a(e-g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469a(e-g-i)yx-pinctrl.dtsi
@@ -871,6 +871,272 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f4/stm32f469b(e-g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469b(e-g-i)tx-pinctrl.dtsi
@@ -1169,6 +1169,368 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_g4_pj13: ltdc_g4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f4/stm32f469i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469i(e-g)tx-pinctrl.dtsi
@@ -1105,6 +1105,240 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f4/stm32f469i(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469i(e-g-i)hx-pinctrl.dtsi
@@ -1105,6 +1105,240 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f4/stm32f469iitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469iitx-pinctrl.dtsi
@@ -1105,6 +1105,240 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f4/stm32f469n(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469n(e-g)hx-pinctrl.dtsi
@@ -1169,6 +1169,368 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_g4_pj13: ltdc_g4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f4/stm32f469nihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469nihx-pinctrl.dtsi
@@ -1169,6 +1169,368 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_g4_pj13: ltdc_g4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f4/stm32f469v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469v(e-g)tx-pinctrl.dtsi
@@ -513,6 +513,132 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f4/stm32f469vitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469vitx-pinctrl.dtsi
@@ -513,6 +513,132 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f4/stm32f469z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469z(e-g)tx-pinctrl.dtsi
@@ -755,6 +755,180 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f4/stm32f469zitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469zitx-pinctrl.dtsi
@@ -755,6 +755,180 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f4/stm32f479a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479a(g-i)hx-pinctrl.dtsi
@@ -871,6 +871,272 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f4/stm32f479a(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479a(g-i)yx-pinctrl.dtsi
@@ -871,6 +871,272 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f4/stm32f479b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479b(g-i)tx-pinctrl.dtsi
@@ -1169,6 +1169,368 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_g4_pj13: ltdc_g4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f4/stm32f479i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479i(g-i)hx-pinctrl.dtsi
@@ -1105,6 +1105,240 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f4/stm32f479i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479i(g-i)tx-pinctrl.dtsi
@@ -1105,6 +1105,240 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f4/stm32f479n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479n(g-i)hx-pinctrl.dtsi
@@ -1169,6 +1169,368 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_g4_pj13: ltdc_g4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f4/stm32f479v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479v(g-i)tx-pinctrl.dtsi
@@ -513,6 +513,132 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f4/stm32f479z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479z(g-i)tx-pinctrl.dtsi
@@ -755,6 +755,180 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f746b(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746b(e-g)tx-pinctrl.dtsi
@@ -1245,6 +1245,356 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f746i(e-g)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746i(e-g)kx-pinctrl.dtsi
@@ -1245,6 +1245,244 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f746ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746ietx-pinctrl.dtsi
@@ -1245,6 +1245,244 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f746igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746igtx-pinctrl.dtsi
@@ -1245,6 +1245,244 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f746nehx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746nehx-pinctrl.dtsi
@@ -1245,6 +1245,356 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f746nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746nghx-pinctrl.dtsi
@@ -1245,6 +1245,356 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f746v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746v(e-g)hx-pinctrl.dtsi
@@ -792,6 +792,128 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f746vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746vetx-pinctrl.dtsi
@@ -792,6 +792,128 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f746vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746vgtx-pinctrl.dtsi
@@ -792,6 +792,128 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f746z(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746z(e-g)yx-pinctrl.dtsi
@@ -1024,6 +1024,168 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f746zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746zetx-pinctrl.dtsi
@@ -1024,6 +1024,168 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f746zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746zgtx-pinctrl.dtsi
@@ -1024,6 +1024,168 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f750n8hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750n8hx-pinctrl.dtsi
@@ -1245,6 +1245,356 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f750v8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750v8tx-pinctrl.dtsi
@@ -792,6 +792,128 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f750z8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750z8tx-pinctrl.dtsi
@@ -1024,6 +1024,168 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f756bgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756bgtx-pinctrl.dtsi
@@ -1245,6 +1245,356 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f756igkx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756igkx-pinctrl.dtsi
@@ -1245,6 +1245,244 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f756igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756igtx-pinctrl.dtsi
@@ -1245,6 +1245,244 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f756nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756nghx-pinctrl.dtsi
@@ -1245,6 +1245,356 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f756vghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756vghx-pinctrl.dtsi
@@ -792,6 +792,128 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f756vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756vgtx-pinctrl.dtsi
@@ -792,6 +792,128 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f756zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756zgtx-pinctrl.dtsi
@@ -1024,6 +1024,168 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f756zgyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756zgyx-pinctrl.dtsi
@@ -1024,6 +1024,168 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f767b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767b(g-i)tx-pinctrl.dtsi
@@ -1344,6 +1344,428 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF9)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_g4_pj13: ltdc_g4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f767i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767i(g-i)kx-pinctrl.dtsi
@@ -1344,6 +1344,300 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF9)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f767i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767i(g-i)tx-pinctrl.dtsi
@@ -1344,6 +1344,300 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF9)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f767n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767n(g-i)hx-pinctrl.dtsi
@@ -1344,6 +1344,428 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF9)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_g4_pj13: ltdc_g4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f767vghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vghx-pinctrl.dtsi
@@ -871,6 +871,168 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF9)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f767vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vgtx-pinctrl.dtsi
@@ -871,6 +871,168 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF9)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f767vihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vihx-pinctrl.dtsi
@@ -871,6 +871,168 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF9)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f767vitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vitx-pinctrl.dtsi
@@ -871,6 +871,168 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF9)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f767zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767zgtx-pinctrl.dtsi
@@ -1118,6 +1118,212 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF9)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f767zitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767zitx-pinctrl.dtsi
@@ -1118,6 +1118,212 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF9)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f768aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f768aiyx-pinctrl.dtsi
@@ -1046,6 +1046,296 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF9)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f769a(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769a(g-i)yx-pinctrl.dtsi
@@ -1046,6 +1046,296 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF9)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f769b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769b(g-i)tx-pinctrl.dtsi
@@ -1344,6 +1344,392 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF9)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_g4_pj13: ltdc_g4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f769igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769igtx-pinctrl.dtsi
@@ -1263,6 +1263,264 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF9)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f769iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769iitx-pinctrl.dtsi
@@ -1263,6 +1263,264 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF9)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f769nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769nghx-pinctrl.dtsi
@@ -1344,6 +1344,392 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF9)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_g4_pj13: ltdc_g4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f769nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769nihx-pinctrl.dtsi
@@ -1344,6 +1344,392 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF9)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_g4_pj13: ltdc_g4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f777bitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777bitx-pinctrl.dtsi
@@ -1344,6 +1344,428 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF9)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_g4_pj13: ltdc_g4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f777iikx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777iikx-pinctrl.dtsi
@@ -1344,6 +1344,300 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF9)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f777iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777iitx-pinctrl.dtsi
@@ -1344,6 +1344,300 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF9)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f777nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777nihx-pinctrl.dtsi
@@ -1344,6 +1344,428 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF9)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_g4_pj13: ltdc_g4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f777vihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777vihx-pinctrl.dtsi
@@ -871,6 +871,168 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF9)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f777vitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777vitx-pinctrl.dtsi
@@ -871,6 +871,168 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF9)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f777zitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777zitx-pinctrl.dtsi
@@ -1118,6 +1118,212 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF9)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f778aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f778aiyx-pinctrl.dtsi
@@ -1046,6 +1046,296 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF9)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f779aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779aiyx-pinctrl.dtsi
@@ -1046,6 +1046,296 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF9)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f779bitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779bitx-pinctrl.dtsi
@@ -1344,6 +1344,392 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF9)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_g4_pj13: ltdc_g4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f779iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779iitx-pinctrl.dtsi
@@ -1263,6 +1263,264 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF9)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/f7/stm32f779nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779nihx-pinctrl.dtsi
@@ -1344,6 +1344,392 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF9)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_g4_pj13: ltdc_g4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h723vehx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vehx-pinctrl.dtsi
@@ -943,6 +943,236 @@
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h723vetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vetx-pinctrl.dtsi
@@ -943,6 +943,236 @@
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h723vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vghx-pinctrl.dtsi
@@ -943,6 +943,236 @@
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h723vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vgtx-pinctrl.dtsi
@@ -943,6 +943,236 @@
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h723zeix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zeix-pinctrl.dtsi
@@ -1300,6 +1300,280 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h723zetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zetx-pinctrl.dtsi
@@ -1272,6 +1272,280 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h723zgix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zgix-pinctrl.dtsi
@@ -1300,6 +1300,280 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h723zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zgtx-pinctrl.dtsi
@@ -1272,6 +1272,280 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725aeix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725aeix-pinctrl.dtsi
@@ -1467,6 +1467,312 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725agix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725agix-pinctrl.dtsi
@@ -1467,6 +1467,312 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725iekx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725iekx-pinctrl.dtsi
@@ -1553,6 +1553,332 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725ietx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725ietx-pinctrl.dtsi
@@ -1272,6 +1272,308 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725igkx-pinctrl.dtsi
@@ -1553,6 +1553,332 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725igtx-pinctrl.dtsi
@@ -1272,6 +1272,308 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725revx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725revx-pinctrl.dtsi
@@ -391,6 +391,176 @@
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725rgvx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725rgvx-pinctrl.dtsi
@@ -391,6 +391,176 @@
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725vehx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vehx-pinctrl.dtsi
@@ -913,6 +913,216 @@
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725vetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vetx-pinctrl.dtsi
@@ -865,6 +865,200 @@
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vghx-pinctrl.dtsi
@@ -913,6 +913,216 @@
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vgtx-pinctrl.dtsi
@@ -865,6 +865,200 @@
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725vgyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vgyx-pinctrl.dtsi
@@ -827,6 +827,200 @@
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725zetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725zetx-pinctrl.dtsi
@@ -1130,6 +1130,280 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h725zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725zgtx-pinctrl.dtsi
@@ -1130,6 +1130,280 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h730abixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730abixq-pinctrl.dtsi
@@ -1420,6 +1420,308 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h730ibkxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730ibkxq-pinctrl.dtsi
@@ -1506,6 +1506,328 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h730ibtxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730ibtxq-pinctrl.dtsi
@@ -1246,6 +1246,308 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h730vbhx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730vbhx-pinctrl.dtsi
@@ -917,6 +917,236 @@
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h730vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730vbtx-pinctrl.dtsi
@@ -917,6 +917,236 @@
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h730zbix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730zbix-pinctrl.dtsi
@@ -1300,6 +1300,280 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h730zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730zbtx-pinctrl.dtsi
@@ -1246,6 +1246,280 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h733vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733vghx-pinctrl.dtsi
@@ -943,6 +943,236 @@
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h733vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733vgtx-pinctrl.dtsi
@@ -943,6 +943,236 @@
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h733zgix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733zgix-pinctrl.dtsi
@@ -1300,6 +1300,280 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h733zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733zgtx-pinctrl.dtsi
@@ -1272,6 +1272,280 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h735agix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735agix-pinctrl.dtsi
@@ -1467,6 +1467,312 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h735igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735igkx-pinctrl.dtsi
@@ -1553,6 +1553,332 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h735igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735igtx-pinctrl.dtsi
@@ -1272,6 +1272,308 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h735rgvx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735rgvx-pinctrl.dtsi
@@ -391,6 +391,176 @@
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h735vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vghx-pinctrl.dtsi
@@ -913,6 +913,216 @@
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h735vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vgtx-pinctrl.dtsi
@@ -865,6 +865,200 @@
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h735vgyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vgyx-pinctrl.dtsi
@@ -827,6 +827,200 @@
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h735zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735zgtx-pinctrl.dtsi
@@ -1130,6 +1130,280 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF3)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
@@ -1459,6 +1459,12 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
@@ -1253,6 +1253,280 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
@@ -1358,6 +1358,424 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_b4_pj13: ltdc_b4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h743bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bitx-pinctrl.dtsi
@@ -1358,6 +1358,424 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_b4_pj13: ltdc_b4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h743igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igkx-pinctrl.dtsi
@@ -1358,6 +1358,296 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h743igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igtx-pinctrl.dtsi
@@ -1358,6 +1358,296 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h743iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iikx-pinctrl.dtsi
@@ -1358,6 +1358,296 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h743iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iitx-pinctrl.dtsi
@@ -1358,6 +1358,296 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
@@ -818,6 +818,164 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
@@ -818,6 +818,164 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h743vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vitx-pinctrl.dtsi
@@ -818,6 +818,164 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h743xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xghx-pinctrl.dtsi
@@ -1459,6 +1459,428 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_b4_pj13: ltdc_b4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h743xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xihx-pinctrl.dtsi
@@ -1459,6 +1459,428 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_b4_pj13: ltdc_b4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
@@ -1110,6 +1110,208 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h743zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zitx-pinctrl.dtsi
@@ -1110,6 +1110,208 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
@@ -1358,6 +1358,340 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h745bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bitx-pinctrl.dtsi
@@ -1358,6 +1358,340 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h745igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igkx-pinctrl.dtsi
@@ -1381,6 +1381,260 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h745igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igtx-pinctrl.dtsi
@@ -1110,6 +1110,236 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h745iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iikx-pinctrl.dtsi
@@ -1381,6 +1381,260 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h745iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iitx-pinctrl.dtsi
@@ -1110,6 +1110,236 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h745xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xghx-pinctrl.dtsi
@@ -1459,6 +1459,428 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_b4_pj13: ltdc_b4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h745xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xihx-pinctrl.dtsi
@@ -1459,6 +1459,428 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_b4_pj13: ltdc_b4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
@@ -980,6 +980,208 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h745zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zitx-pinctrl.dtsi
@@ -980,6 +980,208 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
@@ -1110,6 +1110,208 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
@@ -1358,6 +1358,304 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h747bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bitx-pinctrl.dtsi
@@ -1358,6 +1358,304 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h747igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747igtx-pinctrl.dtsi
@@ -1110,6 +1110,208 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h747iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747iitx-pinctrl.dtsi
@@ -1110,6 +1110,208 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h747xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xghx-pinctrl.dtsi
@@ -1459,6 +1459,428 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_b4_pj13: ltdc_b4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h747xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xihx-pinctrl.dtsi
@@ -1459,6 +1459,428 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_b4_pj13: ltdc_b4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
@@ -1001,6 +1001,168 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
@@ -1358,6 +1358,296 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
@@ -1358,6 +1358,296 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
@@ -818,6 +818,164 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
@@ -1459,6 +1459,428 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_b4_pj13: ltdc_b4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
@@ -1110,6 +1110,208 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h753aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753aiix-pinctrl.dtsi
@@ -1253,6 +1253,280 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h753bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753bitx-pinctrl.dtsi
@@ -1358,6 +1358,424 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_b4_pj13: ltdc_b4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h753iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iikx-pinctrl.dtsi
@@ -1358,6 +1358,296 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h753iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iitx-pinctrl.dtsi
@@ -1358,6 +1358,296 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h753vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vihx-pinctrl.dtsi
@@ -818,6 +818,164 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h753vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vitx-pinctrl.dtsi
@@ -818,6 +818,164 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h753xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753xihx-pinctrl.dtsi
@@ -1459,6 +1459,428 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_b4_pj13: ltdc_b4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h753zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753zitx-pinctrl.dtsi
@@ -1110,6 +1110,208 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h755bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755bitx-pinctrl.dtsi
@@ -1358,6 +1358,340 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h755iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iikx-pinctrl.dtsi
@@ -1381,6 +1381,260 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h755iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iitx-pinctrl.dtsi
@@ -1110,6 +1110,236 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h755xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755xihx-pinctrl.dtsi
@@ -1459,6 +1459,428 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_b4_pj13: ltdc_b4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h755zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755zitx-pinctrl.dtsi
@@ -980,6 +980,208 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h757aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757aiix-pinctrl.dtsi
@@ -1110,6 +1110,208 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h757bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757bitx-pinctrl.dtsi
@@ -1358,6 +1358,304 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h757iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757iitx-pinctrl.dtsi
@@ -1110,6 +1110,208 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h757xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757xihx-pinctrl.dtsi
@@ -1459,6 +1459,428 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_b4_pj13: ltdc_b4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
@@ -1001,6 +1001,168 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
@@ -1034,6 +1034,312 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
@@ -1107,6 +1107,368 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
@@ -1094,6 +1094,332 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
@@ -1107,6 +1107,368 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
@@ -912,6 +912,308 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
@@ -1167,6 +1167,500 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_b4_pj13: ltdc_b4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
@@ -1107,6 +1107,496 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_b4_pj13: ltdc_b4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3qiyxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3qiyxq-pinctrl.dtsi
@@ -750,6 +750,264 @@
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3r(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3r(g-i)tx-pinctrl.dtsi
@@ -389,6 +389,176 @@
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)hx-pinctrl.dtsi
@@ -684,6 +684,236 @@
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3v(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)hxq-pinctrl.dtsi
@@ -654,6 +654,216 @@
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)tx-pinctrl.dtsi
@@ -684,6 +684,236 @@
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3v(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)txq-pinctrl.dtsi
@@ -612,6 +612,204 @@
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
@@ -912,6 +912,280 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7a3z(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)txq-pinctrl.dtsi
@@ -798,6 +798,280 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
@@ -1034,6 +1034,312 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
@@ -1094,6 +1094,332 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
@@ -1107,6 +1107,368 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b0rbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0rbtx-pinctrl.dtsi
@@ -389,6 +389,176 @@
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b0vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0vbtx-pinctrl.dtsi
@@ -684,6 +684,236 @@
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
@@ -912,6 +912,280 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
@@ -1034,6 +1034,312 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
@@ -1107,6 +1107,368 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
@@ -1094,6 +1094,332 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
@@ -1107,6 +1107,368 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
@@ -912,6 +912,308 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
@@ -1167,6 +1167,500 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_b4_pj13: ltdc_b4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
@@ -1107,6 +1107,496 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_b4_pj13: ltdc_b4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3qiyxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3qiyxq-pinctrl.dtsi
@@ -750,6 +750,264 @@
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3ritx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3ritx-pinctrl.dtsi
@@ -389,6 +389,176 @@
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vihx-pinctrl.dtsi
@@ -684,6 +684,236 @@
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3vihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vihxq-pinctrl.dtsi
@@ -654,6 +654,216 @@
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vitx-pinctrl.dtsi
@@ -684,6 +684,236 @@
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3vitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vitxq-pinctrl.dtsi
@@ -612,6 +612,204 @@
 				pinmux = <STM32_PINMUX('A', 15, AF7)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
@@ -912,6 +912,280 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h7b3zitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitxq-pinctrl.dtsi
@@ -798,6 +798,280 @@
 				pinmux = <STM32_PINMUX('G', 8, AF5)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_vsync_pa7: ltdc_vsync_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF14)>;
+			};
+
+			ltdc_b3_pa8: ltdc_b3_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_b4_pa10: ltdc_b4_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF12)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_b6_pa15: ltdc_b6_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_r3_pa15: ltdc_r3_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF9)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_b5_pb5: ltdc_b5_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF11)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_clk_pb14: ltdc_clk_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF14)>;
+			};
+
+			ltdc_g7_pb15: ltdc_g7_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF14)>;
+			};
+
+			ltdc_g2_pc0: ltdc_g2_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_g5_pc1: ltdc_g5_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF14)>;
+			};
+
+			ltdc_r7_pc4: ltdc_r7_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF14)>;
+			};
+
+			ltdc_de_pc5: ltdc_de_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_g3_pc9: ltdc_g3_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF10)>;
+			};
+
+			ltdc_b1_pc10: ltdc_b1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF10)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_b4_pc11: ltdc_b4_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF14)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF14)>;
+			};
+
+			ltdc_b1_pd0: ltdc_b1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF14)>;
+			};
+
+			ltdc_b2_pd2: ltdc_b2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF14)>;
+			};
+
+			ltdc_b7_pd2: ltdc_b7_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF9)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r0_pe0: ltdc_r0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF14)>;
+			};
+
+			ltdc_r6_pe1: ltdc_r6_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4p5a(g-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5a(g-e)ix-pinctrl.dtsi
@@ -718,6 +718,228 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_clk_pa4: ltdc_clk_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+			};
+
+			ltdc_r7_pa5: ltdc_r7_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+			};
+
+			ltdc_b7_pa8: ltdc_b7_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+			};
+
+			ltdc_g7_pa9: ltdc_g7_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF11)>;
+			};
+
+			ltdc_g6_pa10: ltdc_g6_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF11)>;
+			};
+
+			ltdc_de_pa11: ltdc_de_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+			};
+
+			ltdc_vsync_pa12: ltdc_vsync_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+			};
+
+			ltdc_hsync_pa15: ltdc_hsync_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+			};
+
+			ltdc_b6_pb0: ltdc_b6_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+			};
+
+			ltdc_g6_pb1: ltdc_g6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+			};
+
+			ltdc_r6_pb6: ltdc_r6_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+			};
+
+			ltdc_vsync_pb7: ltdc_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+			};
+
+			ltdc_de_pb8: ltdc_de_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_vsync_pb11: ltdc_vsync_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+			};
+
+			ltdc_de_pc0: ltdc_de_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_hsync_pc2: ltdc_hsync_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+			};
+
+			ltdc_clk_pc5: ltdc_clk_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+			};
+
+			ltdc_g7_pc6: ltdc_g7_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_b6_pc7: ltdc_b6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF11)>;
+			};
+
+			ltdc_b4_pd0: ltdc_b4_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+			};
+
+			ltdc_b5_pd1: ltdc_b5_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+			};
+
+			ltdc_clk_pd3: ltdc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF11)>;
+			};
+
+			ltdc_de_pd6: ltdc_de_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF11)>;
+			};
+
+			ltdc_r3_pd8: ltdc_r3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+			};
+
+			ltdc_r4_pd9: ltdc_r4_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF11)>;
+			};
+
+			ltdc_r5_pd10: ltdc_r5_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF11)>;
+			};
+
+			ltdc_r6_pd11: ltdc_r6_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF11)>;
+			};
+
+			ltdc_r7_pd12: ltdc_r7_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF11)>;
+			};
+
+			ltdc_b2_pd14: ltdc_b2_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+			};
+
+			ltdc_b3_pd15: ltdc_b3_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF11)>;
+			};
+
+			ltdc_hsync_pe0: ltdc_hsync_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF11)>;
+			};
+
+			ltdc_vsync_pe1: ltdc_vsync_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF11)>;
+			};
+
+			ltdc_r7_pe2: ltdc_r7_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+			};
+
+			ltdc_r6_pe3: ltdc_r6_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+			};
+
+			ltdc_b7_pe4: ltdc_b7_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF11)>;
+			};
+
+			ltdc_g7_pe5: ltdc_g7_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF11)>;
+			};
+
+			ltdc_g6_pe6: ltdc_g6_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+			};
+
+			ltdc_b6_pe7: ltdc_b6_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF11)>;
+			};
+
+			ltdc_b7_pe8: ltdc_b7_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF11)>;
+			};
+
+			ltdc_g2_pe9: ltdc_g2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF11)>;
+			};
+
+			ltdc_g3_pe10: ltdc_g3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF11)>;
+			};
+
+			ltdc_g4_pe11: ltdc_g4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+			};
+
+			ltdc_g5_pe12: ltdc_g5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF11)>;
+			};
+
+			ltdc_g6_pe13: ltdc_g6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF11)>;
+			};
+
+			ltdc_g7_pe14: ltdc_g7_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF11)>;
+			};
+
+			ltdc_r2_pe15: ltdc_r2_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF11)>;
+			};
+
+			ltdc_de_pf11: ltdc_de_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+			};
+
+			ltdc_b0_pf12: ltdc_b0_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF11)>;
+			};
+
+			ltdc_b1_pf13: ltdc_b1_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF11)>;
+			};
+
+			ltdc_g0_pf14: ltdc_g0_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF11)>;
+			};
+
+			ltdc_g1_pf15: ltdc_g1_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF11)>;
+			};
+
+			ltdc_r1_pg6: ltdc_r1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+			};
+
+			ltdc_r1_pg14: ltdc_r1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4p5agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5agixp-pinctrl.dtsi
@@ -718,6 +718,228 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_clk_pa4: ltdc_clk_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+			};
+
+			ltdc_r7_pa5: ltdc_r7_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+			};
+
+			ltdc_b7_pa8: ltdc_b7_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+			};
+
+			ltdc_g7_pa9: ltdc_g7_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF11)>;
+			};
+
+			ltdc_g6_pa10: ltdc_g6_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF11)>;
+			};
+
+			ltdc_de_pa11: ltdc_de_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+			};
+
+			ltdc_vsync_pa12: ltdc_vsync_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+			};
+
+			ltdc_hsync_pa15: ltdc_hsync_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+			};
+
+			ltdc_b6_pb0: ltdc_b6_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+			};
+
+			ltdc_g6_pb1: ltdc_g6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+			};
+
+			ltdc_r6_pb6: ltdc_r6_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+			};
+
+			ltdc_vsync_pb7: ltdc_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+			};
+
+			ltdc_de_pb8: ltdc_de_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_vsync_pb11: ltdc_vsync_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+			};
+
+			ltdc_de_pc0: ltdc_de_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_hsync_pc2: ltdc_hsync_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+			};
+
+			ltdc_clk_pc5: ltdc_clk_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+			};
+
+			ltdc_g7_pc6: ltdc_g7_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_b6_pc7: ltdc_b6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF11)>;
+			};
+
+			ltdc_b4_pd0: ltdc_b4_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+			};
+
+			ltdc_b5_pd1: ltdc_b5_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+			};
+
+			ltdc_clk_pd3: ltdc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF11)>;
+			};
+
+			ltdc_de_pd6: ltdc_de_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF11)>;
+			};
+
+			ltdc_r3_pd8: ltdc_r3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+			};
+
+			ltdc_r4_pd9: ltdc_r4_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF11)>;
+			};
+
+			ltdc_r5_pd10: ltdc_r5_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF11)>;
+			};
+
+			ltdc_r6_pd11: ltdc_r6_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF11)>;
+			};
+
+			ltdc_r7_pd12: ltdc_r7_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF11)>;
+			};
+
+			ltdc_b2_pd14: ltdc_b2_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+			};
+
+			ltdc_b3_pd15: ltdc_b3_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF11)>;
+			};
+
+			ltdc_hsync_pe0: ltdc_hsync_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF11)>;
+			};
+
+			ltdc_vsync_pe1: ltdc_vsync_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF11)>;
+			};
+
+			ltdc_r7_pe2: ltdc_r7_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+			};
+
+			ltdc_r6_pe3: ltdc_r6_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+			};
+
+			ltdc_b7_pe4: ltdc_b7_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF11)>;
+			};
+
+			ltdc_g7_pe5: ltdc_g7_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF11)>;
+			};
+
+			ltdc_g6_pe6: ltdc_g6_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+			};
+
+			ltdc_b6_pe7: ltdc_b6_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF11)>;
+			};
+
+			ltdc_b7_pe8: ltdc_b7_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF11)>;
+			};
+
+			ltdc_g2_pe9: ltdc_g2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF11)>;
+			};
+
+			ltdc_g3_pe10: ltdc_g3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF11)>;
+			};
+
+			ltdc_g4_pe11: ltdc_g4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+			};
+
+			ltdc_g5_pe12: ltdc_g5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF11)>;
+			};
+
+			ltdc_g6_pe13: ltdc_g6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF11)>;
+			};
+
+			ltdc_g7_pe14: ltdc_g7_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF11)>;
+			};
+
+			ltdc_r2_pe15: ltdc_r2_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF11)>;
+			};
+
+			ltdc_de_pf11: ltdc_de_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+			};
+
+			ltdc_b0_pf12: ltdc_b0_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF11)>;
+			};
+
+			ltdc_b1_pf13: ltdc_b1_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF11)>;
+			};
+
+			ltdc_g0_pf14: ltdc_g0_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF11)>;
+			};
+
+			ltdc_g1_pf15: ltdc_g1_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF11)>;
+			};
+
+			ltdc_r1_pg6: ltdc_r1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+			};
+
+			ltdc_r1_pg14: ltdc_r1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4p5c(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5c(g-e)tx-pinctrl.dtsi
@@ -212,6 +212,64 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_clk_pa4: ltdc_clk_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+			};
+
+			ltdc_r7_pa5: ltdc_r7_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+			};
+
+			ltdc_b7_pa8: ltdc_b7_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+			};
+
+			ltdc_g7_pa9: ltdc_g7_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF11)>;
+			};
+
+			ltdc_g6_pa10: ltdc_g6_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF11)>;
+			};
+
+			ltdc_de_pa11: ltdc_de_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+			};
+
+			ltdc_vsync_pa12: ltdc_vsync_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+			};
+
+			ltdc_hsync_pa15: ltdc_hsync_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+			};
+
+			ltdc_b6_pb0: ltdc_b6_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+			};
+
+			ltdc_g6_pb1: ltdc_g6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+			};
+
+			ltdc_r6_pb6: ltdc_r6_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+			};
+
+			ltdc_vsync_pb7: ltdc_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+			};
+
+			ltdc_de_pb8: ltdc_de_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_vsync_pb11: ltdc_vsync_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc2_cmd_pa1: sdmmc2_cmd_pa1 {

--- a/dts/st/l4/stm32l4p5c(g-e)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5c(g-e)ux-pinctrl.dtsi
@@ -212,6 +212,64 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_clk_pa4: ltdc_clk_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+			};
+
+			ltdc_r7_pa5: ltdc_r7_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+			};
+
+			ltdc_b7_pa8: ltdc_b7_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+			};
+
+			ltdc_g7_pa9: ltdc_g7_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF11)>;
+			};
+
+			ltdc_g6_pa10: ltdc_g6_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF11)>;
+			};
+
+			ltdc_de_pa11: ltdc_de_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+			};
+
+			ltdc_vsync_pa12: ltdc_vsync_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+			};
+
+			ltdc_hsync_pa15: ltdc_hsync_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+			};
+
+			ltdc_b6_pb0: ltdc_b6_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+			};
+
+			ltdc_g6_pb1: ltdc_g6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+			};
+
+			ltdc_r6_pb6: ltdc_r6_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+			};
+
+			ltdc_vsync_pb7: ltdc_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+			};
+
+			ltdc_de_pb8: ltdc_de_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_vsync_pb11: ltdc_vsync_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc2_cmd_pa1: sdmmc2_cmd_pa1 {

--- a/dts/st/l4/stm32l4p5cgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5cgtxp-pinctrl.dtsi
@@ -189,6 +189,56 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_clk_pa4: ltdc_clk_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+			};
+
+			ltdc_r7_pa5: ltdc_r7_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+			};
+
+			ltdc_b7_pa8: ltdc_b7_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+			};
+
+			ltdc_g7_pa9: ltdc_g7_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF11)>;
+			};
+
+			ltdc_g6_pa10: ltdc_g6_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF11)>;
+			};
+
+			ltdc_de_pa11: ltdc_de_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+			};
+
+			ltdc_vsync_pa12: ltdc_vsync_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+			};
+
+			ltdc_hsync_pa15: ltdc_hsync_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+			};
+
+			ltdc_b6_pb0: ltdc_b6_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+			};
+
+			ltdc_g6_pb1: ltdc_g6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+			};
+
+			ltdc_r6_pb6: ltdc_r6_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+			};
+
+			ltdc_vsync_pb7: ltdc_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc2_cmd_pa1: sdmmc2_cmd_pa1 {

--- a/dts/st/l4/stm32l4p5cguxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5cguxp-pinctrl.dtsi
@@ -189,6 +189,56 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_clk_pa4: ltdc_clk_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+			};
+
+			ltdc_r7_pa5: ltdc_r7_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+			};
+
+			ltdc_b7_pa8: ltdc_b7_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+			};
+
+			ltdc_g7_pa9: ltdc_g7_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF11)>;
+			};
+
+			ltdc_g6_pa10: ltdc_g6_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF11)>;
+			};
+
+			ltdc_de_pa11: ltdc_de_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+			};
+
+			ltdc_vsync_pa12: ltdc_vsync_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+			};
+
+			ltdc_hsync_pa15: ltdc_hsync_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+			};
+
+			ltdc_b6_pb0: ltdc_b6_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+			};
+
+			ltdc_g6_pb1: ltdc_g6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+			};
+
+			ltdc_r6_pb6: ltdc_r6_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+			};
+
+			ltdc_vsync_pb7: ltdc_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc2_cmd_pa1: sdmmc2_cmd_pa1 {

--- a/dts/st/l4/stm32l4p5q(g-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5q(g-e)ix-pinctrl.dtsi
@@ -685,6 +685,228 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_clk_pa4: ltdc_clk_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+			};
+
+			ltdc_r7_pa5: ltdc_r7_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+			};
+
+			ltdc_b7_pa8: ltdc_b7_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+			};
+
+			ltdc_g7_pa9: ltdc_g7_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF11)>;
+			};
+
+			ltdc_g6_pa10: ltdc_g6_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF11)>;
+			};
+
+			ltdc_de_pa11: ltdc_de_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+			};
+
+			ltdc_vsync_pa12: ltdc_vsync_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+			};
+
+			ltdc_hsync_pa15: ltdc_hsync_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+			};
+
+			ltdc_b6_pb0: ltdc_b6_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+			};
+
+			ltdc_g6_pb1: ltdc_g6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+			};
+
+			ltdc_r6_pb6: ltdc_r6_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+			};
+
+			ltdc_vsync_pb7: ltdc_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+			};
+
+			ltdc_de_pb8: ltdc_de_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_vsync_pb11: ltdc_vsync_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+			};
+
+			ltdc_de_pc0: ltdc_de_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_hsync_pc2: ltdc_hsync_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+			};
+
+			ltdc_clk_pc5: ltdc_clk_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+			};
+
+			ltdc_g7_pc6: ltdc_g7_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_b6_pc7: ltdc_b6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF11)>;
+			};
+
+			ltdc_b4_pd0: ltdc_b4_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+			};
+
+			ltdc_b5_pd1: ltdc_b5_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+			};
+
+			ltdc_clk_pd3: ltdc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF11)>;
+			};
+
+			ltdc_de_pd6: ltdc_de_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF11)>;
+			};
+
+			ltdc_r3_pd8: ltdc_r3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+			};
+
+			ltdc_r4_pd9: ltdc_r4_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF11)>;
+			};
+
+			ltdc_r5_pd10: ltdc_r5_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF11)>;
+			};
+
+			ltdc_r6_pd11: ltdc_r6_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF11)>;
+			};
+
+			ltdc_r7_pd12: ltdc_r7_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF11)>;
+			};
+
+			ltdc_b2_pd14: ltdc_b2_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+			};
+
+			ltdc_b3_pd15: ltdc_b3_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF11)>;
+			};
+
+			ltdc_hsync_pe0: ltdc_hsync_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF11)>;
+			};
+
+			ltdc_vsync_pe1: ltdc_vsync_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF11)>;
+			};
+
+			ltdc_r7_pe2: ltdc_r7_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+			};
+
+			ltdc_r6_pe3: ltdc_r6_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+			};
+
+			ltdc_b7_pe4: ltdc_b7_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF11)>;
+			};
+
+			ltdc_g7_pe5: ltdc_g7_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF11)>;
+			};
+
+			ltdc_g6_pe6: ltdc_g6_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+			};
+
+			ltdc_b6_pe7: ltdc_b6_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF11)>;
+			};
+
+			ltdc_b7_pe8: ltdc_b7_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF11)>;
+			};
+
+			ltdc_g2_pe9: ltdc_g2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF11)>;
+			};
+
+			ltdc_g3_pe10: ltdc_g3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF11)>;
+			};
+
+			ltdc_g4_pe11: ltdc_g4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+			};
+
+			ltdc_g5_pe12: ltdc_g5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF11)>;
+			};
+
+			ltdc_g6_pe13: ltdc_g6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF11)>;
+			};
+
+			ltdc_g7_pe14: ltdc_g7_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF11)>;
+			};
+
+			ltdc_r2_pe15: ltdc_r2_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF11)>;
+			};
+
+			ltdc_de_pf11: ltdc_de_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+			};
+
+			ltdc_b0_pf12: ltdc_b0_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF11)>;
+			};
+
+			ltdc_b1_pf13: ltdc_b1_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF11)>;
+			};
+
+			ltdc_g0_pf14: ltdc_g0_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF11)>;
+			};
+
+			ltdc_g1_pf15: ltdc_g1_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF11)>;
+			};
+
+			ltdc_r1_pg6: ltdc_r1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+			};
+
+			ltdc_r1_pg14: ltdc_r1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4p5qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5qgixp-pinctrl.dtsi
@@ -661,6 +661,220 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_clk_pa4: ltdc_clk_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+			};
+
+			ltdc_r7_pa5: ltdc_r7_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+			};
+
+			ltdc_b7_pa8: ltdc_b7_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+			};
+
+			ltdc_g7_pa9: ltdc_g7_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF11)>;
+			};
+
+			ltdc_g6_pa10: ltdc_g6_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF11)>;
+			};
+
+			ltdc_de_pa11: ltdc_de_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+			};
+
+			ltdc_vsync_pa12: ltdc_vsync_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+			};
+
+			ltdc_hsync_pa15: ltdc_hsync_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+			};
+
+			ltdc_b6_pb0: ltdc_b6_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+			};
+
+			ltdc_g6_pb1: ltdc_g6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+			};
+
+			ltdc_r6_pb6: ltdc_r6_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+			};
+
+			ltdc_vsync_pb7: ltdc_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+			};
+
+			ltdc_de_pb8: ltdc_de_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_de_pc0: ltdc_de_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_hsync_pc2: ltdc_hsync_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+			};
+
+			ltdc_clk_pc5: ltdc_clk_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+			};
+
+			ltdc_g7_pc6: ltdc_g7_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_b6_pc7: ltdc_b6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF11)>;
+			};
+
+			ltdc_b4_pd0: ltdc_b4_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+			};
+
+			ltdc_b5_pd1: ltdc_b5_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+			};
+
+			ltdc_clk_pd3: ltdc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF11)>;
+			};
+
+			ltdc_de_pd6: ltdc_de_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF11)>;
+			};
+
+			ltdc_r3_pd8: ltdc_r3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+			};
+
+			ltdc_r4_pd9: ltdc_r4_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF11)>;
+			};
+
+			ltdc_r5_pd10: ltdc_r5_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF11)>;
+			};
+
+			ltdc_r6_pd11: ltdc_r6_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF11)>;
+			};
+
+			ltdc_r7_pd12: ltdc_r7_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF11)>;
+			};
+
+			ltdc_b2_pd14: ltdc_b2_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+			};
+
+			ltdc_b3_pd15: ltdc_b3_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF11)>;
+			};
+
+			ltdc_hsync_pe0: ltdc_hsync_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF11)>;
+			};
+
+			ltdc_vsync_pe1: ltdc_vsync_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF11)>;
+			};
+
+			ltdc_r7_pe2: ltdc_r7_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+			};
+
+			ltdc_r6_pe3: ltdc_r6_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+			};
+
+			ltdc_b7_pe4: ltdc_b7_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF11)>;
+			};
+
+			ltdc_g7_pe5: ltdc_g7_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF11)>;
+			};
+
+			ltdc_g6_pe6: ltdc_g6_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+			};
+
+			ltdc_b6_pe7: ltdc_b6_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF11)>;
+			};
+
+			ltdc_b7_pe8: ltdc_b7_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF11)>;
+			};
+
+			ltdc_g2_pe9: ltdc_g2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF11)>;
+			};
+
+			ltdc_g3_pe10: ltdc_g3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF11)>;
+			};
+
+			ltdc_g4_pe11: ltdc_g4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+			};
+
+			ltdc_g5_pe12: ltdc_g5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF11)>;
+			};
+
+			ltdc_g6_pe13: ltdc_g6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF11)>;
+			};
+
+			ltdc_g7_pe14: ltdc_g7_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF11)>;
+			};
+
+			ltdc_r2_pe15: ltdc_r2_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF11)>;
+			};
+
+			ltdc_de_pf11: ltdc_de_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+			};
+
+			ltdc_b0_pf12: ltdc_b0_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF11)>;
+			};
+
+			ltdc_b1_pf13: ltdc_b1_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF11)>;
+			};
+
+			ltdc_g0_pf14: ltdc_g0_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF11)>;
+			};
+
+			ltdc_g1_pf15: ltdc_g1_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF11)>;
+			};
+
+			ltdc_r1_pg6: ltdc_r1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4p5r(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5r(g-e)tx-pinctrl.dtsi
@@ -278,6 +278,88 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_clk_pa4: ltdc_clk_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+			};
+
+			ltdc_r7_pa5: ltdc_r7_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+			};
+
+			ltdc_b7_pa8: ltdc_b7_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+			};
+
+			ltdc_g7_pa9: ltdc_g7_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF11)>;
+			};
+
+			ltdc_g6_pa10: ltdc_g6_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF11)>;
+			};
+
+			ltdc_de_pa11: ltdc_de_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+			};
+
+			ltdc_vsync_pa12: ltdc_vsync_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+			};
+
+			ltdc_hsync_pa15: ltdc_hsync_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+			};
+
+			ltdc_b6_pb0: ltdc_b6_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+			};
+
+			ltdc_g6_pb1: ltdc_g6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+			};
+
+			ltdc_r6_pb6: ltdc_r6_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+			};
+
+			ltdc_vsync_pb7: ltdc_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+			};
+
+			ltdc_de_pb8: ltdc_de_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_vsync_pb11: ltdc_vsync_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+			};
+
+			ltdc_de_pc0: ltdc_de_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_hsync_pc2: ltdc_hsync_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+			};
+
+			ltdc_clk_pc5: ltdc_clk_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+			};
+
+			ltdc_g7_pc6: ltdc_g7_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_b6_pc7: ltdc_b6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4p5rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5rgtxp-pinctrl.dtsi
@@ -270,6 +270,84 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_clk_pa4: ltdc_clk_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+			};
+
+			ltdc_r7_pa5: ltdc_r7_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+			};
+
+			ltdc_b7_pa8: ltdc_b7_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+			};
+
+			ltdc_g7_pa9: ltdc_g7_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF11)>;
+			};
+
+			ltdc_g6_pa10: ltdc_g6_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF11)>;
+			};
+
+			ltdc_de_pa11: ltdc_de_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+			};
+
+			ltdc_vsync_pa12: ltdc_vsync_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+			};
+
+			ltdc_hsync_pa15: ltdc_hsync_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+			};
+
+			ltdc_b6_pb0: ltdc_b6_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+			};
+
+			ltdc_g6_pb1: ltdc_g6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+			};
+
+			ltdc_r6_pb6: ltdc_r6_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+			};
+
+			ltdc_vsync_pb7: ltdc_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+			};
+
+			ltdc_de_pb8: ltdc_de_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_vsync_pb11: ltdc_vsync_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+			};
+
+			ltdc_de_pc0: ltdc_de_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_hsync_pc2: ltdc_hsync_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+			};
+
+			ltdc_g7_pc6: ltdc_g7_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_b6_pc7: ltdc_b6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4p5v(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5v(g-e)tx-pinctrl.dtsi
@@ -499,6 +499,196 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_clk_pa4: ltdc_clk_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+			};
+
+			ltdc_r7_pa5: ltdc_r7_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+			};
+
+			ltdc_b7_pa8: ltdc_b7_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+			};
+
+			ltdc_g7_pa9: ltdc_g7_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF11)>;
+			};
+
+			ltdc_g6_pa10: ltdc_g6_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF11)>;
+			};
+
+			ltdc_de_pa11: ltdc_de_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+			};
+
+			ltdc_vsync_pa12: ltdc_vsync_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+			};
+
+			ltdc_hsync_pa15: ltdc_hsync_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+			};
+
+			ltdc_b6_pb0: ltdc_b6_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+			};
+
+			ltdc_g6_pb1: ltdc_g6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+			};
+
+			ltdc_r6_pb6: ltdc_r6_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+			};
+
+			ltdc_vsync_pb7: ltdc_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+			};
+
+			ltdc_de_pb8: ltdc_de_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_vsync_pb11: ltdc_vsync_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+			};
+
+			ltdc_de_pc0: ltdc_de_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_hsync_pc2: ltdc_hsync_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+			};
+
+			ltdc_clk_pc5: ltdc_clk_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+			};
+
+			ltdc_g7_pc6: ltdc_g7_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_b6_pc7: ltdc_b6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF11)>;
+			};
+
+			ltdc_b4_pd0: ltdc_b4_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+			};
+
+			ltdc_b5_pd1: ltdc_b5_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+			};
+
+			ltdc_clk_pd3: ltdc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF11)>;
+			};
+
+			ltdc_de_pd6: ltdc_de_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF11)>;
+			};
+
+			ltdc_r3_pd8: ltdc_r3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+			};
+
+			ltdc_r4_pd9: ltdc_r4_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF11)>;
+			};
+
+			ltdc_r5_pd10: ltdc_r5_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF11)>;
+			};
+
+			ltdc_r6_pd11: ltdc_r6_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF11)>;
+			};
+
+			ltdc_r7_pd12: ltdc_r7_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF11)>;
+			};
+
+			ltdc_b2_pd14: ltdc_b2_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+			};
+
+			ltdc_b3_pd15: ltdc_b3_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF11)>;
+			};
+
+			ltdc_hsync_pe0: ltdc_hsync_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF11)>;
+			};
+
+			ltdc_vsync_pe1: ltdc_vsync_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF11)>;
+			};
+
+			ltdc_r7_pe2: ltdc_r7_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+			};
+
+			ltdc_r6_pe3: ltdc_r6_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+			};
+
+			ltdc_b7_pe4: ltdc_b7_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF11)>;
+			};
+
+			ltdc_g7_pe5: ltdc_g7_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF11)>;
+			};
+
+			ltdc_g6_pe6: ltdc_g6_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+			};
+
+			ltdc_b6_pe7: ltdc_b6_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF11)>;
+			};
+
+			ltdc_b7_pe8: ltdc_b7_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF11)>;
+			};
+
+			ltdc_g2_pe9: ltdc_g2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF11)>;
+			};
+
+			ltdc_g3_pe10: ltdc_g3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF11)>;
+			};
+
+			ltdc_g4_pe11: ltdc_g4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+			};
+
+			ltdc_g5_pe12: ltdc_g5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF11)>;
+			};
+
+			ltdc_g6_pe13: ltdc_g6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF11)>;
+			};
+
+			ltdc_g7_pe14: ltdc_g7_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF11)>;
+			};
+
+			ltdc_r2_pe15: ltdc_r2_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4p5v(g-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5v(g-e)yx-pinctrl.dtsi
@@ -475,6 +475,176 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_clk_pa4: ltdc_clk_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+			};
+
+			ltdc_r7_pa5: ltdc_r7_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+			};
+
+			ltdc_b7_pa8: ltdc_b7_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+			};
+
+			ltdc_g7_pa9: ltdc_g7_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF11)>;
+			};
+
+			ltdc_g6_pa10: ltdc_g6_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF11)>;
+			};
+
+			ltdc_de_pa11: ltdc_de_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+			};
+
+			ltdc_vsync_pa12: ltdc_vsync_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+			};
+
+			ltdc_hsync_pa15: ltdc_hsync_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+			};
+
+			ltdc_b6_pb0: ltdc_b6_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+			};
+
+			ltdc_g6_pb1: ltdc_g6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+			};
+
+			ltdc_r6_pb6: ltdc_r6_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+			};
+
+			ltdc_vsync_pb7: ltdc_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+			};
+
+			ltdc_de_pb8: ltdc_de_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_vsync_pb11: ltdc_vsync_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+			};
+
+			ltdc_de_pc0: ltdc_de_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_hsync_pc2: ltdc_hsync_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+			};
+
+			ltdc_clk_pc5: ltdc_clk_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+			};
+
+			ltdc_g7_pc6: ltdc_g7_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_b6_pc7: ltdc_b6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF11)>;
+			};
+
+			ltdc_b4_pd0: ltdc_b4_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+			};
+
+			ltdc_b5_pd1: ltdc_b5_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+			};
+
+			ltdc_de_pd6: ltdc_de_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF11)>;
+			};
+
+			ltdc_r3_pd8: ltdc_r3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+			};
+
+			ltdc_r4_pd9: ltdc_r4_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF11)>;
+			};
+
+			ltdc_r5_pd10: ltdc_r5_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF11)>;
+			};
+
+			ltdc_b2_pd14: ltdc_b2_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+			};
+
+			ltdc_b3_pd15: ltdc_b3_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF11)>;
+			};
+
+			ltdc_r7_pe2: ltdc_r7_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+			};
+
+			ltdc_r6_pe3: ltdc_r6_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+			};
+
+			ltdc_b7_pe4: ltdc_b7_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF11)>;
+			};
+
+			ltdc_g7_pe5: ltdc_g7_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF11)>;
+			};
+
+			ltdc_g6_pe6: ltdc_g6_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+			};
+
+			ltdc_b6_pe7: ltdc_b6_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF11)>;
+			};
+
+			ltdc_b7_pe8: ltdc_b7_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF11)>;
+			};
+
+			ltdc_g2_pe9: ltdc_g2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF11)>;
+			};
+
+			ltdc_g3_pe10: ltdc_g3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF11)>;
+			};
+
+			ltdc_g4_pe11: ltdc_g4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+			};
+
+			ltdc_g5_pe12: ltdc_g5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF11)>;
+			};
+
+			ltdc_g6_pe13: ltdc_g6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF11)>;
+			};
+
+			ltdc_g7_pe14: ltdc_g7_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF11)>;
+			};
+
+			ltdc_r2_pe15: ltdc_r2_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4p5vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5vgtxp-pinctrl.dtsi
@@ -481,6 +481,188 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_clk_pa4: ltdc_clk_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+			};
+
+			ltdc_r7_pa5: ltdc_r7_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+			};
+
+			ltdc_b7_pa8: ltdc_b7_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+			};
+
+			ltdc_g7_pa9: ltdc_g7_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF11)>;
+			};
+
+			ltdc_g6_pa10: ltdc_g6_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF11)>;
+			};
+
+			ltdc_de_pa11: ltdc_de_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+			};
+
+			ltdc_vsync_pa12: ltdc_vsync_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+			};
+
+			ltdc_hsync_pa15: ltdc_hsync_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+			};
+
+			ltdc_b6_pb0: ltdc_b6_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+			};
+
+			ltdc_g6_pb1: ltdc_g6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+			};
+
+			ltdc_r6_pb6: ltdc_r6_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+			};
+
+			ltdc_vsync_pb7: ltdc_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+			};
+
+			ltdc_de_pb8: ltdc_de_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_de_pc0: ltdc_de_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_hsync_pc2: ltdc_hsync_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+			};
+
+			ltdc_clk_pc5: ltdc_clk_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+			};
+
+			ltdc_g7_pc6: ltdc_g7_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_b6_pc7: ltdc_b6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF11)>;
+			};
+
+			ltdc_b4_pd0: ltdc_b4_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+			};
+
+			ltdc_b5_pd1: ltdc_b5_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+			};
+
+			ltdc_clk_pd3: ltdc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF11)>;
+			};
+
+			ltdc_de_pd6: ltdc_de_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF11)>;
+			};
+
+			ltdc_r3_pd8: ltdc_r3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+			};
+
+			ltdc_r4_pd9: ltdc_r4_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF11)>;
+			};
+
+			ltdc_r5_pd10: ltdc_r5_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF11)>;
+			};
+
+			ltdc_r6_pd11: ltdc_r6_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF11)>;
+			};
+
+			ltdc_r7_pd12: ltdc_r7_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF11)>;
+			};
+
+			ltdc_b2_pd14: ltdc_b2_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+			};
+
+			ltdc_b3_pd15: ltdc_b3_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF11)>;
+			};
+
+			ltdc_hsync_pe0: ltdc_hsync_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF11)>;
+			};
+
+			ltdc_r7_pe2: ltdc_r7_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+			};
+
+			ltdc_r6_pe3: ltdc_r6_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+			};
+
+			ltdc_b7_pe4: ltdc_b7_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF11)>;
+			};
+
+			ltdc_g7_pe5: ltdc_g7_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF11)>;
+			};
+
+			ltdc_g6_pe6: ltdc_g6_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+			};
+
+			ltdc_b6_pe7: ltdc_b6_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF11)>;
+			};
+
+			ltdc_b7_pe8: ltdc_b7_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF11)>;
+			};
+
+			ltdc_g2_pe9: ltdc_g2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF11)>;
+			};
+
+			ltdc_g3_pe10: ltdc_g3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF11)>;
+			};
+
+			ltdc_g4_pe11: ltdc_g4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+			};
+
+			ltdc_g5_pe12: ltdc_g5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF11)>;
+			};
+
+			ltdc_g6_pe13: ltdc_g6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF11)>;
+			};
+
+			ltdc_g7_pe14: ltdc_g7_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF11)>;
+			};
+
+			ltdc_r2_pe15: ltdc_r2_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4p5vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5vgyxp-pinctrl.dtsi
@@ -467,6 +467,172 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_clk_pa4: ltdc_clk_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+			};
+
+			ltdc_r7_pa5: ltdc_r7_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+			};
+
+			ltdc_b7_pa8: ltdc_b7_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+			};
+
+			ltdc_g7_pa9: ltdc_g7_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF11)>;
+			};
+
+			ltdc_g6_pa10: ltdc_g6_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF11)>;
+			};
+
+			ltdc_de_pa11: ltdc_de_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+			};
+
+			ltdc_vsync_pa12: ltdc_vsync_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+			};
+
+			ltdc_hsync_pa15: ltdc_hsync_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+			};
+
+			ltdc_b6_pb0: ltdc_b6_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+			};
+
+			ltdc_g6_pb1: ltdc_g6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+			};
+
+			ltdc_r6_pb6: ltdc_r6_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+			};
+
+			ltdc_vsync_pb7: ltdc_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+			};
+
+			ltdc_de_pb8: ltdc_de_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_vsync_pb11: ltdc_vsync_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+			};
+
+			ltdc_de_pc0: ltdc_de_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_hsync_pc2: ltdc_hsync_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+			};
+
+			ltdc_g7_pc6: ltdc_g7_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_b6_pc7: ltdc_b6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF11)>;
+			};
+
+			ltdc_b4_pd0: ltdc_b4_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+			};
+
+			ltdc_b5_pd1: ltdc_b5_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+			};
+
+			ltdc_de_pd6: ltdc_de_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF11)>;
+			};
+
+			ltdc_r3_pd8: ltdc_r3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+			};
+
+			ltdc_r4_pd9: ltdc_r4_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF11)>;
+			};
+
+			ltdc_r5_pd10: ltdc_r5_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF11)>;
+			};
+
+			ltdc_b2_pd14: ltdc_b2_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+			};
+
+			ltdc_b3_pd15: ltdc_b3_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF11)>;
+			};
+
+			ltdc_r7_pe2: ltdc_r7_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+			};
+
+			ltdc_r6_pe3: ltdc_r6_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+			};
+
+			ltdc_b7_pe4: ltdc_b7_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF11)>;
+			};
+
+			ltdc_g7_pe5: ltdc_g7_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF11)>;
+			};
+
+			ltdc_g6_pe6: ltdc_g6_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+			};
+
+			ltdc_b6_pe7: ltdc_b6_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF11)>;
+			};
+
+			ltdc_b7_pe8: ltdc_b7_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF11)>;
+			};
+
+			ltdc_g2_pe9: ltdc_g2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF11)>;
+			};
+
+			ltdc_g3_pe10: ltdc_g3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF11)>;
+			};
+
+			ltdc_g4_pe11: ltdc_g4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+			};
+
+			ltdc_g5_pe12: ltdc_g5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF11)>;
+			};
+
+			ltdc_g6_pe13: ltdc_g6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF11)>;
+			};
+
+			ltdc_g7_pe14: ltdc_g7_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF11)>;
+			};
+
+			ltdc_r2_pe15: ltdc_r2_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4p5z(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5z(g-e)tx-pinctrl.dtsi
@@ -685,6 +685,228 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_clk_pa4: ltdc_clk_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+			};
+
+			ltdc_r7_pa5: ltdc_r7_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+			};
+
+			ltdc_b7_pa8: ltdc_b7_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+			};
+
+			ltdc_g7_pa9: ltdc_g7_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF11)>;
+			};
+
+			ltdc_g6_pa10: ltdc_g6_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF11)>;
+			};
+
+			ltdc_de_pa11: ltdc_de_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+			};
+
+			ltdc_vsync_pa12: ltdc_vsync_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+			};
+
+			ltdc_hsync_pa15: ltdc_hsync_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+			};
+
+			ltdc_b6_pb0: ltdc_b6_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+			};
+
+			ltdc_g6_pb1: ltdc_g6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+			};
+
+			ltdc_r6_pb6: ltdc_r6_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+			};
+
+			ltdc_vsync_pb7: ltdc_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+			};
+
+			ltdc_de_pb8: ltdc_de_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_vsync_pb11: ltdc_vsync_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+			};
+
+			ltdc_de_pc0: ltdc_de_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_hsync_pc2: ltdc_hsync_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+			};
+
+			ltdc_clk_pc5: ltdc_clk_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+			};
+
+			ltdc_g7_pc6: ltdc_g7_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_b6_pc7: ltdc_b6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF11)>;
+			};
+
+			ltdc_b4_pd0: ltdc_b4_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+			};
+
+			ltdc_b5_pd1: ltdc_b5_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+			};
+
+			ltdc_clk_pd3: ltdc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF11)>;
+			};
+
+			ltdc_de_pd6: ltdc_de_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF11)>;
+			};
+
+			ltdc_r3_pd8: ltdc_r3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+			};
+
+			ltdc_r4_pd9: ltdc_r4_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF11)>;
+			};
+
+			ltdc_r5_pd10: ltdc_r5_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF11)>;
+			};
+
+			ltdc_r6_pd11: ltdc_r6_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF11)>;
+			};
+
+			ltdc_r7_pd12: ltdc_r7_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF11)>;
+			};
+
+			ltdc_b2_pd14: ltdc_b2_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+			};
+
+			ltdc_b3_pd15: ltdc_b3_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF11)>;
+			};
+
+			ltdc_hsync_pe0: ltdc_hsync_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF11)>;
+			};
+
+			ltdc_vsync_pe1: ltdc_vsync_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF11)>;
+			};
+
+			ltdc_r7_pe2: ltdc_r7_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+			};
+
+			ltdc_r6_pe3: ltdc_r6_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+			};
+
+			ltdc_b7_pe4: ltdc_b7_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF11)>;
+			};
+
+			ltdc_g7_pe5: ltdc_g7_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF11)>;
+			};
+
+			ltdc_g6_pe6: ltdc_g6_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+			};
+
+			ltdc_b6_pe7: ltdc_b6_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF11)>;
+			};
+
+			ltdc_b7_pe8: ltdc_b7_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF11)>;
+			};
+
+			ltdc_g2_pe9: ltdc_g2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF11)>;
+			};
+
+			ltdc_g3_pe10: ltdc_g3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF11)>;
+			};
+
+			ltdc_g4_pe11: ltdc_g4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+			};
+
+			ltdc_g5_pe12: ltdc_g5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF11)>;
+			};
+
+			ltdc_g6_pe13: ltdc_g6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF11)>;
+			};
+
+			ltdc_g7_pe14: ltdc_g7_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF11)>;
+			};
+
+			ltdc_r2_pe15: ltdc_r2_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF11)>;
+			};
+
+			ltdc_de_pf11: ltdc_de_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+			};
+
+			ltdc_b0_pf12: ltdc_b0_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF11)>;
+			};
+
+			ltdc_b1_pf13: ltdc_b1_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF11)>;
+			};
+
+			ltdc_g0_pf14: ltdc_g0_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF11)>;
+			};
+
+			ltdc_g1_pf15: ltdc_g1_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF11)>;
+			};
+
+			ltdc_r1_pg6: ltdc_r1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+			};
+
+			ltdc_r1_pg14: ltdc_r1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4p5zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5zgtxp-pinctrl.dtsi
@@ -673,6 +673,224 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_clk_pa4: ltdc_clk_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+			};
+
+			ltdc_r7_pa5: ltdc_r7_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+			};
+
+			ltdc_b7_pa8: ltdc_b7_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+			};
+
+			ltdc_g7_pa9: ltdc_g7_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF11)>;
+			};
+
+			ltdc_g6_pa10: ltdc_g6_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF11)>;
+			};
+
+			ltdc_de_pa11: ltdc_de_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+			};
+
+			ltdc_vsync_pa12: ltdc_vsync_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+			};
+
+			ltdc_hsync_pa15: ltdc_hsync_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+			};
+
+			ltdc_b6_pb0: ltdc_b6_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+			};
+
+			ltdc_g6_pb1: ltdc_g6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+			};
+
+			ltdc_r6_pb6: ltdc_r6_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+			};
+
+			ltdc_vsync_pb7: ltdc_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+			};
+
+			ltdc_de_pb8: ltdc_de_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_de_pc0: ltdc_de_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_hsync_pc2: ltdc_hsync_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+			};
+
+			ltdc_clk_pc5: ltdc_clk_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+			};
+
+			ltdc_g7_pc6: ltdc_g7_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_b6_pc7: ltdc_b6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF11)>;
+			};
+
+			ltdc_b4_pd0: ltdc_b4_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+			};
+
+			ltdc_b5_pd1: ltdc_b5_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+			};
+
+			ltdc_clk_pd3: ltdc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF11)>;
+			};
+
+			ltdc_de_pd6: ltdc_de_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF11)>;
+			};
+
+			ltdc_r3_pd8: ltdc_r3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+			};
+
+			ltdc_r4_pd9: ltdc_r4_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF11)>;
+			};
+
+			ltdc_r5_pd10: ltdc_r5_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF11)>;
+			};
+
+			ltdc_r6_pd11: ltdc_r6_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF11)>;
+			};
+
+			ltdc_r7_pd12: ltdc_r7_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF11)>;
+			};
+
+			ltdc_b2_pd14: ltdc_b2_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+			};
+
+			ltdc_b3_pd15: ltdc_b3_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF11)>;
+			};
+
+			ltdc_hsync_pe0: ltdc_hsync_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF11)>;
+			};
+
+			ltdc_vsync_pe1: ltdc_vsync_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF11)>;
+			};
+
+			ltdc_r7_pe2: ltdc_r7_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+			};
+
+			ltdc_r6_pe3: ltdc_r6_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+			};
+
+			ltdc_b7_pe4: ltdc_b7_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF11)>;
+			};
+
+			ltdc_g7_pe5: ltdc_g7_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF11)>;
+			};
+
+			ltdc_g6_pe6: ltdc_g6_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+			};
+
+			ltdc_b6_pe7: ltdc_b6_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF11)>;
+			};
+
+			ltdc_b7_pe8: ltdc_b7_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF11)>;
+			};
+
+			ltdc_g2_pe9: ltdc_g2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF11)>;
+			};
+
+			ltdc_g3_pe10: ltdc_g3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF11)>;
+			};
+
+			ltdc_g4_pe11: ltdc_g4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+			};
+
+			ltdc_g5_pe12: ltdc_g5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF11)>;
+			};
+
+			ltdc_g6_pe13: ltdc_g6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF11)>;
+			};
+
+			ltdc_g7_pe14: ltdc_g7_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF11)>;
+			};
+
+			ltdc_r2_pe15: ltdc_r2_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF11)>;
+			};
+
+			ltdc_de_pf11: ltdc_de_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+			};
+
+			ltdc_b0_pf12: ltdc_b0_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF11)>;
+			};
+
+			ltdc_b1_pf13: ltdc_b1_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF11)>;
+			};
+
+			ltdc_g0_pf14: ltdc_g0_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF11)>;
+			};
+
+			ltdc_g1_pf15: ltdc_g1_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF11)>;
+			};
+
+			ltdc_r1_pg6: ltdc_r1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+			};
+
+			ltdc_r1_pg14: ltdc_r1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4q5agix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5agix-pinctrl.dtsi
@@ -718,6 +718,228 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_clk_pa4: ltdc_clk_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+			};
+
+			ltdc_r7_pa5: ltdc_r7_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+			};
+
+			ltdc_b7_pa8: ltdc_b7_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+			};
+
+			ltdc_g7_pa9: ltdc_g7_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF11)>;
+			};
+
+			ltdc_g6_pa10: ltdc_g6_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF11)>;
+			};
+
+			ltdc_de_pa11: ltdc_de_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+			};
+
+			ltdc_vsync_pa12: ltdc_vsync_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+			};
+
+			ltdc_hsync_pa15: ltdc_hsync_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+			};
+
+			ltdc_b6_pb0: ltdc_b6_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+			};
+
+			ltdc_g6_pb1: ltdc_g6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+			};
+
+			ltdc_r6_pb6: ltdc_r6_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+			};
+
+			ltdc_vsync_pb7: ltdc_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+			};
+
+			ltdc_de_pb8: ltdc_de_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_vsync_pb11: ltdc_vsync_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+			};
+
+			ltdc_de_pc0: ltdc_de_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_hsync_pc2: ltdc_hsync_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+			};
+
+			ltdc_clk_pc5: ltdc_clk_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+			};
+
+			ltdc_g7_pc6: ltdc_g7_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_b6_pc7: ltdc_b6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF11)>;
+			};
+
+			ltdc_b4_pd0: ltdc_b4_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+			};
+
+			ltdc_b5_pd1: ltdc_b5_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+			};
+
+			ltdc_clk_pd3: ltdc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF11)>;
+			};
+
+			ltdc_de_pd6: ltdc_de_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF11)>;
+			};
+
+			ltdc_r3_pd8: ltdc_r3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+			};
+
+			ltdc_r4_pd9: ltdc_r4_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF11)>;
+			};
+
+			ltdc_r5_pd10: ltdc_r5_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF11)>;
+			};
+
+			ltdc_r6_pd11: ltdc_r6_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF11)>;
+			};
+
+			ltdc_r7_pd12: ltdc_r7_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF11)>;
+			};
+
+			ltdc_b2_pd14: ltdc_b2_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+			};
+
+			ltdc_b3_pd15: ltdc_b3_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF11)>;
+			};
+
+			ltdc_hsync_pe0: ltdc_hsync_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF11)>;
+			};
+
+			ltdc_vsync_pe1: ltdc_vsync_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF11)>;
+			};
+
+			ltdc_r7_pe2: ltdc_r7_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+			};
+
+			ltdc_r6_pe3: ltdc_r6_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+			};
+
+			ltdc_b7_pe4: ltdc_b7_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF11)>;
+			};
+
+			ltdc_g7_pe5: ltdc_g7_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF11)>;
+			};
+
+			ltdc_g6_pe6: ltdc_g6_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+			};
+
+			ltdc_b6_pe7: ltdc_b6_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF11)>;
+			};
+
+			ltdc_b7_pe8: ltdc_b7_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF11)>;
+			};
+
+			ltdc_g2_pe9: ltdc_g2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF11)>;
+			};
+
+			ltdc_g3_pe10: ltdc_g3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF11)>;
+			};
+
+			ltdc_g4_pe11: ltdc_g4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+			};
+
+			ltdc_g5_pe12: ltdc_g5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF11)>;
+			};
+
+			ltdc_g6_pe13: ltdc_g6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF11)>;
+			};
+
+			ltdc_g7_pe14: ltdc_g7_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF11)>;
+			};
+
+			ltdc_r2_pe15: ltdc_r2_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF11)>;
+			};
+
+			ltdc_de_pf11: ltdc_de_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+			};
+
+			ltdc_b0_pf12: ltdc_b0_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF11)>;
+			};
+
+			ltdc_b1_pf13: ltdc_b1_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF11)>;
+			};
+
+			ltdc_g0_pf14: ltdc_g0_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF11)>;
+			};
+
+			ltdc_g1_pf15: ltdc_g1_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF11)>;
+			};
+
+			ltdc_r1_pg6: ltdc_r1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+			};
+
+			ltdc_r1_pg14: ltdc_r1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4q5agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5agixp-pinctrl.dtsi
@@ -718,6 +718,228 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_clk_pa4: ltdc_clk_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+			};
+
+			ltdc_r7_pa5: ltdc_r7_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+			};
+
+			ltdc_b7_pa8: ltdc_b7_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+			};
+
+			ltdc_g7_pa9: ltdc_g7_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF11)>;
+			};
+
+			ltdc_g6_pa10: ltdc_g6_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF11)>;
+			};
+
+			ltdc_de_pa11: ltdc_de_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+			};
+
+			ltdc_vsync_pa12: ltdc_vsync_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+			};
+
+			ltdc_hsync_pa15: ltdc_hsync_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+			};
+
+			ltdc_b6_pb0: ltdc_b6_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+			};
+
+			ltdc_g6_pb1: ltdc_g6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+			};
+
+			ltdc_r6_pb6: ltdc_r6_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+			};
+
+			ltdc_vsync_pb7: ltdc_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+			};
+
+			ltdc_de_pb8: ltdc_de_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_vsync_pb11: ltdc_vsync_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+			};
+
+			ltdc_de_pc0: ltdc_de_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_hsync_pc2: ltdc_hsync_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+			};
+
+			ltdc_clk_pc5: ltdc_clk_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+			};
+
+			ltdc_g7_pc6: ltdc_g7_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_b6_pc7: ltdc_b6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF11)>;
+			};
+
+			ltdc_b4_pd0: ltdc_b4_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+			};
+
+			ltdc_b5_pd1: ltdc_b5_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+			};
+
+			ltdc_clk_pd3: ltdc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF11)>;
+			};
+
+			ltdc_de_pd6: ltdc_de_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF11)>;
+			};
+
+			ltdc_r3_pd8: ltdc_r3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+			};
+
+			ltdc_r4_pd9: ltdc_r4_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF11)>;
+			};
+
+			ltdc_r5_pd10: ltdc_r5_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF11)>;
+			};
+
+			ltdc_r6_pd11: ltdc_r6_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF11)>;
+			};
+
+			ltdc_r7_pd12: ltdc_r7_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF11)>;
+			};
+
+			ltdc_b2_pd14: ltdc_b2_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+			};
+
+			ltdc_b3_pd15: ltdc_b3_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF11)>;
+			};
+
+			ltdc_hsync_pe0: ltdc_hsync_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF11)>;
+			};
+
+			ltdc_vsync_pe1: ltdc_vsync_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF11)>;
+			};
+
+			ltdc_r7_pe2: ltdc_r7_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+			};
+
+			ltdc_r6_pe3: ltdc_r6_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+			};
+
+			ltdc_b7_pe4: ltdc_b7_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF11)>;
+			};
+
+			ltdc_g7_pe5: ltdc_g7_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF11)>;
+			};
+
+			ltdc_g6_pe6: ltdc_g6_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+			};
+
+			ltdc_b6_pe7: ltdc_b6_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF11)>;
+			};
+
+			ltdc_b7_pe8: ltdc_b7_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF11)>;
+			};
+
+			ltdc_g2_pe9: ltdc_g2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF11)>;
+			};
+
+			ltdc_g3_pe10: ltdc_g3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF11)>;
+			};
+
+			ltdc_g4_pe11: ltdc_g4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+			};
+
+			ltdc_g5_pe12: ltdc_g5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF11)>;
+			};
+
+			ltdc_g6_pe13: ltdc_g6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF11)>;
+			};
+
+			ltdc_g7_pe14: ltdc_g7_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF11)>;
+			};
+
+			ltdc_r2_pe15: ltdc_r2_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF11)>;
+			};
+
+			ltdc_de_pf11: ltdc_de_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+			};
+
+			ltdc_b0_pf12: ltdc_b0_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF11)>;
+			};
+
+			ltdc_b1_pf13: ltdc_b1_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF11)>;
+			};
+
+			ltdc_g0_pf14: ltdc_g0_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF11)>;
+			};
+
+			ltdc_g1_pf15: ltdc_g1_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF11)>;
+			};
+
+			ltdc_r1_pg6: ltdc_r1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+			};
+
+			ltdc_r1_pg14: ltdc_r1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4q5cgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5cgtx-pinctrl.dtsi
@@ -212,6 +212,64 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_clk_pa4: ltdc_clk_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+			};
+
+			ltdc_r7_pa5: ltdc_r7_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+			};
+
+			ltdc_b7_pa8: ltdc_b7_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+			};
+
+			ltdc_g7_pa9: ltdc_g7_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF11)>;
+			};
+
+			ltdc_g6_pa10: ltdc_g6_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF11)>;
+			};
+
+			ltdc_de_pa11: ltdc_de_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+			};
+
+			ltdc_vsync_pa12: ltdc_vsync_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+			};
+
+			ltdc_hsync_pa15: ltdc_hsync_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+			};
+
+			ltdc_b6_pb0: ltdc_b6_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+			};
+
+			ltdc_g6_pb1: ltdc_g6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+			};
+
+			ltdc_r6_pb6: ltdc_r6_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+			};
+
+			ltdc_vsync_pb7: ltdc_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+			};
+
+			ltdc_de_pb8: ltdc_de_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_vsync_pb11: ltdc_vsync_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc2_cmd_pa1: sdmmc2_cmd_pa1 {

--- a/dts/st/l4/stm32l4q5cgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5cgtxp-pinctrl.dtsi
@@ -189,6 +189,56 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_clk_pa4: ltdc_clk_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+			};
+
+			ltdc_r7_pa5: ltdc_r7_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+			};
+
+			ltdc_b7_pa8: ltdc_b7_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+			};
+
+			ltdc_g7_pa9: ltdc_g7_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF11)>;
+			};
+
+			ltdc_g6_pa10: ltdc_g6_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF11)>;
+			};
+
+			ltdc_de_pa11: ltdc_de_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+			};
+
+			ltdc_vsync_pa12: ltdc_vsync_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+			};
+
+			ltdc_hsync_pa15: ltdc_hsync_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+			};
+
+			ltdc_b6_pb0: ltdc_b6_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+			};
+
+			ltdc_g6_pb1: ltdc_g6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+			};
+
+			ltdc_r6_pb6: ltdc_r6_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+			};
+
+			ltdc_vsync_pb7: ltdc_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc2_cmd_pa1: sdmmc2_cmd_pa1 {

--- a/dts/st/l4/stm32l4q5cgux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5cgux-pinctrl.dtsi
@@ -212,6 +212,64 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_clk_pa4: ltdc_clk_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+			};
+
+			ltdc_r7_pa5: ltdc_r7_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+			};
+
+			ltdc_b7_pa8: ltdc_b7_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+			};
+
+			ltdc_g7_pa9: ltdc_g7_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF11)>;
+			};
+
+			ltdc_g6_pa10: ltdc_g6_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF11)>;
+			};
+
+			ltdc_de_pa11: ltdc_de_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+			};
+
+			ltdc_vsync_pa12: ltdc_vsync_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+			};
+
+			ltdc_hsync_pa15: ltdc_hsync_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+			};
+
+			ltdc_b6_pb0: ltdc_b6_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+			};
+
+			ltdc_g6_pb1: ltdc_g6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+			};
+
+			ltdc_r6_pb6: ltdc_r6_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+			};
+
+			ltdc_vsync_pb7: ltdc_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+			};
+
+			ltdc_de_pb8: ltdc_de_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_vsync_pb11: ltdc_vsync_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc2_cmd_pa1: sdmmc2_cmd_pa1 {

--- a/dts/st/l4/stm32l4q5cguxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5cguxp-pinctrl.dtsi
@@ -189,6 +189,56 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_clk_pa4: ltdc_clk_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+			};
+
+			ltdc_r7_pa5: ltdc_r7_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+			};
+
+			ltdc_b7_pa8: ltdc_b7_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+			};
+
+			ltdc_g7_pa9: ltdc_g7_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF11)>;
+			};
+
+			ltdc_g6_pa10: ltdc_g6_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF11)>;
+			};
+
+			ltdc_de_pa11: ltdc_de_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+			};
+
+			ltdc_vsync_pa12: ltdc_vsync_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+			};
+
+			ltdc_hsync_pa15: ltdc_hsync_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+			};
+
+			ltdc_b6_pb0: ltdc_b6_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+			};
+
+			ltdc_g6_pb1: ltdc_g6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+			};
+
+			ltdc_r6_pb6: ltdc_r6_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+			};
+
+			ltdc_vsync_pb7: ltdc_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc2_cmd_pa1: sdmmc2_cmd_pa1 {

--- a/dts/st/l4/stm32l4q5qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5qgix-pinctrl.dtsi
@@ -685,6 +685,228 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_clk_pa4: ltdc_clk_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+			};
+
+			ltdc_r7_pa5: ltdc_r7_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+			};
+
+			ltdc_b7_pa8: ltdc_b7_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+			};
+
+			ltdc_g7_pa9: ltdc_g7_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF11)>;
+			};
+
+			ltdc_g6_pa10: ltdc_g6_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF11)>;
+			};
+
+			ltdc_de_pa11: ltdc_de_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+			};
+
+			ltdc_vsync_pa12: ltdc_vsync_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+			};
+
+			ltdc_hsync_pa15: ltdc_hsync_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+			};
+
+			ltdc_b6_pb0: ltdc_b6_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+			};
+
+			ltdc_g6_pb1: ltdc_g6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+			};
+
+			ltdc_r6_pb6: ltdc_r6_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+			};
+
+			ltdc_vsync_pb7: ltdc_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+			};
+
+			ltdc_de_pb8: ltdc_de_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_vsync_pb11: ltdc_vsync_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+			};
+
+			ltdc_de_pc0: ltdc_de_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_hsync_pc2: ltdc_hsync_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+			};
+
+			ltdc_clk_pc5: ltdc_clk_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+			};
+
+			ltdc_g7_pc6: ltdc_g7_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_b6_pc7: ltdc_b6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF11)>;
+			};
+
+			ltdc_b4_pd0: ltdc_b4_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+			};
+
+			ltdc_b5_pd1: ltdc_b5_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+			};
+
+			ltdc_clk_pd3: ltdc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF11)>;
+			};
+
+			ltdc_de_pd6: ltdc_de_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF11)>;
+			};
+
+			ltdc_r3_pd8: ltdc_r3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+			};
+
+			ltdc_r4_pd9: ltdc_r4_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF11)>;
+			};
+
+			ltdc_r5_pd10: ltdc_r5_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF11)>;
+			};
+
+			ltdc_r6_pd11: ltdc_r6_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF11)>;
+			};
+
+			ltdc_r7_pd12: ltdc_r7_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF11)>;
+			};
+
+			ltdc_b2_pd14: ltdc_b2_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+			};
+
+			ltdc_b3_pd15: ltdc_b3_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF11)>;
+			};
+
+			ltdc_hsync_pe0: ltdc_hsync_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF11)>;
+			};
+
+			ltdc_vsync_pe1: ltdc_vsync_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF11)>;
+			};
+
+			ltdc_r7_pe2: ltdc_r7_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+			};
+
+			ltdc_r6_pe3: ltdc_r6_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+			};
+
+			ltdc_b7_pe4: ltdc_b7_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF11)>;
+			};
+
+			ltdc_g7_pe5: ltdc_g7_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF11)>;
+			};
+
+			ltdc_g6_pe6: ltdc_g6_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+			};
+
+			ltdc_b6_pe7: ltdc_b6_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF11)>;
+			};
+
+			ltdc_b7_pe8: ltdc_b7_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF11)>;
+			};
+
+			ltdc_g2_pe9: ltdc_g2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF11)>;
+			};
+
+			ltdc_g3_pe10: ltdc_g3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF11)>;
+			};
+
+			ltdc_g4_pe11: ltdc_g4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+			};
+
+			ltdc_g5_pe12: ltdc_g5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF11)>;
+			};
+
+			ltdc_g6_pe13: ltdc_g6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF11)>;
+			};
+
+			ltdc_g7_pe14: ltdc_g7_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF11)>;
+			};
+
+			ltdc_r2_pe15: ltdc_r2_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF11)>;
+			};
+
+			ltdc_de_pf11: ltdc_de_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+			};
+
+			ltdc_b0_pf12: ltdc_b0_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF11)>;
+			};
+
+			ltdc_b1_pf13: ltdc_b1_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF11)>;
+			};
+
+			ltdc_g0_pf14: ltdc_g0_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF11)>;
+			};
+
+			ltdc_g1_pf15: ltdc_g1_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF11)>;
+			};
+
+			ltdc_r1_pg6: ltdc_r1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+			};
+
+			ltdc_r1_pg14: ltdc_r1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4q5qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5qgixp-pinctrl.dtsi
@@ -661,6 +661,220 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_clk_pa4: ltdc_clk_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+			};
+
+			ltdc_r7_pa5: ltdc_r7_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+			};
+
+			ltdc_b7_pa8: ltdc_b7_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+			};
+
+			ltdc_g7_pa9: ltdc_g7_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF11)>;
+			};
+
+			ltdc_g6_pa10: ltdc_g6_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF11)>;
+			};
+
+			ltdc_de_pa11: ltdc_de_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+			};
+
+			ltdc_vsync_pa12: ltdc_vsync_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+			};
+
+			ltdc_hsync_pa15: ltdc_hsync_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+			};
+
+			ltdc_b6_pb0: ltdc_b6_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+			};
+
+			ltdc_g6_pb1: ltdc_g6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+			};
+
+			ltdc_r6_pb6: ltdc_r6_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+			};
+
+			ltdc_vsync_pb7: ltdc_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+			};
+
+			ltdc_de_pb8: ltdc_de_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_de_pc0: ltdc_de_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_hsync_pc2: ltdc_hsync_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+			};
+
+			ltdc_clk_pc5: ltdc_clk_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+			};
+
+			ltdc_g7_pc6: ltdc_g7_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_b6_pc7: ltdc_b6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF11)>;
+			};
+
+			ltdc_b4_pd0: ltdc_b4_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+			};
+
+			ltdc_b5_pd1: ltdc_b5_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+			};
+
+			ltdc_clk_pd3: ltdc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF11)>;
+			};
+
+			ltdc_de_pd6: ltdc_de_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF11)>;
+			};
+
+			ltdc_r3_pd8: ltdc_r3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+			};
+
+			ltdc_r4_pd9: ltdc_r4_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF11)>;
+			};
+
+			ltdc_r5_pd10: ltdc_r5_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF11)>;
+			};
+
+			ltdc_r6_pd11: ltdc_r6_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF11)>;
+			};
+
+			ltdc_r7_pd12: ltdc_r7_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF11)>;
+			};
+
+			ltdc_b2_pd14: ltdc_b2_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+			};
+
+			ltdc_b3_pd15: ltdc_b3_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF11)>;
+			};
+
+			ltdc_hsync_pe0: ltdc_hsync_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF11)>;
+			};
+
+			ltdc_vsync_pe1: ltdc_vsync_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF11)>;
+			};
+
+			ltdc_r7_pe2: ltdc_r7_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+			};
+
+			ltdc_r6_pe3: ltdc_r6_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+			};
+
+			ltdc_b7_pe4: ltdc_b7_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF11)>;
+			};
+
+			ltdc_g7_pe5: ltdc_g7_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF11)>;
+			};
+
+			ltdc_g6_pe6: ltdc_g6_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+			};
+
+			ltdc_b6_pe7: ltdc_b6_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF11)>;
+			};
+
+			ltdc_b7_pe8: ltdc_b7_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF11)>;
+			};
+
+			ltdc_g2_pe9: ltdc_g2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF11)>;
+			};
+
+			ltdc_g3_pe10: ltdc_g3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF11)>;
+			};
+
+			ltdc_g4_pe11: ltdc_g4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+			};
+
+			ltdc_g5_pe12: ltdc_g5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF11)>;
+			};
+
+			ltdc_g6_pe13: ltdc_g6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF11)>;
+			};
+
+			ltdc_g7_pe14: ltdc_g7_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF11)>;
+			};
+
+			ltdc_r2_pe15: ltdc_r2_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF11)>;
+			};
+
+			ltdc_de_pf11: ltdc_de_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+			};
+
+			ltdc_b0_pf12: ltdc_b0_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF11)>;
+			};
+
+			ltdc_b1_pf13: ltdc_b1_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF11)>;
+			};
+
+			ltdc_g0_pf14: ltdc_g0_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF11)>;
+			};
+
+			ltdc_g1_pf15: ltdc_g1_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF11)>;
+			};
+
+			ltdc_r1_pg6: ltdc_r1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4q5rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5rgtx-pinctrl.dtsi
@@ -278,6 +278,88 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_clk_pa4: ltdc_clk_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+			};
+
+			ltdc_r7_pa5: ltdc_r7_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+			};
+
+			ltdc_b7_pa8: ltdc_b7_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+			};
+
+			ltdc_g7_pa9: ltdc_g7_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF11)>;
+			};
+
+			ltdc_g6_pa10: ltdc_g6_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF11)>;
+			};
+
+			ltdc_de_pa11: ltdc_de_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+			};
+
+			ltdc_vsync_pa12: ltdc_vsync_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+			};
+
+			ltdc_hsync_pa15: ltdc_hsync_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+			};
+
+			ltdc_b6_pb0: ltdc_b6_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+			};
+
+			ltdc_g6_pb1: ltdc_g6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+			};
+
+			ltdc_r6_pb6: ltdc_r6_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+			};
+
+			ltdc_vsync_pb7: ltdc_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+			};
+
+			ltdc_de_pb8: ltdc_de_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_vsync_pb11: ltdc_vsync_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+			};
+
+			ltdc_de_pc0: ltdc_de_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_hsync_pc2: ltdc_hsync_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+			};
+
+			ltdc_clk_pc5: ltdc_clk_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+			};
+
+			ltdc_g7_pc6: ltdc_g7_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_b6_pc7: ltdc_b6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4q5rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5rgtxp-pinctrl.dtsi
@@ -270,6 +270,84 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_clk_pa4: ltdc_clk_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+			};
+
+			ltdc_r7_pa5: ltdc_r7_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+			};
+
+			ltdc_b7_pa8: ltdc_b7_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+			};
+
+			ltdc_g7_pa9: ltdc_g7_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF11)>;
+			};
+
+			ltdc_g6_pa10: ltdc_g6_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF11)>;
+			};
+
+			ltdc_de_pa11: ltdc_de_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+			};
+
+			ltdc_vsync_pa12: ltdc_vsync_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+			};
+
+			ltdc_hsync_pa15: ltdc_hsync_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+			};
+
+			ltdc_b6_pb0: ltdc_b6_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+			};
+
+			ltdc_g6_pb1: ltdc_g6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+			};
+
+			ltdc_r6_pb6: ltdc_r6_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+			};
+
+			ltdc_vsync_pb7: ltdc_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+			};
+
+			ltdc_de_pb8: ltdc_de_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_vsync_pb11: ltdc_vsync_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+			};
+
+			ltdc_de_pc0: ltdc_de_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_hsync_pc2: ltdc_hsync_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+			};
+
+			ltdc_g7_pc6: ltdc_g7_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_b6_pc7: ltdc_b6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4q5vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgtx-pinctrl.dtsi
@@ -499,6 +499,196 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_clk_pa4: ltdc_clk_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+			};
+
+			ltdc_r7_pa5: ltdc_r7_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+			};
+
+			ltdc_b7_pa8: ltdc_b7_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+			};
+
+			ltdc_g7_pa9: ltdc_g7_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF11)>;
+			};
+
+			ltdc_g6_pa10: ltdc_g6_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF11)>;
+			};
+
+			ltdc_de_pa11: ltdc_de_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+			};
+
+			ltdc_vsync_pa12: ltdc_vsync_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+			};
+
+			ltdc_hsync_pa15: ltdc_hsync_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+			};
+
+			ltdc_b6_pb0: ltdc_b6_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+			};
+
+			ltdc_g6_pb1: ltdc_g6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+			};
+
+			ltdc_r6_pb6: ltdc_r6_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+			};
+
+			ltdc_vsync_pb7: ltdc_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+			};
+
+			ltdc_de_pb8: ltdc_de_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_vsync_pb11: ltdc_vsync_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+			};
+
+			ltdc_de_pc0: ltdc_de_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_hsync_pc2: ltdc_hsync_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+			};
+
+			ltdc_clk_pc5: ltdc_clk_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+			};
+
+			ltdc_g7_pc6: ltdc_g7_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_b6_pc7: ltdc_b6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF11)>;
+			};
+
+			ltdc_b4_pd0: ltdc_b4_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+			};
+
+			ltdc_b5_pd1: ltdc_b5_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+			};
+
+			ltdc_clk_pd3: ltdc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF11)>;
+			};
+
+			ltdc_de_pd6: ltdc_de_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF11)>;
+			};
+
+			ltdc_r3_pd8: ltdc_r3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+			};
+
+			ltdc_r4_pd9: ltdc_r4_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF11)>;
+			};
+
+			ltdc_r5_pd10: ltdc_r5_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF11)>;
+			};
+
+			ltdc_r6_pd11: ltdc_r6_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF11)>;
+			};
+
+			ltdc_r7_pd12: ltdc_r7_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF11)>;
+			};
+
+			ltdc_b2_pd14: ltdc_b2_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+			};
+
+			ltdc_b3_pd15: ltdc_b3_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF11)>;
+			};
+
+			ltdc_hsync_pe0: ltdc_hsync_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF11)>;
+			};
+
+			ltdc_vsync_pe1: ltdc_vsync_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF11)>;
+			};
+
+			ltdc_r7_pe2: ltdc_r7_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+			};
+
+			ltdc_r6_pe3: ltdc_r6_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+			};
+
+			ltdc_b7_pe4: ltdc_b7_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF11)>;
+			};
+
+			ltdc_g7_pe5: ltdc_g7_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF11)>;
+			};
+
+			ltdc_g6_pe6: ltdc_g6_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+			};
+
+			ltdc_b6_pe7: ltdc_b6_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF11)>;
+			};
+
+			ltdc_b7_pe8: ltdc_b7_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF11)>;
+			};
+
+			ltdc_g2_pe9: ltdc_g2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF11)>;
+			};
+
+			ltdc_g3_pe10: ltdc_g3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF11)>;
+			};
+
+			ltdc_g4_pe11: ltdc_g4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+			};
+
+			ltdc_g5_pe12: ltdc_g5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF11)>;
+			};
+
+			ltdc_g6_pe13: ltdc_g6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF11)>;
+			};
+
+			ltdc_g7_pe14: ltdc_g7_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF11)>;
+			};
+
+			ltdc_r2_pe15: ltdc_r2_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4q5vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgtxp-pinctrl.dtsi
@@ -481,6 +481,188 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_clk_pa4: ltdc_clk_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+			};
+
+			ltdc_r7_pa5: ltdc_r7_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+			};
+
+			ltdc_b7_pa8: ltdc_b7_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+			};
+
+			ltdc_g7_pa9: ltdc_g7_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF11)>;
+			};
+
+			ltdc_g6_pa10: ltdc_g6_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF11)>;
+			};
+
+			ltdc_de_pa11: ltdc_de_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+			};
+
+			ltdc_vsync_pa12: ltdc_vsync_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+			};
+
+			ltdc_hsync_pa15: ltdc_hsync_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+			};
+
+			ltdc_b6_pb0: ltdc_b6_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+			};
+
+			ltdc_g6_pb1: ltdc_g6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+			};
+
+			ltdc_r6_pb6: ltdc_r6_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+			};
+
+			ltdc_vsync_pb7: ltdc_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+			};
+
+			ltdc_de_pb8: ltdc_de_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_de_pc0: ltdc_de_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_hsync_pc2: ltdc_hsync_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+			};
+
+			ltdc_clk_pc5: ltdc_clk_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+			};
+
+			ltdc_g7_pc6: ltdc_g7_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_b6_pc7: ltdc_b6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF11)>;
+			};
+
+			ltdc_b4_pd0: ltdc_b4_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+			};
+
+			ltdc_b5_pd1: ltdc_b5_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+			};
+
+			ltdc_clk_pd3: ltdc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF11)>;
+			};
+
+			ltdc_de_pd6: ltdc_de_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF11)>;
+			};
+
+			ltdc_r3_pd8: ltdc_r3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+			};
+
+			ltdc_r4_pd9: ltdc_r4_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF11)>;
+			};
+
+			ltdc_r5_pd10: ltdc_r5_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF11)>;
+			};
+
+			ltdc_r6_pd11: ltdc_r6_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF11)>;
+			};
+
+			ltdc_r7_pd12: ltdc_r7_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF11)>;
+			};
+
+			ltdc_b2_pd14: ltdc_b2_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+			};
+
+			ltdc_b3_pd15: ltdc_b3_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF11)>;
+			};
+
+			ltdc_hsync_pe0: ltdc_hsync_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF11)>;
+			};
+
+			ltdc_r7_pe2: ltdc_r7_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+			};
+
+			ltdc_r6_pe3: ltdc_r6_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+			};
+
+			ltdc_b7_pe4: ltdc_b7_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF11)>;
+			};
+
+			ltdc_g7_pe5: ltdc_g7_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF11)>;
+			};
+
+			ltdc_g6_pe6: ltdc_g6_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+			};
+
+			ltdc_b6_pe7: ltdc_b6_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF11)>;
+			};
+
+			ltdc_b7_pe8: ltdc_b7_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF11)>;
+			};
+
+			ltdc_g2_pe9: ltdc_g2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF11)>;
+			};
+
+			ltdc_g3_pe10: ltdc_g3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF11)>;
+			};
+
+			ltdc_g4_pe11: ltdc_g4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+			};
+
+			ltdc_g5_pe12: ltdc_g5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF11)>;
+			};
+
+			ltdc_g6_pe13: ltdc_g6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF11)>;
+			};
+
+			ltdc_g7_pe14: ltdc_g7_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF11)>;
+			};
+
+			ltdc_r2_pe15: ltdc_r2_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4q5vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgyx-pinctrl.dtsi
@@ -475,6 +475,176 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_clk_pa4: ltdc_clk_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+			};
+
+			ltdc_r7_pa5: ltdc_r7_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+			};
+
+			ltdc_b7_pa8: ltdc_b7_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+			};
+
+			ltdc_g7_pa9: ltdc_g7_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF11)>;
+			};
+
+			ltdc_g6_pa10: ltdc_g6_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF11)>;
+			};
+
+			ltdc_de_pa11: ltdc_de_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+			};
+
+			ltdc_vsync_pa12: ltdc_vsync_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+			};
+
+			ltdc_hsync_pa15: ltdc_hsync_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+			};
+
+			ltdc_b6_pb0: ltdc_b6_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+			};
+
+			ltdc_g6_pb1: ltdc_g6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+			};
+
+			ltdc_r6_pb6: ltdc_r6_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+			};
+
+			ltdc_vsync_pb7: ltdc_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+			};
+
+			ltdc_de_pb8: ltdc_de_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_vsync_pb11: ltdc_vsync_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+			};
+
+			ltdc_de_pc0: ltdc_de_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_hsync_pc2: ltdc_hsync_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+			};
+
+			ltdc_clk_pc5: ltdc_clk_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+			};
+
+			ltdc_g7_pc6: ltdc_g7_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_b6_pc7: ltdc_b6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF11)>;
+			};
+
+			ltdc_b4_pd0: ltdc_b4_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+			};
+
+			ltdc_b5_pd1: ltdc_b5_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+			};
+
+			ltdc_de_pd6: ltdc_de_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF11)>;
+			};
+
+			ltdc_r3_pd8: ltdc_r3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+			};
+
+			ltdc_r4_pd9: ltdc_r4_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF11)>;
+			};
+
+			ltdc_r5_pd10: ltdc_r5_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF11)>;
+			};
+
+			ltdc_b2_pd14: ltdc_b2_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+			};
+
+			ltdc_b3_pd15: ltdc_b3_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF11)>;
+			};
+
+			ltdc_r7_pe2: ltdc_r7_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+			};
+
+			ltdc_r6_pe3: ltdc_r6_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+			};
+
+			ltdc_b7_pe4: ltdc_b7_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF11)>;
+			};
+
+			ltdc_g7_pe5: ltdc_g7_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF11)>;
+			};
+
+			ltdc_g6_pe6: ltdc_g6_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+			};
+
+			ltdc_b6_pe7: ltdc_b6_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF11)>;
+			};
+
+			ltdc_b7_pe8: ltdc_b7_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF11)>;
+			};
+
+			ltdc_g2_pe9: ltdc_g2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF11)>;
+			};
+
+			ltdc_g3_pe10: ltdc_g3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF11)>;
+			};
+
+			ltdc_g4_pe11: ltdc_g4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+			};
+
+			ltdc_g5_pe12: ltdc_g5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF11)>;
+			};
+
+			ltdc_g6_pe13: ltdc_g6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF11)>;
+			};
+
+			ltdc_g7_pe14: ltdc_g7_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF11)>;
+			};
+
+			ltdc_r2_pe15: ltdc_r2_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4q5vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgyxp-pinctrl.dtsi
@@ -467,6 +467,172 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_clk_pa4: ltdc_clk_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+			};
+
+			ltdc_r7_pa5: ltdc_r7_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+			};
+
+			ltdc_b7_pa8: ltdc_b7_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+			};
+
+			ltdc_g7_pa9: ltdc_g7_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF11)>;
+			};
+
+			ltdc_g6_pa10: ltdc_g6_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF11)>;
+			};
+
+			ltdc_de_pa11: ltdc_de_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+			};
+
+			ltdc_vsync_pa12: ltdc_vsync_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+			};
+
+			ltdc_hsync_pa15: ltdc_hsync_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+			};
+
+			ltdc_b6_pb0: ltdc_b6_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+			};
+
+			ltdc_g6_pb1: ltdc_g6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+			};
+
+			ltdc_r6_pb6: ltdc_r6_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+			};
+
+			ltdc_vsync_pb7: ltdc_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+			};
+
+			ltdc_de_pb8: ltdc_de_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_vsync_pb11: ltdc_vsync_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+			};
+
+			ltdc_de_pc0: ltdc_de_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_hsync_pc2: ltdc_hsync_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+			};
+
+			ltdc_g7_pc6: ltdc_g7_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_b6_pc7: ltdc_b6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF11)>;
+			};
+
+			ltdc_b4_pd0: ltdc_b4_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+			};
+
+			ltdc_b5_pd1: ltdc_b5_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+			};
+
+			ltdc_de_pd6: ltdc_de_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF11)>;
+			};
+
+			ltdc_r3_pd8: ltdc_r3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+			};
+
+			ltdc_r4_pd9: ltdc_r4_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF11)>;
+			};
+
+			ltdc_r5_pd10: ltdc_r5_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF11)>;
+			};
+
+			ltdc_b2_pd14: ltdc_b2_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+			};
+
+			ltdc_b3_pd15: ltdc_b3_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF11)>;
+			};
+
+			ltdc_r7_pe2: ltdc_r7_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+			};
+
+			ltdc_r6_pe3: ltdc_r6_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+			};
+
+			ltdc_b7_pe4: ltdc_b7_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF11)>;
+			};
+
+			ltdc_g7_pe5: ltdc_g7_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF11)>;
+			};
+
+			ltdc_g6_pe6: ltdc_g6_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+			};
+
+			ltdc_b6_pe7: ltdc_b6_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF11)>;
+			};
+
+			ltdc_b7_pe8: ltdc_b7_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF11)>;
+			};
+
+			ltdc_g2_pe9: ltdc_g2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF11)>;
+			};
+
+			ltdc_g3_pe10: ltdc_g3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF11)>;
+			};
+
+			ltdc_g4_pe11: ltdc_g4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+			};
+
+			ltdc_g5_pe12: ltdc_g5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF11)>;
+			};
+
+			ltdc_g6_pe13: ltdc_g6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF11)>;
+			};
+
+			ltdc_g7_pe14: ltdc_g7_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF11)>;
+			};
+
+			ltdc_r2_pe15: ltdc_r2_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4q5zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5zgtx-pinctrl.dtsi
@@ -685,6 +685,228 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_clk_pa4: ltdc_clk_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+			};
+
+			ltdc_r7_pa5: ltdc_r7_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+			};
+
+			ltdc_b7_pa8: ltdc_b7_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+			};
+
+			ltdc_g7_pa9: ltdc_g7_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF11)>;
+			};
+
+			ltdc_g6_pa10: ltdc_g6_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF11)>;
+			};
+
+			ltdc_de_pa11: ltdc_de_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+			};
+
+			ltdc_vsync_pa12: ltdc_vsync_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+			};
+
+			ltdc_hsync_pa15: ltdc_hsync_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+			};
+
+			ltdc_b6_pb0: ltdc_b6_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+			};
+
+			ltdc_g6_pb1: ltdc_g6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+			};
+
+			ltdc_r6_pb6: ltdc_r6_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+			};
+
+			ltdc_vsync_pb7: ltdc_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+			};
+
+			ltdc_de_pb8: ltdc_de_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_vsync_pb11: ltdc_vsync_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF11)>;
+			};
+
+			ltdc_de_pc0: ltdc_de_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_hsync_pc2: ltdc_hsync_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+			};
+
+			ltdc_clk_pc5: ltdc_clk_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+			};
+
+			ltdc_g7_pc6: ltdc_g7_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_b6_pc7: ltdc_b6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF11)>;
+			};
+
+			ltdc_b4_pd0: ltdc_b4_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+			};
+
+			ltdc_b5_pd1: ltdc_b5_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+			};
+
+			ltdc_clk_pd3: ltdc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF11)>;
+			};
+
+			ltdc_de_pd6: ltdc_de_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF11)>;
+			};
+
+			ltdc_r3_pd8: ltdc_r3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+			};
+
+			ltdc_r4_pd9: ltdc_r4_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF11)>;
+			};
+
+			ltdc_r5_pd10: ltdc_r5_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF11)>;
+			};
+
+			ltdc_r6_pd11: ltdc_r6_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF11)>;
+			};
+
+			ltdc_r7_pd12: ltdc_r7_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF11)>;
+			};
+
+			ltdc_b2_pd14: ltdc_b2_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+			};
+
+			ltdc_b3_pd15: ltdc_b3_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF11)>;
+			};
+
+			ltdc_hsync_pe0: ltdc_hsync_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF11)>;
+			};
+
+			ltdc_vsync_pe1: ltdc_vsync_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF11)>;
+			};
+
+			ltdc_r7_pe2: ltdc_r7_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+			};
+
+			ltdc_r6_pe3: ltdc_r6_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+			};
+
+			ltdc_b7_pe4: ltdc_b7_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF11)>;
+			};
+
+			ltdc_g7_pe5: ltdc_g7_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF11)>;
+			};
+
+			ltdc_g6_pe6: ltdc_g6_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+			};
+
+			ltdc_b6_pe7: ltdc_b6_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF11)>;
+			};
+
+			ltdc_b7_pe8: ltdc_b7_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF11)>;
+			};
+
+			ltdc_g2_pe9: ltdc_g2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF11)>;
+			};
+
+			ltdc_g3_pe10: ltdc_g3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF11)>;
+			};
+
+			ltdc_g4_pe11: ltdc_g4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+			};
+
+			ltdc_g5_pe12: ltdc_g5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF11)>;
+			};
+
+			ltdc_g6_pe13: ltdc_g6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF11)>;
+			};
+
+			ltdc_g7_pe14: ltdc_g7_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF11)>;
+			};
+
+			ltdc_r2_pe15: ltdc_r2_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF11)>;
+			};
+
+			ltdc_de_pf11: ltdc_de_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+			};
+
+			ltdc_b0_pf12: ltdc_b0_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF11)>;
+			};
+
+			ltdc_b1_pf13: ltdc_b1_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF11)>;
+			};
+
+			ltdc_g0_pf14: ltdc_g0_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF11)>;
+			};
+
+			ltdc_g1_pf15: ltdc_g1_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF11)>;
+			};
+
+			ltdc_r1_pg6: ltdc_r1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+			};
+
+			ltdc_r1_pg14: ltdc_r1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4q5zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5zgtxp-pinctrl.dtsi
@@ -673,6 +673,224 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_clk_pa4: ltdc_clk_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF11)>;
+			};
+
+			ltdc_r7_pa5: ltdc_r7_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF11)>;
+			};
+
+			ltdc_b7_pa8: ltdc_b7_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF11)>;
+			};
+
+			ltdc_g7_pa9: ltdc_g7_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF11)>;
+			};
+
+			ltdc_g6_pa10: ltdc_g6_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF11)>;
+			};
+
+			ltdc_de_pa11: ltdc_de_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF11)>;
+			};
+
+			ltdc_vsync_pa12: ltdc_vsync_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF11)>;
+			};
+
+			ltdc_hsync_pa15: ltdc_hsync_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF11)>;
+			};
+
+			ltdc_b6_pb0: ltdc_b6_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF11)>;
+			};
+
+			ltdc_g6_pb1: ltdc_g6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF11)>;
+			};
+
+			ltdc_r6_pb6: ltdc_r6_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF11)>;
+			};
+
+			ltdc_vsync_pb7: ltdc_vsync_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF11)>;
+			};
+
+			ltdc_de_pb8: ltdc_de_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_de_pc0: ltdc_de_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF11)>;
+			};
+
+			ltdc_hsync_pc2: ltdc_hsync_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+			};
+
+			ltdc_clk_pc5: ltdc_clk_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF11)>;
+			};
+
+			ltdc_g7_pc6: ltdc_g7_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_b6_pc7: ltdc_b6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_r6_pc12: ltdc_r6_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF11)>;
+			};
+
+			ltdc_b4_pd0: ltdc_b4_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+			};
+
+			ltdc_b5_pd1: ltdc_b5_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+			};
+
+			ltdc_clk_pd3: ltdc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF11)>;
+			};
+
+			ltdc_de_pd6: ltdc_de_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF11)>;
+			};
+
+			ltdc_r3_pd8: ltdc_r3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+			};
+
+			ltdc_r4_pd9: ltdc_r4_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF11)>;
+			};
+
+			ltdc_r5_pd10: ltdc_r5_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF11)>;
+			};
+
+			ltdc_r6_pd11: ltdc_r6_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF11)>;
+			};
+
+			ltdc_r7_pd12: ltdc_r7_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF11)>;
+			};
+
+			ltdc_b2_pd14: ltdc_b2_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+			};
+
+			ltdc_b3_pd15: ltdc_b3_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF11)>;
+			};
+
+			ltdc_hsync_pe0: ltdc_hsync_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF11)>;
+			};
+
+			ltdc_vsync_pe1: ltdc_vsync_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF11)>;
+			};
+
+			ltdc_r7_pe2: ltdc_r7_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+			};
+
+			ltdc_r6_pe3: ltdc_r6_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+			};
+
+			ltdc_b7_pe4: ltdc_b7_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF11)>;
+			};
+
+			ltdc_g7_pe5: ltdc_g7_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF11)>;
+			};
+
+			ltdc_g6_pe6: ltdc_g6_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+			};
+
+			ltdc_b6_pe7: ltdc_b6_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF11)>;
+			};
+
+			ltdc_b7_pe8: ltdc_b7_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF11)>;
+			};
+
+			ltdc_g2_pe9: ltdc_g2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF11)>;
+			};
+
+			ltdc_g3_pe10: ltdc_g3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF11)>;
+			};
+
+			ltdc_g4_pe11: ltdc_g4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+			};
+
+			ltdc_g5_pe12: ltdc_g5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF11)>;
+			};
+
+			ltdc_g6_pe13: ltdc_g6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF11)>;
+			};
+
+			ltdc_g7_pe14: ltdc_g7_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF11)>;
+			};
+
+			ltdc_r2_pe15: ltdc_r2_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF11)>;
+			};
+
+			ltdc_de_pf11: ltdc_de_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+			};
+
+			ltdc_b0_pf12: ltdc_b0_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF11)>;
+			};
+
+			ltdc_b1_pf13: ltdc_b1_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF11)>;
+			};
+
+			ltdc_g0_pf14: ltdc_g0_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF11)>;
+			};
+
+			ltdc_g1_pf15: ltdc_g1_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF11)>;
+			};
+
+			ltdc_r1_pg6: ltdc_r1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+			};
+
+			ltdc_r1_pg14: ltdc_r1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r7aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7aiix-pinctrl.dtsi
@@ -654,6 +654,164 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_b1_pb2: ltdc_b1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+			};
+
+			ltdc_b1_pb8: ltdc_b1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_r0_pc6: ltdc_r0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_r1_pc7: ltdc_r1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_b4_pd0: ltdc_b4_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+			};
+
+			ltdc_b5_pd1: ltdc_b5_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+			};
+
+			ltdc_clk_pd3: ltdc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF11)>;
+			};
+
+			ltdc_de_pd6: ltdc_de_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF11)>;
+			};
+
+			ltdc_r3_pd8: ltdc_r3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+			};
+
+			ltdc_r4_pd9: ltdc_r4_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF11)>;
+			};
+
+			ltdc_r5_pd10: ltdc_r5_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF11)>;
+			};
+
+			ltdc_r6_pd11: ltdc_r6_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF11)>;
+			};
+
+			ltdc_r7_pd12: ltdc_r7_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF11)>;
+			};
+
+			ltdc_b2_pd14: ltdc_b2_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+			};
+
+			ltdc_b3_pd15: ltdc_b3_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF11)>;
+			};
+
+			ltdc_hsync_pe0: ltdc_hsync_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF11)>;
+			};
+
+			ltdc_vsync_pe1: ltdc_vsync_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF11)>;
+			};
+
+			ltdc_r0_pe2: ltdc_r0_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+			};
+
+			ltdc_r1_pe3: ltdc_r1_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF11)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF11)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+			};
+
+			ltdc_b6_pe7: ltdc_b6_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF11)>;
+			};
+
+			ltdc_b7_pe8: ltdc_b7_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF11)>;
+			};
+
+			ltdc_g2_pe9: ltdc_g2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF11)>;
+			};
+
+			ltdc_g3_pe10: ltdc_g3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF11)>;
+			};
+
+			ltdc_g4_pe11: ltdc_g4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+			};
+
+			ltdc_g5_pe12: ltdc_g5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF11)>;
+			};
+
+			ltdc_g6_pe13: ltdc_g6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF11)>;
+			};
+
+			ltdc_g7_pe14: ltdc_g7_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF11)>;
+			};
+
+			ltdc_r2_pe15: ltdc_r2_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF11)>;
+			};
+
+			ltdc_de_pf11: ltdc_de_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+			};
+
+			ltdc_b0_pf12: ltdc_b0_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF11)>;
+			};
+
+			ltdc_b1_pf13: ltdc_b1_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF11)>;
+			};
+
+			ltdc_g0_pf14: ltdc_g0_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF11)>;
+			};
+
+			ltdc_g1_pf15: ltdc_g1_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF11)>;
+			};
+
+			ltdc_r1_pg6: ltdc_r1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+			};
+
+			ltdc_r1_pg14: ltdc_r1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r7vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7vitx-pinctrl.dtsi
@@ -435,6 +435,132 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_b1_pb2: ltdc_b1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+			};
+
+			ltdc_b1_pb8: ltdc_b1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_r0_pc6: ltdc_r0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_r1_pc7: ltdc_r1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_b4_pd0: ltdc_b4_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+			};
+
+			ltdc_b5_pd1: ltdc_b5_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+			};
+
+			ltdc_clk_pd3: ltdc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF11)>;
+			};
+
+			ltdc_de_pd6: ltdc_de_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF11)>;
+			};
+
+			ltdc_r3_pd8: ltdc_r3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+			};
+
+			ltdc_r4_pd9: ltdc_r4_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF11)>;
+			};
+
+			ltdc_r5_pd10: ltdc_r5_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF11)>;
+			};
+
+			ltdc_r6_pd11: ltdc_r6_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF11)>;
+			};
+
+			ltdc_r7_pd12: ltdc_r7_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF11)>;
+			};
+
+			ltdc_b2_pd14: ltdc_b2_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+			};
+
+			ltdc_b3_pd15: ltdc_b3_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF11)>;
+			};
+
+			ltdc_hsync_pe0: ltdc_hsync_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF11)>;
+			};
+
+			ltdc_vsync_pe1: ltdc_vsync_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF11)>;
+			};
+
+			ltdc_r0_pe2: ltdc_r0_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+			};
+
+			ltdc_r1_pe3: ltdc_r1_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF11)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF11)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+			};
+
+			ltdc_b6_pe7: ltdc_b6_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF11)>;
+			};
+
+			ltdc_b7_pe8: ltdc_b7_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF11)>;
+			};
+
+			ltdc_g2_pe9: ltdc_g2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF11)>;
+			};
+
+			ltdc_g3_pe10: ltdc_g3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF11)>;
+			};
+
+			ltdc_g4_pe11: ltdc_g4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+			};
+
+			ltdc_g5_pe12: ltdc_g5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF11)>;
+			};
+
+			ltdc_g6_pe13: ltdc_g6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF11)>;
+			};
+
+			ltdc_g7_pe14: ltdc_g7_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF11)>;
+			};
+
+			ltdc_r2_pe15: ltdc_r2_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r7zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7zitx-pinctrl.dtsi
@@ -621,6 +621,164 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_b1_pb2: ltdc_b1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+			};
+
+			ltdc_b1_pb8: ltdc_b1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_r0_pc6: ltdc_r0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_r1_pc7: ltdc_r1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_b4_pd0: ltdc_b4_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+			};
+
+			ltdc_b5_pd1: ltdc_b5_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+			};
+
+			ltdc_clk_pd3: ltdc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF11)>;
+			};
+
+			ltdc_de_pd6: ltdc_de_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF11)>;
+			};
+
+			ltdc_r3_pd8: ltdc_r3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+			};
+
+			ltdc_r4_pd9: ltdc_r4_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF11)>;
+			};
+
+			ltdc_r5_pd10: ltdc_r5_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF11)>;
+			};
+
+			ltdc_r6_pd11: ltdc_r6_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF11)>;
+			};
+
+			ltdc_r7_pd12: ltdc_r7_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF11)>;
+			};
+
+			ltdc_b2_pd14: ltdc_b2_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+			};
+
+			ltdc_b3_pd15: ltdc_b3_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF11)>;
+			};
+
+			ltdc_hsync_pe0: ltdc_hsync_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF11)>;
+			};
+
+			ltdc_vsync_pe1: ltdc_vsync_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF11)>;
+			};
+
+			ltdc_r0_pe2: ltdc_r0_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+			};
+
+			ltdc_r1_pe3: ltdc_r1_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF11)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF11)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+			};
+
+			ltdc_b6_pe7: ltdc_b6_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF11)>;
+			};
+
+			ltdc_b7_pe8: ltdc_b7_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF11)>;
+			};
+
+			ltdc_g2_pe9: ltdc_g2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF11)>;
+			};
+
+			ltdc_g3_pe10: ltdc_g3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF11)>;
+			};
+
+			ltdc_g4_pe11: ltdc_g4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+			};
+
+			ltdc_g5_pe12: ltdc_g5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF11)>;
+			};
+
+			ltdc_g6_pe13: ltdc_g6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF11)>;
+			};
+
+			ltdc_g7_pe14: ltdc_g7_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF11)>;
+			};
+
+			ltdc_r2_pe15: ltdc_r2_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF11)>;
+			};
+
+			ltdc_de_pf11: ltdc_de_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+			};
+
+			ltdc_b0_pf12: ltdc_b0_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF11)>;
+			};
+
+			ltdc_b1_pf13: ltdc_b1_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF11)>;
+			};
+
+			ltdc_g0_pf14: ltdc_g0_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF11)>;
+			};
+
+			ltdc_g1_pf15: ltdc_g1_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF11)>;
+			};
+
+			ltdc_r1_pg6: ltdc_r1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+			};
+
+			ltdc_r1_pg14: ltdc_r1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r9a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9a(g-i)ix-pinctrl.dtsi
@@ -632,6 +632,160 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_b1_pb2: ltdc_b1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+			};
+
+			ltdc_b1_pb8: ltdc_b1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_r0_pc6: ltdc_r0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_r1_pc7: ltdc_r1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_b4_pd0: ltdc_b4_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+			};
+
+			ltdc_b5_pd1: ltdc_b5_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+			};
+
+			ltdc_clk_pd3: ltdc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF11)>;
+			};
+
+			ltdc_de_pd6: ltdc_de_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF11)>;
+			};
+
+			ltdc_r3_pd8: ltdc_r3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+			};
+
+			ltdc_r4_pd9: ltdc_r4_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF11)>;
+			};
+
+			ltdc_r5_pd10: ltdc_r5_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF11)>;
+			};
+
+			ltdc_r6_pd11: ltdc_r6_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF11)>;
+			};
+
+			ltdc_r7_pd12: ltdc_r7_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF11)>;
+			};
+
+			ltdc_b2_pd14: ltdc_b2_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+			};
+
+			ltdc_b3_pd15: ltdc_b3_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF11)>;
+			};
+
+			ltdc_hsync_pe0: ltdc_hsync_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF11)>;
+			};
+
+			ltdc_vsync_pe1: ltdc_vsync_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF11)>;
+			};
+
+			ltdc_r0_pe2: ltdc_r0_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+			};
+
+			ltdc_r1_pe3: ltdc_r1_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF11)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF11)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+			};
+
+			ltdc_b6_pe7: ltdc_b6_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF11)>;
+			};
+
+			ltdc_b7_pe8: ltdc_b7_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF11)>;
+			};
+
+			ltdc_g2_pe9: ltdc_g2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF11)>;
+			};
+
+			ltdc_g3_pe10: ltdc_g3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF11)>;
+			};
+
+			ltdc_g4_pe11: ltdc_g4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+			};
+
+			ltdc_g5_pe12: ltdc_g5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF11)>;
+			};
+
+			ltdc_g6_pe13: ltdc_g6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF11)>;
+			};
+
+			ltdc_g7_pe14: ltdc_g7_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF11)>;
+			};
+
+			ltdc_r2_pe15: ltdc_r2_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF11)>;
+			};
+
+			ltdc_de_pf11: ltdc_de_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+			};
+
+			ltdc_b0_pf12: ltdc_b0_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF11)>;
+			};
+
+			ltdc_b1_pf13: ltdc_b1_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF11)>;
+			};
+
+			ltdc_g0_pf14: ltdc_g0_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF11)>;
+			};
+
+			ltdc_g1_pf15: ltdc_g1_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF11)>;
+			};
+
+			ltdc_r1_pg6: ltdc_r1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r9v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9v(g-i)tx-pinctrl.dtsi
@@ -383,6 +383,116 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_b1_pb2: ltdc_b1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+			};
+
+			ltdc_b1_pb8: ltdc_b1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_r0_pc6: ltdc_r0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_r1_pc7: ltdc_r1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_b4_pd0: ltdc_b4_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+			};
+
+			ltdc_b5_pd1: ltdc_b5_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+			};
+
+			ltdc_clk_pd3: ltdc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF11)>;
+			};
+
+			ltdc_de_pd6: ltdc_de_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF11)>;
+			};
+
+			ltdc_r3_pd8: ltdc_r3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+			};
+
+			ltdc_r4_pd9: ltdc_r4_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF11)>;
+			};
+
+			ltdc_r5_pd10: ltdc_r5_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF11)>;
+			};
+
+			ltdc_b2_pd14: ltdc_b2_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+			};
+
+			ltdc_b3_pd15: ltdc_b3_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF11)>;
+			};
+
+			ltdc_r0_pe2: ltdc_r0_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+			};
+
+			ltdc_r1_pe3: ltdc_r1_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF11)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF11)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+			};
+
+			ltdc_b6_pe7: ltdc_b6_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF11)>;
+			};
+
+			ltdc_b7_pe8: ltdc_b7_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF11)>;
+			};
+
+			ltdc_g2_pe9: ltdc_g2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF11)>;
+			};
+
+			ltdc_g3_pe10: ltdc_g3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF11)>;
+			};
+
+			ltdc_g4_pe11: ltdc_g4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+			};
+
+			ltdc_g5_pe12: ltdc_g5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF11)>;
+			};
+
+			ltdc_g6_pe13: ltdc_g6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF11)>;
+			};
+
+			ltdc_g7_pe14: ltdc_g7_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF11)>;
+			};
+
+			ltdc_r2_pe15: ltdc_r2_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r9z(g-i)jx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)jx-pinctrl.dtsi
@@ -609,6 +609,160 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_b1_pb2: ltdc_b1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+			};
+
+			ltdc_b1_pb8: ltdc_b1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_r0_pc6: ltdc_r0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_r1_pc7: ltdc_r1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_b4_pd0: ltdc_b4_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+			};
+
+			ltdc_b5_pd1: ltdc_b5_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+			};
+
+			ltdc_clk_pd3: ltdc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF11)>;
+			};
+
+			ltdc_de_pd6: ltdc_de_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF11)>;
+			};
+
+			ltdc_r3_pd8: ltdc_r3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+			};
+
+			ltdc_r4_pd9: ltdc_r4_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF11)>;
+			};
+
+			ltdc_r5_pd10: ltdc_r5_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF11)>;
+			};
+
+			ltdc_r6_pd11: ltdc_r6_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF11)>;
+			};
+
+			ltdc_r7_pd12: ltdc_r7_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF11)>;
+			};
+
+			ltdc_b2_pd14: ltdc_b2_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+			};
+
+			ltdc_b3_pd15: ltdc_b3_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF11)>;
+			};
+
+			ltdc_hsync_pe0: ltdc_hsync_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF11)>;
+			};
+
+			ltdc_vsync_pe1: ltdc_vsync_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF11)>;
+			};
+
+			ltdc_r0_pe2: ltdc_r0_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+			};
+
+			ltdc_r1_pe3: ltdc_r1_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF11)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF11)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+			};
+
+			ltdc_b6_pe7: ltdc_b6_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF11)>;
+			};
+
+			ltdc_b7_pe8: ltdc_b7_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF11)>;
+			};
+
+			ltdc_g2_pe9: ltdc_g2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF11)>;
+			};
+
+			ltdc_g3_pe10: ltdc_g3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF11)>;
+			};
+
+			ltdc_g4_pe11: ltdc_g4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+			};
+
+			ltdc_g5_pe12: ltdc_g5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF11)>;
+			};
+
+			ltdc_g6_pe13: ltdc_g6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF11)>;
+			};
+
+			ltdc_g7_pe14: ltdc_g7_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF11)>;
+			};
+
+			ltdc_r2_pe15: ltdc_r2_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF11)>;
+			};
+
+			ltdc_de_pf11: ltdc_de_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+			};
+
+			ltdc_b0_pf12: ltdc_b0_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF11)>;
+			};
+
+			ltdc_b1_pf13: ltdc_b1_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF11)>;
+			};
+
+			ltdc_g0_pf14: ltdc_g0_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF11)>;
+			};
+
+			ltdc_g1_pf15: ltdc_g1_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF11)>;
+			};
+
+			ltdc_r1_pg6: ltdc_r1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r9z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)tx-pinctrl.dtsi
@@ -593,6 +593,156 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_b1_pb2: ltdc_b1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+			};
+
+			ltdc_b1_pb8: ltdc_b1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_r0_pc6: ltdc_r0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_r1_pc7: ltdc_r1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_b4_pd0: ltdc_b4_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+			};
+
+			ltdc_b5_pd1: ltdc_b5_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+			};
+
+			ltdc_clk_pd3: ltdc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF11)>;
+			};
+
+			ltdc_de_pd6: ltdc_de_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF11)>;
+			};
+
+			ltdc_r3_pd8: ltdc_r3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+			};
+
+			ltdc_r4_pd9: ltdc_r4_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF11)>;
+			};
+
+			ltdc_r5_pd10: ltdc_r5_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF11)>;
+			};
+
+			ltdc_r6_pd11: ltdc_r6_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF11)>;
+			};
+
+			ltdc_r7_pd12: ltdc_r7_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF11)>;
+			};
+
+			ltdc_b2_pd14: ltdc_b2_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+			};
+
+			ltdc_b3_pd15: ltdc_b3_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF11)>;
+			};
+
+			ltdc_hsync_pe0: ltdc_hsync_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF11)>;
+			};
+
+			ltdc_vsync_pe1: ltdc_vsync_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF11)>;
+			};
+
+			ltdc_r0_pe2: ltdc_r0_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+			};
+
+			ltdc_r1_pe3: ltdc_r1_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF11)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF11)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+			};
+
+			ltdc_b6_pe7: ltdc_b6_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF11)>;
+			};
+
+			ltdc_b7_pe8: ltdc_b7_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF11)>;
+			};
+
+			ltdc_g2_pe9: ltdc_g2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF11)>;
+			};
+
+			ltdc_g3_pe10: ltdc_g3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF11)>;
+			};
+
+			ltdc_g4_pe11: ltdc_g4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+			};
+
+			ltdc_g5_pe12: ltdc_g5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF11)>;
+			};
+
+			ltdc_g6_pe13: ltdc_g6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF11)>;
+			};
+
+			ltdc_g7_pe14: ltdc_g7_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF11)>;
+			};
+
+			ltdc_r2_pe15: ltdc_r2_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF11)>;
+			};
+
+			ltdc_de_pf11: ltdc_de_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+			};
+
+			ltdc_b0_pf12: ltdc_b0_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF11)>;
+			};
+
+			ltdc_b1_pf13: ltdc_b1_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF11)>;
+			};
+
+			ltdc_g0_pf14: ltdc_g0_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF11)>;
+			};
+
+			ltdc_g1_pf15: ltdc_g1_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF11)>;
+			};
+
+			ltdc_r1_pg6: ltdc_r1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF9)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r9z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)yx-pinctrl.dtsi
@@ -609,6 +609,160 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_b1_pb2: ltdc_b1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+			};
+
+			ltdc_b1_pb8: ltdc_b1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_r0_pc6: ltdc_r0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_r1_pc7: ltdc_r1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_b4_pd0: ltdc_b4_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+			};
+
+			ltdc_b5_pd1: ltdc_b5_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+			};
+
+			ltdc_clk_pd3: ltdc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF11)>;
+			};
+
+			ltdc_de_pd6: ltdc_de_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF11)>;
+			};
+
+			ltdc_r3_pd8: ltdc_r3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+			};
+
+			ltdc_r4_pd9: ltdc_r4_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF11)>;
+			};
+
+			ltdc_r5_pd10: ltdc_r5_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF11)>;
+			};
+
+			ltdc_r6_pd11: ltdc_r6_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF11)>;
+			};
+
+			ltdc_r7_pd12: ltdc_r7_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF11)>;
+			};
+
+			ltdc_b2_pd14: ltdc_b2_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+			};
+
+			ltdc_b3_pd15: ltdc_b3_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF11)>;
+			};
+
+			ltdc_hsync_pe0: ltdc_hsync_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF11)>;
+			};
+
+			ltdc_vsync_pe1: ltdc_vsync_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF11)>;
+			};
+
+			ltdc_r0_pe2: ltdc_r0_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+			};
+
+			ltdc_r1_pe3: ltdc_r1_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF11)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF11)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+			};
+
+			ltdc_b6_pe7: ltdc_b6_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF11)>;
+			};
+
+			ltdc_b7_pe8: ltdc_b7_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF11)>;
+			};
+
+			ltdc_g2_pe9: ltdc_g2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF11)>;
+			};
+
+			ltdc_g3_pe10: ltdc_g3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF11)>;
+			};
+
+			ltdc_g4_pe11: ltdc_g4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+			};
+
+			ltdc_g5_pe12: ltdc_g5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF11)>;
+			};
+
+			ltdc_g6_pe13: ltdc_g6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF11)>;
+			};
+
+			ltdc_g7_pe14: ltdc_g7_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF11)>;
+			};
+
+			ltdc_r2_pe15: ltdc_r2_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF11)>;
+			};
+
+			ltdc_de_pf11: ltdc_de_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+			};
+
+			ltdc_b0_pf12: ltdc_b0_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF11)>;
+			};
+
+			ltdc_b1_pf13: ltdc_b1_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF11)>;
+			};
+
+			ltdc_g0_pf14: ltdc_g0_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF11)>;
+			};
+
+			ltdc_g1_pf15: ltdc_g1_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF11)>;
+			};
+
+			ltdc_r1_pg6: ltdc_r1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4r9ziyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9ziyxp-pinctrl.dtsi
@@ -585,6 +585,156 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_b1_pb2: ltdc_b1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+			};
+
+			ltdc_b1_pb8: ltdc_b1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_r0_pc6: ltdc_r0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_r1_pc7: ltdc_r1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_b4_pd0: ltdc_b4_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+			};
+
+			ltdc_b5_pd1: ltdc_b5_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+			};
+
+			ltdc_clk_pd3: ltdc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF11)>;
+			};
+
+			ltdc_de_pd6: ltdc_de_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF11)>;
+			};
+
+			ltdc_r3_pd8: ltdc_r3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+			};
+
+			ltdc_r4_pd9: ltdc_r4_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF11)>;
+			};
+
+			ltdc_r5_pd10: ltdc_r5_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF11)>;
+			};
+
+			ltdc_r6_pd11: ltdc_r6_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF11)>;
+			};
+
+			ltdc_r7_pd12: ltdc_r7_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF11)>;
+			};
+
+			ltdc_b2_pd14: ltdc_b2_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+			};
+
+			ltdc_b3_pd15: ltdc_b3_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF11)>;
+			};
+
+			ltdc_hsync_pe0: ltdc_hsync_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF11)>;
+			};
+
+			ltdc_vsync_pe1: ltdc_vsync_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF11)>;
+			};
+
+			ltdc_r0_pe2: ltdc_r0_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+			};
+
+			ltdc_r1_pe3: ltdc_r1_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF11)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF11)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+			};
+
+			ltdc_b6_pe7: ltdc_b6_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF11)>;
+			};
+
+			ltdc_b7_pe8: ltdc_b7_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF11)>;
+			};
+
+			ltdc_g2_pe9: ltdc_g2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF11)>;
+			};
+
+			ltdc_g3_pe10: ltdc_g3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF11)>;
+			};
+
+			ltdc_g4_pe11: ltdc_g4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+			};
+
+			ltdc_g5_pe12: ltdc_g5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF11)>;
+			};
+
+			ltdc_g6_pe13: ltdc_g6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF11)>;
+			};
+
+			ltdc_g7_pe14: ltdc_g7_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF11)>;
+			};
+
+			ltdc_r2_pe15: ltdc_r2_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF11)>;
+			};
+
+			ltdc_de_pf11: ltdc_de_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+			};
+
+			ltdc_b0_pf12: ltdc_b0_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF11)>;
+			};
+
+			ltdc_b1_pf13: ltdc_b1_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF11)>;
+			};
+
+			ltdc_g0_pf14: ltdc_g0_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF11)>;
+			};
+
+			ltdc_g1_pf15: ltdc_g1_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF11)>;
+			};
+
+			ltdc_r1_pg6: ltdc_r1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF9)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4s7aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7aiix-pinctrl.dtsi
@@ -654,6 +654,164 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_b1_pb2: ltdc_b1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+			};
+
+			ltdc_b1_pb8: ltdc_b1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_r0_pc6: ltdc_r0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_r1_pc7: ltdc_r1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_b4_pd0: ltdc_b4_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+			};
+
+			ltdc_b5_pd1: ltdc_b5_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+			};
+
+			ltdc_clk_pd3: ltdc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF11)>;
+			};
+
+			ltdc_de_pd6: ltdc_de_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF11)>;
+			};
+
+			ltdc_r3_pd8: ltdc_r3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+			};
+
+			ltdc_r4_pd9: ltdc_r4_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF11)>;
+			};
+
+			ltdc_r5_pd10: ltdc_r5_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF11)>;
+			};
+
+			ltdc_r6_pd11: ltdc_r6_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF11)>;
+			};
+
+			ltdc_r7_pd12: ltdc_r7_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF11)>;
+			};
+
+			ltdc_b2_pd14: ltdc_b2_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+			};
+
+			ltdc_b3_pd15: ltdc_b3_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF11)>;
+			};
+
+			ltdc_hsync_pe0: ltdc_hsync_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF11)>;
+			};
+
+			ltdc_vsync_pe1: ltdc_vsync_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF11)>;
+			};
+
+			ltdc_r0_pe2: ltdc_r0_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+			};
+
+			ltdc_r1_pe3: ltdc_r1_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF11)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF11)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+			};
+
+			ltdc_b6_pe7: ltdc_b6_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF11)>;
+			};
+
+			ltdc_b7_pe8: ltdc_b7_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF11)>;
+			};
+
+			ltdc_g2_pe9: ltdc_g2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF11)>;
+			};
+
+			ltdc_g3_pe10: ltdc_g3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF11)>;
+			};
+
+			ltdc_g4_pe11: ltdc_g4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+			};
+
+			ltdc_g5_pe12: ltdc_g5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF11)>;
+			};
+
+			ltdc_g6_pe13: ltdc_g6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF11)>;
+			};
+
+			ltdc_g7_pe14: ltdc_g7_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF11)>;
+			};
+
+			ltdc_r2_pe15: ltdc_r2_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF11)>;
+			};
+
+			ltdc_de_pf11: ltdc_de_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+			};
+
+			ltdc_b0_pf12: ltdc_b0_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF11)>;
+			};
+
+			ltdc_b1_pf13: ltdc_b1_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF11)>;
+			};
+
+			ltdc_g0_pf14: ltdc_g0_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF11)>;
+			};
+
+			ltdc_g1_pf15: ltdc_g1_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF11)>;
+			};
+
+			ltdc_r1_pg6: ltdc_r1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+			};
+
+			ltdc_r1_pg14: ltdc_r1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4s7vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7vitx-pinctrl.dtsi
@@ -435,6 +435,132 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_b1_pb2: ltdc_b1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+			};
+
+			ltdc_b1_pb8: ltdc_b1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_r0_pc6: ltdc_r0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_r1_pc7: ltdc_r1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_b4_pd0: ltdc_b4_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+			};
+
+			ltdc_b5_pd1: ltdc_b5_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+			};
+
+			ltdc_clk_pd3: ltdc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF11)>;
+			};
+
+			ltdc_de_pd6: ltdc_de_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF11)>;
+			};
+
+			ltdc_r3_pd8: ltdc_r3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+			};
+
+			ltdc_r4_pd9: ltdc_r4_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF11)>;
+			};
+
+			ltdc_r5_pd10: ltdc_r5_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF11)>;
+			};
+
+			ltdc_r6_pd11: ltdc_r6_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF11)>;
+			};
+
+			ltdc_r7_pd12: ltdc_r7_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF11)>;
+			};
+
+			ltdc_b2_pd14: ltdc_b2_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+			};
+
+			ltdc_b3_pd15: ltdc_b3_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF11)>;
+			};
+
+			ltdc_hsync_pe0: ltdc_hsync_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF11)>;
+			};
+
+			ltdc_vsync_pe1: ltdc_vsync_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF11)>;
+			};
+
+			ltdc_r0_pe2: ltdc_r0_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+			};
+
+			ltdc_r1_pe3: ltdc_r1_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF11)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF11)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+			};
+
+			ltdc_b6_pe7: ltdc_b6_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF11)>;
+			};
+
+			ltdc_b7_pe8: ltdc_b7_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF11)>;
+			};
+
+			ltdc_g2_pe9: ltdc_g2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF11)>;
+			};
+
+			ltdc_g3_pe10: ltdc_g3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF11)>;
+			};
+
+			ltdc_g4_pe11: ltdc_g4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+			};
+
+			ltdc_g5_pe12: ltdc_g5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF11)>;
+			};
+
+			ltdc_g6_pe13: ltdc_g6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF11)>;
+			};
+
+			ltdc_g7_pe14: ltdc_g7_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF11)>;
+			};
+
+			ltdc_r2_pe15: ltdc_r2_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4s7zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7zitx-pinctrl.dtsi
@@ -621,6 +621,164 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_b1_pb2: ltdc_b1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+			};
+
+			ltdc_b1_pb8: ltdc_b1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_r0_pc6: ltdc_r0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_r1_pc7: ltdc_r1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_b4_pd0: ltdc_b4_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+			};
+
+			ltdc_b5_pd1: ltdc_b5_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+			};
+
+			ltdc_clk_pd3: ltdc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF11)>;
+			};
+
+			ltdc_de_pd6: ltdc_de_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF11)>;
+			};
+
+			ltdc_r3_pd8: ltdc_r3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+			};
+
+			ltdc_r4_pd9: ltdc_r4_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF11)>;
+			};
+
+			ltdc_r5_pd10: ltdc_r5_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF11)>;
+			};
+
+			ltdc_r6_pd11: ltdc_r6_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF11)>;
+			};
+
+			ltdc_r7_pd12: ltdc_r7_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF11)>;
+			};
+
+			ltdc_b2_pd14: ltdc_b2_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+			};
+
+			ltdc_b3_pd15: ltdc_b3_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF11)>;
+			};
+
+			ltdc_hsync_pe0: ltdc_hsync_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF11)>;
+			};
+
+			ltdc_vsync_pe1: ltdc_vsync_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF11)>;
+			};
+
+			ltdc_r0_pe2: ltdc_r0_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+			};
+
+			ltdc_r1_pe3: ltdc_r1_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF11)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF11)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+			};
+
+			ltdc_b6_pe7: ltdc_b6_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF11)>;
+			};
+
+			ltdc_b7_pe8: ltdc_b7_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF11)>;
+			};
+
+			ltdc_g2_pe9: ltdc_g2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF11)>;
+			};
+
+			ltdc_g3_pe10: ltdc_g3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF11)>;
+			};
+
+			ltdc_g4_pe11: ltdc_g4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+			};
+
+			ltdc_g5_pe12: ltdc_g5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF11)>;
+			};
+
+			ltdc_g6_pe13: ltdc_g6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF11)>;
+			};
+
+			ltdc_g7_pe14: ltdc_g7_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF11)>;
+			};
+
+			ltdc_r2_pe15: ltdc_r2_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF11)>;
+			};
+
+			ltdc_de_pf11: ltdc_de_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+			};
+
+			ltdc_b0_pf12: ltdc_b0_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF11)>;
+			};
+
+			ltdc_b1_pf13: ltdc_b1_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF11)>;
+			};
+
+			ltdc_g0_pf14: ltdc_g0_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF11)>;
+			};
+
+			ltdc_g1_pf15: ltdc_g1_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF11)>;
+			};
+
+			ltdc_r1_pg6: ltdc_r1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+			};
+
+			ltdc_r1_pg14: ltdc_r1_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4s9aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9aiix-pinctrl.dtsi
@@ -632,6 +632,160 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_b1_pb2: ltdc_b1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+			};
+
+			ltdc_b1_pb8: ltdc_b1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_r0_pc6: ltdc_r0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_r1_pc7: ltdc_r1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_b4_pd0: ltdc_b4_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+			};
+
+			ltdc_b5_pd1: ltdc_b5_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+			};
+
+			ltdc_clk_pd3: ltdc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF11)>;
+			};
+
+			ltdc_de_pd6: ltdc_de_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF11)>;
+			};
+
+			ltdc_r3_pd8: ltdc_r3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+			};
+
+			ltdc_r4_pd9: ltdc_r4_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF11)>;
+			};
+
+			ltdc_r5_pd10: ltdc_r5_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF11)>;
+			};
+
+			ltdc_r6_pd11: ltdc_r6_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF11)>;
+			};
+
+			ltdc_r7_pd12: ltdc_r7_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF11)>;
+			};
+
+			ltdc_b2_pd14: ltdc_b2_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+			};
+
+			ltdc_b3_pd15: ltdc_b3_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF11)>;
+			};
+
+			ltdc_hsync_pe0: ltdc_hsync_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF11)>;
+			};
+
+			ltdc_vsync_pe1: ltdc_vsync_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF11)>;
+			};
+
+			ltdc_r0_pe2: ltdc_r0_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+			};
+
+			ltdc_r1_pe3: ltdc_r1_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF11)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF11)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+			};
+
+			ltdc_b6_pe7: ltdc_b6_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF11)>;
+			};
+
+			ltdc_b7_pe8: ltdc_b7_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF11)>;
+			};
+
+			ltdc_g2_pe9: ltdc_g2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF11)>;
+			};
+
+			ltdc_g3_pe10: ltdc_g3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF11)>;
+			};
+
+			ltdc_g4_pe11: ltdc_g4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+			};
+
+			ltdc_g5_pe12: ltdc_g5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF11)>;
+			};
+
+			ltdc_g6_pe13: ltdc_g6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF11)>;
+			};
+
+			ltdc_g7_pe14: ltdc_g7_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF11)>;
+			};
+
+			ltdc_r2_pe15: ltdc_r2_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF11)>;
+			};
+
+			ltdc_de_pf11: ltdc_de_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+			};
+
+			ltdc_b0_pf12: ltdc_b0_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF11)>;
+			};
+
+			ltdc_b1_pf13: ltdc_b1_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF11)>;
+			};
+
+			ltdc_g0_pf14: ltdc_g0_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF11)>;
+			};
+
+			ltdc_g1_pf15: ltdc_g1_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF11)>;
+			};
+
+			ltdc_r1_pg6: ltdc_r1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4s9vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9vitx-pinctrl.dtsi
@@ -383,6 +383,116 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_b1_pb2: ltdc_b1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+			};
+
+			ltdc_b1_pb8: ltdc_b1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_r0_pc6: ltdc_r0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_r1_pc7: ltdc_r1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_b4_pd0: ltdc_b4_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+			};
+
+			ltdc_b5_pd1: ltdc_b5_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+			};
+
+			ltdc_clk_pd3: ltdc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF11)>;
+			};
+
+			ltdc_de_pd6: ltdc_de_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF11)>;
+			};
+
+			ltdc_r3_pd8: ltdc_r3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+			};
+
+			ltdc_r4_pd9: ltdc_r4_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF11)>;
+			};
+
+			ltdc_r5_pd10: ltdc_r5_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF11)>;
+			};
+
+			ltdc_b2_pd14: ltdc_b2_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+			};
+
+			ltdc_b3_pd15: ltdc_b3_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF11)>;
+			};
+
+			ltdc_r0_pe2: ltdc_r0_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+			};
+
+			ltdc_r1_pe3: ltdc_r1_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF11)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF11)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+			};
+
+			ltdc_b6_pe7: ltdc_b6_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF11)>;
+			};
+
+			ltdc_b7_pe8: ltdc_b7_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF11)>;
+			};
+
+			ltdc_g2_pe9: ltdc_g2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF11)>;
+			};
+
+			ltdc_g3_pe10: ltdc_g3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF11)>;
+			};
+
+			ltdc_g4_pe11: ltdc_g4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+			};
+
+			ltdc_g5_pe12: ltdc_g5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF11)>;
+			};
+
+			ltdc_g6_pe13: ltdc_g6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF11)>;
+			};
+
+			ltdc_g7_pe14: ltdc_g7_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF11)>;
+			};
+
+			ltdc_r2_pe15: ltdc_r2_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4s9zijx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9zijx-pinctrl.dtsi
@@ -609,6 +609,160 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_b1_pb2: ltdc_b1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+			};
+
+			ltdc_b1_pb8: ltdc_b1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_r0_pc6: ltdc_r0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_r1_pc7: ltdc_r1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_b4_pd0: ltdc_b4_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+			};
+
+			ltdc_b5_pd1: ltdc_b5_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+			};
+
+			ltdc_clk_pd3: ltdc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF11)>;
+			};
+
+			ltdc_de_pd6: ltdc_de_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF11)>;
+			};
+
+			ltdc_r3_pd8: ltdc_r3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+			};
+
+			ltdc_r4_pd9: ltdc_r4_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF11)>;
+			};
+
+			ltdc_r5_pd10: ltdc_r5_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF11)>;
+			};
+
+			ltdc_r6_pd11: ltdc_r6_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF11)>;
+			};
+
+			ltdc_r7_pd12: ltdc_r7_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF11)>;
+			};
+
+			ltdc_b2_pd14: ltdc_b2_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+			};
+
+			ltdc_b3_pd15: ltdc_b3_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF11)>;
+			};
+
+			ltdc_hsync_pe0: ltdc_hsync_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF11)>;
+			};
+
+			ltdc_vsync_pe1: ltdc_vsync_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF11)>;
+			};
+
+			ltdc_r0_pe2: ltdc_r0_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+			};
+
+			ltdc_r1_pe3: ltdc_r1_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF11)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF11)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+			};
+
+			ltdc_b6_pe7: ltdc_b6_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF11)>;
+			};
+
+			ltdc_b7_pe8: ltdc_b7_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF11)>;
+			};
+
+			ltdc_g2_pe9: ltdc_g2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF11)>;
+			};
+
+			ltdc_g3_pe10: ltdc_g3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF11)>;
+			};
+
+			ltdc_g4_pe11: ltdc_g4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+			};
+
+			ltdc_g5_pe12: ltdc_g5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF11)>;
+			};
+
+			ltdc_g6_pe13: ltdc_g6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF11)>;
+			};
+
+			ltdc_g7_pe14: ltdc_g7_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF11)>;
+			};
+
+			ltdc_r2_pe15: ltdc_r2_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF11)>;
+			};
+
+			ltdc_de_pf11: ltdc_de_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+			};
+
+			ltdc_b0_pf12: ltdc_b0_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF11)>;
+			};
+
+			ltdc_b1_pf13: ltdc_b1_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF11)>;
+			};
+
+			ltdc_g0_pf14: ltdc_g0_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF11)>;
+			};
+
+			ltdc_g1_pf15: ltdc_g1_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF11)>;
+			};
+
+			ltdc_r1_pg6: ltdc_r1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4s9zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9zitx-pinctrl.dtsi
@@ -593,6 +593,156 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_b1_pb2: ltdc_b1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+			};
+
+			ltdc_b1_pb8: ltdc_b1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_r0_pc6: ltdc_r0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_r1_pc7: ltdc_r1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_b4_pd0: ltdc_b4_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+			};
+
+			ltdc_b5_pd1: ltdc_b5_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+			};
+
+			ltdc_clk_pd3: ltdc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF11)>;
+			};
+
+			ltdc_de_pd6: ltdc_de_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF11)>;
+			};
+
+			ltdc_r3_pd8: ltdc_r3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+			};
+
+			ltdc_r4_pd9: ltdc_r4_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF11)>;
+			};
+
+			ltdc_r5_pd10: ltdc_r5_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF11)>;
+			};
+
+			ltdc_r6_pd11: ltdc_r6_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF11)>;
+			};
+
+			ltdc_r7_pd12: ltdc_r7_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF11)>;
+			};
+
+			ltdc_b2_pd14: ltdc_b2_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+			};
+
+			ltdc_b3_pd15: ltdc_b3_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF11)>;
+			};
+
+			ltdc_hsync_pe0: ltdc_hsync_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF11)>;
+			};
+
+			ltdc_vsync_pe1: ltdc_vsync_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF11)>;
+			};
+
+			ltdc_r0_pe2: ltdc_r0_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+			};
+
+			ltdc_r1_pe3: ltdc_r1_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF11)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF11)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+			};
+
+			ltdc_b6_pe7: ltdc_b6_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF11)>;
+			};
+
+			ltdc_b7_pe8: ltdc_b7_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF11)>;
+			};
+
+			ltdc_g2_pe9: ltdc_g2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF11)>;
+			};
+
+			ltdc_g3_pe10: ltdc_g3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF11)>;
+			};
+
+			ltdc_g4_pe11: ltdc_g4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+			};
+
+			ltdc_g5_pe12: ltdc_g5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF11)>;
+			};
+
+			ltdc_g6_pe13: ltdc_g6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF11)>;
+			};
+
+			ltdc_g7_pe14: ltdc_g7_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF11)>;
+			};
+
+			ltdc_r2_pe15: ltdc_r2_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF11)>;
+			};
+
+			ltdc_de_pf11: ltdc_de_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+			};
+
+			ltdc_b0_pf12: ltdc_b0_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF11)>;
+			};
+
+			ltdc_b1_pf13: ltdc_b1_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF11)>;
+			};
+
+			ltdc_g0_pf14: ltdc_g0_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF11)>;
+			};
+
+			ltdc_g1_pf15: ltdc_g1_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF11)>;
+			};
+
+			ltdc_r1_pg6: ltdc_r1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF9)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l4s9ziyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9ziyx-pinctrl.dtsi
@@ -609,6 +609,160 @@
 				drive-open-drain;
 			};
 
+			/* LTDC */
+
+			ltdc_b1_pb2: ltdc_b1_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF11)>;
+			};
+
+			ltdc_b1_pb8: ltdc_b1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF11)>;
+			};
+
+			ltdc_r0_pc6: ltdc_r0_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF11)>;
+			};
+
+			ltdc_r1_pc7: ltdc_r1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF11)>;
+			};
+
+			ltdc_b4_pd0: ltdc_b4_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF11)>;
+			};
+
+			ltdc_b5_pd1: ltdc_b5_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF11)>;
+			};
+
+			ltdc_clk_pd3: ltdc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF11)>;
+			};
+
+			ltdc_de_pd6: ltdc_de_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF11)>;
+			};
+
+			ltdc_r3_pd8: ltdc_r3_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF11)>;
+			};
+
+			ltdc_r4_pd9: ltdc_r4_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF11)>;
+			};
+
+			ltdc_r5_pd10: ltdc_r5_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF11)>;
+			};
+
+			ltdc_r6_pd11: ltdc_r6_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF11)>;
+			};
+
+			ltdc_r7_pd12: ltdc_r7_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF11)>;
+			};
+
+			ltdc_b2_pd14: ltdc_b2_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF11)>;
+			};
+
+			ltdc_b3_pd15: ltdc_b3_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF11)>;
+			};
+
+			ltdc_hsync_pe0: ltdc_hsync_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF11)>;
+			};
+
+			ltdc_vsync_pe1: ltdc_vsync_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF11)>;
+			};
+
+			ltdc_r0_pe2: ltdc_r0_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+			};
+
+			ltdc_r1_pe3: ltdc_r1_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF11)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF11)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF11)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF11)>;
+			};
+
+			ltdc_b6_pe7: ltdc_b6_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF11)>;
+			};
+
+			ltdc_b7_pe8: ltdc_b7_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF11)>;
+			};
+
+			ltdc_g2_pe9: ltdc_g2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF11)>;
+			};
+
+			ltdc_g3_pe10: ltdc_g3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF11)>;
+			};
+
+			ltdc_g4_pe11: ltdc_g4_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF11)>;
+			};
+
+			ltdc_g5_pe12: ltdc_g5_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF11)>;
+			};
+
+			ltdc_g6_pe13: ltdc_g6_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF11)>;
+			};
+
+			ltdc_g7_pe14: ltdc_g7_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF11)>;
+			};
+
+			ltdc_r2_pe15: ltdc_r2_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF11)>;
+			};
+
+			ltdc_de_pf11: ltdc_de_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF9)>;
+			};
+
+			ltdc_b0_pf12: ltdc_b0_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF11)>;
+			};
+
+			ltdc_b1_pf13: ltdc_b1_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF11)>;
+			};
+
+			ltdc_g0_pf14: ltdc_g0_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF11)>;
+			};
+
+			ltdc_g1_pf15: ltdc_g1_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF11)>;
+			};
+
+			ltdc_r1_pg6: ltdc_r1_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF11)>;
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/mp1/stm32mp151aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aaax-pinctrl.dtsi
@@ -1025,6 +1025,444 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_g4_pj13: ltdc_g4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp151aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aabx-pinctrl.dtsi
@@ -663,6 +663,228 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp151aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aacx-pinctrl.dtsi
@@ -1025,6 +1025,316 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp151aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aadx-pinctrl.dtsi
@@ -663,6 +663,228 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp151caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151caax-pinctrl.dtsi
@@ -1025,6 +1025,444 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_g4_pj13: ltdc_g4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp151cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cabx-pinctrl.dtsi
@@ -663,6 +663,228 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp151cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cacx-pinctrl.dtsi
@@ -1025,6 +1025,316 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp151cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cadx-pinctrl.dtsi
@@ -663,6 +663,228 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp151daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151daax-pinctrl.dtsi
@@ -1025,6 +1025,444 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_g4_pj13: ltdc_g4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp151dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dabx-pinctrl.dtsi
@@ -663,6 +663,228 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp151dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dacx-pinctrl.dtsi
@@ -1025,6 +1025,316 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp151dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dadx-pinctrl.dtsi
@@ -663,6 +663,228 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp151faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151faax-pinctrl.dtsi
@@ -1025,6 +1025,444 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_g4_pj13: ltdc_g4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp151fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151fabx-pinctrl.dtsi
@@ -663,6 +663,228 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp151facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151facx-pinctrl.dtsi
@@ -1025,6 +1025,316 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp151fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151fadx-pinctrl.dtsi
@@ -663,6 +663,228 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp153aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aaax-pinctrl.dtsi
@@ -1081,6 +1081,444 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_g4_pj13: ltdc_g4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp153aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aabx-pinctrl.dtsi
@@ -707,6 +707,228 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp153aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aacx-pinctrl.dtsi
@@ -1081,6 +1081,316 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp153aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aadx-pinctrl.dtsi
@@ -707,6 +707,228 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp153caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153caax-pinctrl.dtsi
@@ -1081,6 +1081,444 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_g4_pj13: ltdc_g4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp153cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cabx-pinctrl.dtsi
@@ -707,6 +707,228 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp153cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cacx-pinctrl.dtsi
@@ -1081,6 +1081,316 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp153cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cadx-pinctrl.dtsi
@@ -707,6 +707,228 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp153daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153daax-pinctrl.dtsi
@@ -1081,6 +1081,444 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_g4_pj13: ltdc_g4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp153dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dabx-pinctrl.dtsi
@@ -707,6 +707,228 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp153dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dacx-pinctrl.dtsi
@@ -1081,6 +1081,316 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp153dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dadx-pinctrl.dtsi
@@ -707,6 +707,228 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp153faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153faax-pinctrl.dtsi
@@ -1081,6 +1081,444 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_g4_pj13: ltdc_g4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp153fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153fabx-pinctrl.dtsi
@@ -707,6 +707,228 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp153facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153facx-pinctrl.dtsi
@@ -1081,6 +1081,316 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp153fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153fadx-pinctrl.dtsi
@@ -707,6 +707,228 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp157aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aaax-pinctrl.dtsi
@@ -1081,6 +1081,444 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_g4_pj13: ltdc_g4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp157aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aabx-pinctrl.dtsi
@@ -707,6 +707,228 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp157aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aacx-pinctrl.dtsi
@@ -1081,6 +1081,316 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp157aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aadx-pinctrl.dtsi
@@ -707,6 +707,228 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp157caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157caax-pinctrl.dtsi
@@ -1081,6 +1081,444 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_g4_pj13: ltdc_g4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp157cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cabx-pinctrl.dtsi
@@ -707,6 +707,228 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp157cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cacx-pinctrl.dtsi
@@ -1081,6 +1081,316 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp157cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cadx-pinctrl.dtsi
@@ -707,6 +707,228 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp157daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157daax-pinctrl.dtsi
@@ -1081,6 +1081,444 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_g4_pj13: ltdc_g4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp157dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dabx-pinctrl.dtsi
@@ -707,6 +707,228 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp157dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dacx-pinctrl.dtsi
@@ -1081,6 +1081,316 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp157dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dadx-pinctrl.dtsi
@@ -707,6 +707,228 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp157faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157faax-pinctrl.dtsi
@@ -1081,6 +1081,444 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
+			ltdc_hsync_pi12: ltdc_hsync_pi12 {
+				pinmux = <STM32_PINMUX('I', 12, AF14)>;
+			};
+
+			ltdc_vsync_pi13: ltdc_vsync_pi13 {
+				pinmux = <STM32_PINMUX('I', 13, AF14)>;
+			};
+
+			ltdc_clk_pi14: ltdc_clk_pi14 {
+				pinmux = <STM32_PINMUX('I', 14, AF14)>;
+			};
+
+			ltdc_g2_pi15: ltdc_g2_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF9)>;
+			};
+
+			ltdc_r0_pi15: ltdc_r0_pi15 {
+				pinmux = <STM32_PINMUX('I', 15, AF14)>;
+			};
+
+			ltdc_r1_pj0: ltdc_r1_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF14)>;
+			};
+
+			ltdc_r7_pj0: ltdc_r7_pj0 {
+				pinmux = <STM32_PINMUX('J', 0, AF9)>;
+			};
+
+			ltdc_r2_pj1: ltdc_r2_pj1 {
+				pinmux = <STM32_PINMUX('J', 1, AF14)>;
+			};
+
+			ltdc_r3_pj2: ltdc_r3_pj2 {
+				pinmux = <STM32_PINMUX('J', 2, AF14)>;
+			};
+
+			ltdc_r4_pj3: ltdc_r4_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF14)>;
+			};
+
+			ltdc_r5_pj4: ltdc_r5_pj4 {
+				pinmux = <STM32_PINMUX('J', 4, AF14)>;
+			};
+
+			ltdc_r6_pj5: ltdc_r6_pj5 {
+				pinmux = <STM32_PINMUX('J', 5, AF14)>;
+			};
+
+			ltdc_r7_pj6: ltdc_r7_pj6 {
+				pinmux = <STM32_PINMUX('J', 6, AF14)>;
+			};
+
+			ltdc_g0_pj7: ltdc_g0_pj7 {
+				pinmux = <STM32_PINMUX('J', 7, AF14)>;
+			};
+
+			ltdc_g1_pj8: ltdc_g1_pj8 {
+				pinmux = <STM32_PINMUX('J', 8, AF14)>;
+			};
+
+			ltdc_g2_pj9: ltdc_g2_pj9 {
+				pinmux = <STM32_PINMUX('J', 9, AF14)>;
+			};
+
+			ltdc_g3_pj10: ltdc_g3_pj10 {
+				pinmux = <STM32_PINMUX('J', 10, AF14)>;
+			};
+
+			ltdc_g4_pj11: ltdc_g4_pj11 {
+				pinmux = <STM32_PINMUX('J', 11, AF14)>;
+			};
+
+			ltdc_b0_pj12: ltdc_b0_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF14)>;
+			};
+
+			ltdc_g3_pj12: ltdc_g3_pj12 {
+				pinmux = <STM32_PINMUX('J', 12, AF9)>;
+			};
+
+			ltdc_b1_pj13: ltdc_b1_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF14)>;
+			};
+
+			ltdc_g4_pj13: ltdc_g4_pj13 {
+				pinmux = <STM32_PINMUX('J', 13, AF9)>;
+			};
+
+			ltdc_b2_pj14: ltdc_b2_pj14 {
+				pinmux = <STM32_PINMUX('J', 14, AF14)>;
+			};
+
+			ltdc_b3_pj15: ltdc_b3_pj15 {
+				pinmux = <STM32_PINMUX('J', 15, AF14)>;
+			};
+
+			ltdc_g5_pk0: ltdc_g5_pk0 {
+				pinmux = <STM32_PINMUX('K', 0, AF14)>;
+			};
+
+			ltdc_g6_pk1: ltdc_g6_pk1 {
+				pinmux = <STM32_PINMUX('K', 1, AF14)>;
+			};
+
+			ltdc_g7_pk2: ltdc_g7_pk2 {
+				pinmux = <STM32_PINMUX('K', 2, AF14)>;
+			};
+
+			ltdc_b4_pk3: ltdc_b4_pk3 {
+				pinmux = <STM32_PINMUX('K', 3, AF14)>;
+			};
+
+			ltdc_b5_pk4: ltdc_b5_pk4 {
+				pinmux = <STM32_PINMUX('K', 4, AF14)>;
+			};
+
+			ltdc_b6_pk5: ltdc_b6_pk5 {
+				pinmux = <STM32_PINMUX('K', 5, AF14)>;
+			};
+
+			ltdc_b7_pk6: ltdc_b7_pk6 {
+				pinmux = <STM32_PINMUX('K', 6, AF14)>;
+			};
+
+			ltdc_de_pk7: ltdc_de_pk7 {
+				pinmux = <STM32_PINMUX('K', 7, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp157fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157fabx-pinctrl.dtsi
@@ -707,6 +707,228 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp157facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157facx-pinctrl.dtsi
@@ -1081,6 +1081,316 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
+			ltdc_r0_ph2: ltdc_r0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF14)>;
+			};
+
+			ltdc_r1_ph3: ltdc_r1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF14)>;
+			};
+
+			ltdc_g4_ph4: ltdc_g4_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF14)>;
+			};
+
+			ltdc_g5_ph4: ltdc_g5_ph4 {
+				pinmux = <STM32_PINMUX('H', 4, AF9)>;
+			};
+
+			ltdc_r2_ph8: ltdc_r2_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF14)>;
+			};
+
+			ltdc_r3_ph9: ltdc_r3_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF14)>;
+			};
+
+			ltdc_r4_ph10: ltdc_r4_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF14)>;
+			};
+
+			ltdc_r5_ph11: ltdc_r5_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF14)>;
+			};
+
+			ltdc_r6_ph12: ltdc_r6_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF14)>;
+			};
+
+			ltdc_g2_ph13: ltdc_g2_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF14)>;
+			};
+
+			ltdc_g3_ph14: ltdc_g3_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF14)>;
+			};
+
+			ltdc_g4_ph15: ltdc_g4_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF14)>;
+			};
+
+			ltdc_g5_pi0: ltdc_g5_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF14)>;
+			};
+
+			ltdc_g6_pi1: ltdc_g6_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF14)>;
+			};
+
+			ltdc_g7_pi2: ltdc_g7_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF14)>;
+			};
+
+			ltdc_b4_pi4: ltdc_b4_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF14)>;
+			};
+
+			ltdc_b5_pi5: ltdc_b5_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF14)>;
+			};
+
+			ltdc_b6_pi6: ltdc_b6_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF14)>;
+			};
+
+			ltdc_b7_pi7: ltdc_b7_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF14)>;
+			};
+
+			ltdc_vsync_pi9: ltdc_vsync_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF14)>;
+			};
+
+			ltdc_hsync_pi10: ltdc_hsync_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF14)>;
+			};
+
+			ltdc_g6_pi11: ltdc_g6_pi11 {
+				pinmux = <STM32_PINMUX('I', 11, AF9)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/dts/st/mp1/stm32mp157fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157fadx-pinctrl.dtsi
@@ -707,6 +707,228 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			ltdc_r1_pa2: ltdc_r1_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF14)>;
+			};
+
+			ltdc_b2_pa3: ltdc_b2_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF9)>;
+			};
+
+			ltdc_b5_pa3: ltdc_b5_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF14)>;
+			};
+
+			ltdc_vsync_pa4: ltdc_vsync_pa4 {
+				pinmux = <STM32_PINMUX('A', 4, AF14)>;
+			};
+
+			ltdc_r4_pa5: ltdc_r4_pa5 {
+				pinmux = <STM32_PINMUX('A', 5, AF14)>;
+			};
+
+			ltdc_g2_pa6: ltdc_g2_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF14)>;
+			};
+
+			ltdc_r6_pa8: ltdc_r6_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF14)>;
+			};
+
+			ltdc_r5_pa9: ltdc_r5_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF14)>;
+			};
+
+			ltdc_b1_pa10: ltdc_b1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF14)>;
+			};
+
+			ltdc_r4_pa11: ltdc_r4_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF14)>;
+			};
+
+			ltdc_r5_pa12: ltdc_r5_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF14)>;
+			};
+
+			ltdc_r1_pa15: ltdc_r1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF14)>;
+			};
+
+			ltdc_g1_pb0: ltdc_g1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF14)>;
+			};
+
+			ltdc_r3_pb0: ltdc_r3_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF9)>;
+			};
+
+			ltdc_g0_pb1: ltdc_g0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF14)>;
+			};
+
+			ltdc_r6_pb1: ltdc_r6_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+			};
+
+			ltdc_g7_pb5: ltdc_g7_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF14)>;
+			};
+
+			ltdc_b6_pb8: ltdc_b6_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF14)>;
+			};
+
+			ltdc_b7_pb9: ltdc_b7_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF14)>;
+			};
+
+			ltdc_g4_pb10: ltdc_g4_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF14)>;
+			};
+
+			ltdc_g5_pb11: ltdc_g5_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF14)>;
+			};
+
+			ltdc_r5_pc0: ltdc_r5_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF14)>;
+			};
+
+			ltdc_hsync_pc6: ltdc_hsync_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF14)>;
+			};
+
+			ltdc_g6_pc7: ltdc_g6_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF14)>;
+			};
+
+			ltdc_b2_pc9: ltdc_b2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF14)>;
+			};
+
+			ltdc_r2_pc10: ltdc_r2_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF14)>;
+			};
+
+			ltdc_g7_pd3: ltdc_g7_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF14)>;
+			};
+
+			ltdc_b2_pd6: ltdc_b2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF14)>;
+			};
+
+			ltdc_b7_pd8: ltdc_b7_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF14)>;
+			};
+
+			ltdc_b0_pd9: ltdc_b0_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF14)>;
+			};
+
+			ltdc_b3_pd10: ltdc_b3_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF14)>;
+			};
+
+			ltdc_r1_pd15: ltdc_r1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF14)>;
+			};
+
+			ltdc_b0_pe4: ltdc_b0_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF14)>;
+			};
+
+			ltdc_g0_pe5: ltdc_g0_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF14)>;
+			};
+
+			ltdc_g1_pe6: ltdc_g1_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF14)>;
+			};
+
+			ltdc_g3_pe11: ltdc_g3_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF14)>;
+			};
+
+			ltdc_b4_pe12: ltdc_b4_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF14)>;
+			};
+
+			ltdc_de_pe13: ltdc_de_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF14)>;
+			};
+
+			ltdc_clk_pe14: ltdc_clk_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF14)>;
+			};
+
+			ltdc_g0_pe14: ltdc_g0_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF13)>;
+			};
+
+			ltdc_r7_pe15: ltdc_r7_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF14)>;
+			};
+
+			ltdc_de_pf10: ltdc_de_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF14)>;
+			};
+
+			ltdc_g5_pf11: ltdc_g5_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF14)>;
+			};
+
+			ltdc_r7_pg6: ltdc_r7_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF14)>;
+			};
+
+			ltdc_clk_pg7: ltdc_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF14)>;
+			};
+
+			ltdc_g7_pg8: ltdc_g7_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF14)>;
+			};
+
+			ltdc_r1_pg9: ltdc_r1_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF14)>;
+			};
+
+			ltdc_b2_pg10: ltdc_b2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF14)>;
+			};
+
+			ltdc_g3_pg10: ltdc_g3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF9)>;
+			};
+
+			ltdc_b3_pg11: ltdc_b3_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF14)>;
+			};
+
+			ltdc_b1_pg12: ltdc_b1_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF14)>;
+			};
+
+			ltdc_b4_pg12: ltdc_b4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF9)>;
+			};
+
+			ltdc_r0_pg13: ltdc_r0_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF14)>;
+			};
+
+			ltdc_b0_pg14: ltdc_b0_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {

--- a/scripts/genpinctrl/stm32-pinctrl-config.yaml
+++ b/scripts/genpinctrl/stm32-pinctrl-config.yaml
@@ -169,6 +169,9 @@
 - name: I2S_SD
   match: "^I2S\\d+_SD$"
 
+- name: LTDC
+  match: "^LTDC_(?:DE|CLK|HSYNC|VSYNC|R[0-7]|G[0-7]|B[0-7])$"
+
 - name: QUADSPI
   match: "^QUADSPI(\\d+)?_(?:CLK|NCS|BK1_NCS|BK1_IO[0-3]|BK2_NCS|BK2_IO[0-3])$"
   slew-rate: very-high-speed


### PR DESCRIPTION
Some MCUs from F4, L4, F7, H7 and MP1 series contain an LTDC peripheral, but pinctrl nodes for that peripheral weren't defined. 
These nodes will come in handy for creating device tree bindings for STM32 LTDC display driver. I'll try to tackle it in the next few months and contribute it if it's any good. My initial idea was to define all necessary parameters in LTDC device tree node (including pinctrl) and then make a Zephyr display driver which wraps the LTDC driver from ST's HAL library.