### PR TITLE
stm32cube/stm32u5: ll_utils.c: Fix UTILS_SCALE_... definitions

### DIFF
--- a/stm32cube/stm32u5xx/README
+++ b/stm32cube/stm32u5xx/README
@@ -44,4 +44,8 @@ Patch List:
     -Added stm32cube/stm32u5xx/drivers/include/stm32_assert.h
     -Removed unused stm32cube/stm32u5xx/drivers/include/stm32_assert_template.h
 
+   *Fix utils_ll.c definitions
+    -Added stm32cube/stm32u5xx/drivers/include/stm32_assert.h
+    Internal reference: 116963
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32u5xx/drivers/src/stm32u5xx_ll_utils.c
+++ b/stm32cube/stm32u5xx/drivers/src/stm32u5xx_ll_utils.c
@@ -66,9 +66,9 @@
 #define UTILS_SCALE2_LATENCY1_FREQ    (50000000U)      /*!< HCLK frequency to set FLASH latency 1 in power scale 2 */
 #define UTILS_SCALE2_LATENCY2_FREQ    (75000000U)      /*!< HCLK frequency to set FLASH latency 2 in power scale 2 */
 #define UTILS_SCALE2_LATENCY3_FREQ    (100000000U)     /*!< HCLK frequency to set FLASH latency 3 in power scale 2 */
-#define UTILS_SCALE3_LATENCY0_FREQ    (12.5000000)    /*!< HCLK frequency to set FLASH latency 0 in power scale 3 */
+#define UTILS_SCALE3_LATENCY0_FREQ    (12500000U)      /*!< HCLK frequency to set FLASH latency 0 in power scale 3 */
 #define UTILS_SCALE3_LATENCY1_FREQ    (25000000U)      /*!< HCLK frequency to set FLASH latency 1 in power scale 3 */
-#define UTILS_SCALE3_LATENCY2_FREQ    (37.5000000)    /*!< HCLK frequency to set FLASH latency 2 in power scale 3 */
+#define UTILS_SCALE3_LATENCY2_FREQ    (37500000U)      /*!< HCLK frequency to set FLASH latency 2 in power scale 3 */
 #define UTILS_SCALE3_LATENCY3_FREQ    (50000000U)      /*!< HCLK frequency to set FLASH latency 3 in power scale 3 */
 #define UTILS_SCALE4_LATENCY0_FREQ    (8000000U)       /*!< HCLK frequency to set FLASH latency 0 in power scale 4 */
 #define UTILS_SCALE4_LATENCY1_FREQ    (16000000U)      /*!< HCLK frequency to set FLASH latency 1 in power scale 4 */


### PR DESCRIPTION
These definitions were suspicious
Fix them.
Internal issue: 116963

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/42228

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>