### PR TITLE
stm32H7 spi LL driver read address of the Tx/Rx reg. for DMA

### DIFF
--- a/stm32cube/stm32h7xx/drivers/include/stm32h7xx_ll_spi.h
+++ b/stm32cube/stm32h7xx/drivers/include/stm32h7xx_ll_spi.h
@@ -2376,6 +2376,21 @@ __STATIC_INLINE uint32_t LL_SPI_IsEnabledDMAReq_TX(SPI_TypeDef *SPIx)
 }
 
 /**
+  * @brief  Get the data register address used for DMA transfer
+  * @rmtoll TXDR           TXDR            LL_SPI_DMA_GetRegAddr
+  * @param  SPIx SPI Instance
+  * @retval Address of data register
+  */
+__STATIC_INLINE uint32_t LL_SPI_DMA_GetTxRegAddr(SPI_TypeDef *SPIx)
+{
+  return (uint32_t) &(SPIx->TXDR);
+}
+__STATIC_INLINE uint32_t LL_SPI_DMA_GetRxRegAddr(SPI_TypeDef *SPIx)
+{
+  return (uint32_t) &(SPIx->RXDR);
+}
+
+/**
   * @}
   */
 


### PR DESCRIPTION
This patch adds the LL functions to get the address of SPI Tx/Rx reg.
Unlike other series, the stm32H7 has two registers for Tx and Rx
but no LL function is available to get their location when DMA requires
it for its peripheral address reg.

Signed-off-by: Francois Ramu <francois.ramu@st.com>