### PR TITLE
dts: provide uart/usart/lpuart de pins

### DIFF
--- a/dts/st/f0/stm32f030c6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030c6tx-pinctrl.dtsi
@@ -303,6 +303,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa1: usart1_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa1: usart1_rts_pa1 {

--- a/dts/st/f0/stm32f030c8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030c8tx-pinctrl.dtsi
@@ -311,6 +311,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f030cctx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030cctx-pinctrl.dtsi
@@ -380,6 +380,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f030f4px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030f4px-pinctrl.dtsi
@@ -151,6 +151,13 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa1: usart1_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa1: usart1_rts_pa1 {

--- a/dts/st/f0/stm32f030k6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030k6tx-pinctrl.dtsi
@@ -226,6 +226,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa1: usart1_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa1: usart1_rts_pa1 {

--- a/dts/st/f0/stm32f030r8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030r8tx-pinctrl.dtsi
@@ -351,6 +351,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f030rctx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f030rctx-pinctrl.dtsi
@@ -430,6 +430,43 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF1)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f031c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f031c(4-6)tx-pinctrl.dtsi
@@ -371,6 +371,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa1: usart1_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa1: usart1_rts_pa1 {

--- a/dts/st/f0/stm32f031e6yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f031e6yx-pinctrl.dtsi
@@ -239,6 +239,13 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa1: usart1_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa1: usart1_rts_pa1 {

--- a/dts/st/f0/stm32f031f(4-6)px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f031f(4-6)px-pinctrl.dtsi
@@ -190,6 +190,13 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa1: usart1_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa1: usart1_rts_pa1 {

--- a/dts/st/f0/stm32f031g(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f031g(4-6)ux-pinctrl.dtsi
@@ -276,6 +276,13 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa1: usart1_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa1: usart1_rts_pa1 {

--- a/dts/st/f0/stm32f031k(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f031k(4-6)ux-pinctrl.dtsi
@@ -296,6 +296,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa1: usart1_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa1: usart1_rts_pa1 {

--- a/dts/st/f0/stm32f031k6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f031k6tx-pinctrl.dtsi
@@ -286,6 +286,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa1: usart1_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa1: usart1_rts_pa1 {

--- a/dts/st/f0/stm32f038c6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f038c6tx-pinctrl.dtsi
@@ -371,6 +371,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa1: usart1_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa1: usart1_rts_pa1 {

--- a/dts/st/f0/stm32f038e6yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f038e6yx-pinctrl.dtsi
@@ -239,6 +239,13 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa1: usart1_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa1: usart1_rts_pa1 {

--- a/dts/st/f0/stm32f038f6px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f038f6px-pinctrl.dtsi
@@ -174,6 +174,13 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa1: usart1_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa1: usart1_rts_pa1 {

--- a/dts/st/f0/stm32f038g6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f038g6ux-pinctrl.dtsi
@@ -260,6 +260,13 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa1: usart1_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa1: usart1_rts_pa1 {

--- a/dts/st/f0/stm32f038k6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f038k6ux-pinctrl.dtsi
@@ -296,6 +296,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa1: usart1_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa1: usart1_rts_pa1 {

--- a/dts/st/f0/stm32f042c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042c(4-6)tx-pinctrl.dtsi
@@ -428,6 +428,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f042c(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042c(4-6)ux-pinctrl.dtsi
@@ -428,6 +428,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f042f4px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042f4px-pinctrl.dtsi
@@ -240,6 +240,13 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart2_rts_pa1: usart2_rts_pa1 {

--- a/dts/st/f0/stm32f042f6px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042f6px-pinctrl.dtsi
@@ -240,6 +240,13 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart2_rts_pa1: usart2_rts_pa1 {

--- a/dts/st/f0/stm32f042g(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042g(4-6)ux-pinctrl.dtsi
@@ -328,6 +328,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f042k(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042k(4-6)tx-pinctrl.dtsi
@@ -338,6 +338,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f042k(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042k(4-6)ux-pinctrl.dtsi
@@ -338,6 +338,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f042t6yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042t6yx-pinctrl.dtsi
@@ -338,6 +338,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f048c6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f048c6ux-pinctrl.dtsi
@@ -406,6 +406,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f048g6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f048g6ux-pinctrl.dtsi
@@ -294,6 +294,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f048t6yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f048t6yx-pinctrl.dtsi
@@ -320,6 +320,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f051c4tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051c4tx-pinctrl.dtsi
@@ -334,6 +334,13 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f051c4ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051c4ux-pinctrl.dtsi
@@ -334,6 +334,13 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f051c6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051c6tx-pinctrl.dtsi
@@ -340,6 +340,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f051c6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051c6ux-pinctrl.dtsi
@@ -340,6 +340,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f051c8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051c8tx-pinctrl.dtsi
@@ -385,6 +385,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f051c8ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051c8ux-pinctrl.dtsi
@@ -385,6 +385,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f051k4tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051k4tx-pinctrl.dtsi
@@ -282,6 +282,13 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f051k4ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051k4ux-pinctrl.dtsi
@@ -292,6 +292,13 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f051k6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051k6tx-pinctrl.dtsi
@@ -288,6 +288,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f051k6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051k6ux-pinctrl.dtsi
@@ -298,6 +298,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f051k8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051k8tx-pinctrl.dtsi
@@ -288,6 +288,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f051k8ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051k8ux-pinctrl.dtsi
@@ -298,6 +298,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f051r4tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051r4tx-pinctrl.dtsi
@@ -395,6 +395,13 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f051r6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051r6tx-pinctrl.dtsi
@@ -401,6 +401,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f051r8hx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051r8hx-pinctrl.dtsi
@@ -425,6 +425,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f051r8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051r8tx-pinctrl.dtsi
@@ -425,6 +425,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f051t8yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051t8yx-pinctrl.dtsi
@@ -288,6 +288,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f058c8ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f058c8ux-pinctrl.dtsi
@@ -385,6 +385,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f058r8hx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f058r8hx-pinctrl.dtsi
@@ -425,6 +425,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f058r8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f058r8tx-pinctrl.dtsi
@@ -425,6 +425,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f058t8yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f058t8yx-pinctrl.dtsi
@@ -288,6 +288,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f070c6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f070c6tx-pinctrl.dtsi
@@ -270,6 +270,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f070cbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f070cbtx-pinctrl.dtsi
@@ -344,6 +344,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f070f6px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f070f6px-pinctrl.dtsi
@@ -179,6 +179,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f070rbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f070rbtx-pinctrl.dtsi
@@ -394,6 +394,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF1)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f071c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f071c(8-b)tx-pinctrl.dtsi
@@ -444,6 +444,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f071c(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f071c(8-b)ux-pinctrl.dtsi
@@ -444,6 +444,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f071cbyx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f071cbyx-pinctrl.dtsi
@@ -444,6 +444,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f071rbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f071rbtx-pinctrl.dtsi
@@ -498,6 +498,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF1)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f071v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f071v(8-b)hx-pinctrl.dtsi
@@ -638,6 +638,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f071v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f071v(8-b)tx-pinctrl.dtsi
@@ -638,6 +638,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f072c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072c(8-b)tx-pinctrl.dtsi
@@ -466,6 +466,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f072c(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072c(8-b)ux-pinctrl.dtsi
@@ -466,6 +466,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f072cbyx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072cbyx-pinctrl.dtsi
@@ -466,6 +466,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f072r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072r(8-b)tx-pinctrl.dtsi
@@ -520,6 +520,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF1)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f072rbhx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072rbhx-pinctrl.dtsi
@@ -520,6 +520,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF1)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f072rbix-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072rbix-pinctrl.dtsi
@@ -520,6 +520,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF1)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f072v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072v(8-b)hx-pinctrl.dtsi
@@ -669,6 +669,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f072v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072v(8-b)tx-pinctrl.dtsi
@@ -669,6 +669,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f078cbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078cbtx-pinctrl.dtsi
@@ -444,6 +444,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f078cbux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078cbux-pinctrl.dtsi
@@ -444,6 +444,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f078cbyx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078cbyx-pinctrl.dtsi
@@ -444,6 +444,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f078rbhx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078rbhx-pinctrl.dtsi
@@ -498,6 +498,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF1)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f078rbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078rbtx-pinctrl.dtsi
@@ -498,6 +498,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF1)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f078vbhx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078vbhx-pinctrl.dtsi
@@ -638,6 +638,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f078vbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078vbtx-pinctrl.dtsi
@@ -638,6 +638,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f091c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091c(b-c)tx-pinctrl.dtsi
@@ -502,6 +502,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f091c(b-c)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091c(b-c)ux-pinctrl.dtsi
@@ -502,6 +502,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f091r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091r(b-c)tx-pinctrl.dtsi
@@ -556,6 +556,43 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF1)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f091rchx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091rchx-pinctrl.dtsi
@@ -556,6 +556,43 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF1)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f091rcyx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091rcyx-pinctrl.dtsi
@@ -556,6 +556,43 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF1)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f091v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091v(b-c)tx-pinctrl.dtsi
@@ -705,6 +705,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pe7: usart5_de_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF1)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pf3: usart6_de_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+				drive-push-pull;
+			};
+
+			usart7_de_pd15: usart7_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+				drive-push-pull;
+			};
+
+			usart7_de_pf2: usart7_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+				drive-push-pull;
+			};
+
+			usart8_de_pd12: usart8_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f091vchx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091vchx-pinctrl.dtsi
@@ -705,6 +705,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pe7: usart5_de_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF1)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pf3: usart6_de_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+				drive-push-pull;
+			};
+
+			usart7_de_pd15: usart7_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+				drive-push-pull;
+			};
+
+			usart7_de_pf2: usart7_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+				drive-push-pull;
+			};
+
+			usart8_de_pd12: usart8_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f098cctx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098cctx-pinctrl.dtsi
@@ -502,6 +502,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f098ccux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098ccux-pinctrl.dtsi
@@ -502,6 +502,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f098rchx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098rchx-pinctrl.dtsi
@@ -556,6 +556,43 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF1)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f098rctx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098rctx-pinctrl.dtsi
@@ -556,6 +556,43 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF1)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f098rcyx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098rcyx-pinctrl.dtsi
@@ -556,6 +556,43 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF1)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f098vchx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098vchx-pinctrl.dtsi
@@ -705,6 +705,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pe7: usart5_de_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF1)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pf3: usart6_de_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+				drive-push-pull;
+			};
+
+			usart7_de_pd15: usart7_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+				drive-push-pull;
+			};
+
+			usart7_de_pf2: usart7_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+				drive-push-pull;
+			};
+
+			usart8_de_pd12: usart8_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f0/stm32f098vctx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098vctx-pinctrl.dtsi
@@ -705,6 +705,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pe7: usart5_de_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF1)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pf3: usart6_de_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
+				drive-push-pull;
+			};
+
+			usart7_de_pd15: usart7_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, ANALOG)>;
+				drive-push-pull;
+			};
+
+			usart7_de_pf2: usart7_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, ANALOG)>;
+				drive-push-pull;
+			};
+
+			usart8_de_pd12: usart8_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, ANALOG)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f301c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f301c(6-8)tx-pinctrl.dtsi
@@ -455,6 +455,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f301c8yx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f301c8yx-pinctrl.dtsi
@@ -455,6 +455,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f301k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f301k(6-8)tx-pinctrl.dtsi
@@ -345,6 +345,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f301k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/f3/stm32f301k(6-8)ux-pinctrl.dtsi
@@ -337,6 +337,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f301r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f301r(6-8)tx-pinctrl.dtsi
@@ -518,6 +518,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f302c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302c(6-8)tx-pinctrl.dtsi
@@ -477,6 +477,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f302c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302c(b-c)tx-pinctrl.dtsi
@@ -525,6 +525,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f302c8yx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302c8yx-pinctrl.dtsi
@@ -477,6 +477,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f302k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302k(6-8)ux-pinctrl.dtsi
@@ -350,6 +350,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f302r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302r(6-8)tx-pinctrl.dtsi
@@ -540,6 +540,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f302r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302r(b-c)tx-pinctrl.dtsi
@@ -610,6 +610,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f302r(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302r(d-e)tx-pinctrl.dtsi
@@ -682,6 +682,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f302v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302v(b-c)tx-pinctrl.dtsi
@@ -758,6 +758,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pf6: usart3_de_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f302v(d-e)hx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302v(d-e)hx-pinctrl.dtsi
@@ -1077,6 +1077,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pf6: usart3_de_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f302v(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302v(d-e)tx-pinctrl.dtsi
@@ -1077,6 +1077,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pf6: usart3_de_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f302vcyx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302vcyx-pinctrl.dtsi
@@ -734,6 +734,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pf6: usart3_de_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f302z(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302z(d-e)tx-pinctrl.dtsi
@@ -1201,6 +1201,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pf6: usart3_de_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f303c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303c(6-8)tx-pinctrl.dtsi
@@ -422,6 +422,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f303c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303c(b-c)tx-pinctrl.dtsi
@@ -597,6 +597,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f303c8yx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303c8yx-pinctrl.dtsi
@@ -442,6 +442,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f303k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303k(6-8)tx-pinctrl.dtsi
@@ -325,6 +325,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f303k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303k(6-8)ux-pinctrl.dtsi
@@ -313,6 +313,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f303r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303r(6-8)tx-pinctrl.dtsi
@@ -494,6 +494,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f303r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303r(b-c)tx-pinctrl.dtsi
@@ -710,6 +710,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f303r(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303r(d-e)tx-pinctrl.dtsi
@@ -782,6 +782,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f303v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303v(b-c)tx-pinctrl.dtsi
@@ -950,6 +950,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pf6: usart3_de_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f303v(d-e)hx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303v(d-e)hx-pinctrl.dtsi
@@ -1297,6 +1297,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pf6: usart3_de_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f303v(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303v(d-e)tx-pinctrl.dtsi
@@ -1297,6 +1297,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pf6: usart3_de_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f303vcyx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303vcyx-pinctrl.dtsi
@@ -902,6 +902,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pf6: usart3_de_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f303veyx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303veyx-pinctrl.dtsi
@@ -1043,6 +1043,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pf6: usart3_de_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f303z(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303z(d-e)tx-pinctrl.dtsi
@@ -1469,6 +1469,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pf6: usart3_de_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f318c8tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f318c8tx-pinctrl.dtsi
@@ -455,6 +455,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f318c8yx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f318c8yx-pinctrl.dtsi
@@ -455,6 +455,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f318k8ux-pinctrl.dtsi
+++ b/dts/st/f3/stm32f318k8ux-pinctrl.dtsi
@@ -327,6 +327,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f328c8tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f328c8tx-pinctrl.dtsi
@@ -418,6 +418,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f334c(4-6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f334c(4-6-8)tx-pinctrl.dtsi
@@ -504,6 +504,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f334c8yx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f334c8yx-pinctrl.dtsi
@@ -524,6 +524,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f334k(4-6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f334k(4-6-8)tx-pinctrl.dtsi
@@ -379,6 +379,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f334k(4-6-8)ux-pinctrl.dtsi
+++ b/dts/st/f3/stm32f334k(4-6-8)ux-pinctrl.dtsi
@@ -363,6 +363,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f334r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f334r(6-8)tx-pinctrl.dtsi
@@ -596,6 +596,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f358cctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f358cctx-pinctrl.dtsi
@@ -593,6 +593,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f358rctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f358rctx-pinctrl.dtsi
@@ -706,6 +706,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f358vctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f358vctx-pinctrl.dtsi
@@ -946,6 +946,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pf6: usart3_de_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f373c(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f373c(8-b-c)tx-pinctrl.dtsi
@@ -729,6 +729,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pf6: usart3_de_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f373r(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f373r(8-b-c)tx-pinctrl.dtsi
@@ -899,6 +899,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pf6: usart3_de_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f373v(8-b-c)hx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f373v(8-b-c)hx-pinctrl.dtsi
@@ -987,6 +987,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pf6: usart3_de_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f373v(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f373v(8-b-c)tx-pinctrl.dtsi
@@ -987,6 +987,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pf6: usart3_de_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f378cctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378cctx-pinctrl.dtsi
@@ -729,6 +729,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pf6: usart3_de_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f378rctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378rctx-pinctrl.dtsi
@@ -899,6 +899,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pf6: usart3_de_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f378rcyx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378rcyx-pinctrl.dtsi
@@ -899,6 +899,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pf6: usart3_de_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f378vchx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378vchx-pinctrl.dtsi
@@ -987,6 +987,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pf6: usart3_de_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f378vctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378vctx-pinctrl.dtsi
@@ -987,6 +987,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pf6: usart3_de_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f3/stm32f398vetx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f398vetx-pinctrl.dtsi
@@ -1293,6 +1293,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pf6: usart3_de_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f722i(c-e)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722i(c-e)kx-pinctrl.dtsi
@@ -1957,6 +1957,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f722i(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722i(c-e)tx-pinctrl.dtsi
@@ -1957,6 +1957,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f722r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722r(c-e)tx-pinctrl.dtsi
@@ -852,6 +852,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f722v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722v(c-e)tx-pinctrl.dtsi
@@ -1349,6 +1349,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f722z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722z(c-e)tx-pinctrl.dtsi
@@ -1669,6 +1669,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f723i(c-e)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723i(c-e)kx-pinctrl.dtsi
@@ -1901,6 +1901,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f723i(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723i(c-e)tx-pinctrl.dtsi
@@ -1901,6 +1901,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f723v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723v(c-e)tx-pinctrl.dtsi
@@ -1233,6 +1233,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f723v(c-e)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723v(c-e)yx-pinctrl.dtsi
@@ -1233,6 +1233,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f723z(c-e)ix-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723z(c-e)ix-pinctrl.dtsi
@@ -1613,6 +1613,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f723z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723z(c-e)tx-pinctrl.dtsi
@@ -1613,6 +1613,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f730i8kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730i8kx-pinctrl.dtsi
@@ -1901,6 +1901,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f730r8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730r8tx-pinctrl.dtsi
@@ -852,6 +852,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f730v8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730v8tx-pinctrl.dtsi
@@ -1349,6 +1349,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f730z8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730z8tx-pinctrl.dtsi
@@ -1613,6 +1613,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f732iekx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732iekx-pinctrl.dtsi
@@ -1957,6 +1957,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f732ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732ietx-pinctrl.dtsi
@@ -1957,6 +1957,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f732retx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732retx-pinctrl.dtsi
@@ -852,6 +852,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f732vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732vetx-pinctrl.dtsi
@@ -1349,6 +1349,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f732zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732zetx-pinctrl.dtsi
@@ -1669,6 +1669,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f733iekx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733iekx-pinctrl.dtsi
@@ -1901,6 +1901,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f733ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733ietx-pinctrl.dtsi
@@ -1901,6 +1901,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f733vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733vetx-pinctrl.dtsi
@@ -1233,6 +1233,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f733veyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733veyx-pinctrl.dtsi
@@ -1233,6 +1233,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f733zeix-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733zeix-pinctrl.dtsi
@@ -1613,6 +1613,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f733zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733zetx-pinctrl.dtsi
@@ -1613,6 +1613,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f745i(e-g)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745i(e-g)kx-pinctrl.dtsi
@@ -2127,6 +2127,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f745i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745i(e-g)tx-pinctrl.dtsi
@@ -2127,6 +2127,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f745v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745v(e-g)hx-pinctrl.dtsi
@@ -1464,6 +1464,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f745v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745v(e-g)tx-pinctrl.dtsi
@@ -1464,6 +1464,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f745z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745z(e-g)tx-pinctrl.dtsi
@@ -1807,6 +1807,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f746b(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746b(e-g)tx-pinctrl.dtsi
@@ -2477,6 +2477,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f746i(e-g)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746i(e-g)kx-pinctrl.dtsi
@@ -2365,6 +2365,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f746ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746ietx-pinctrl.dtsi
@@ -2365,6 +2365,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f746igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746igtx-pinctrl.dtsi
@@ -2365,6 +2365,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f746nehx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746nehx-pinctrl.dtsi
@@ -2477,6 +2477,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f746nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746nghx-pinctrl.dtsi
@@ -2477,6 +2477,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f746v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746v(e-g)hx-pinctrl.dtsi
@@ -1586,6 +1586,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f746vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746vetx-pinctrl.dtsi
@@ -1586,6 +1586,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f746vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746vgtx-pinctrl.dtsi
@@ -1586,6 +1586,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f746z(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746z(e-g)yx-pinctrl.dtsi
@@ -1969,6 +1969,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f746zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746zetx-pinctrl.dtsi
@@ -1969,6 +1969,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f746zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746zgtx-pinctrl.dtsi
@@ -1969,6 +1969,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f750n8hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750n8hx-pinctrl.dtsi
@@ -2477,6 +2477,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f750v8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750v8tx-pinctrl.dtsi
@@ -1586,6 +1586,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f750z8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750z8tx-pinctrl.dtsi
@@ -1969,6 +1969,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f756bgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756bgtx-pinctrl.dtsi
@@ -2477,6 +2477,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f756igkx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756igkx-pinctrl.dtsi
@@ -2365,6 +2365,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f756igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756igtx-pinctrl.dtsi
@@ -2365,6 +2365,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f756nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756nghx-pinctrl.dtsi
@@ -2477,6 +2477,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f756vghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756vghx-pinctrl.dtsi
@@ -1586,6 +1586,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f756vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756vgtx-pinctrl.dtsi
@@ -1586,6 +1586,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f756zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756zgtx-pinctrl.dtsi
@@ -1969,6 +1969,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f756zgyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756zgyx-pinctrl.dtsi
@@ -1969,6 +1969,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f765b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765b(g-i)tx-pinctrl.dtsi
@@ -2400,6 +2400,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f765i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765i(g-i)kx-pinctrl.dtsi
@@ -2400,6 +2400,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f765i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765i(g-i)tx-pinctrl.dtsi
@@ -2400,6 +2400,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f765n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765n(g-i)hx-pinctrl.dtsi
@@ -2400,6 +2400,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f765v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765v(g-i)hx-pinctrl.dtsi
@@ -1672,6 +1672,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f765v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765v(g-i)tx-pinctrl.dtsi
@@ -1672,6 +1672,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f765z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765z(g-i)tx-pinctrl.dtsi
@@ -2075,6 +2075,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f767b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767b(g-i)tx-pinctrl.dtsi
@@ -2822,6 +2822,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f767i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767i(g-i)kx-pinctrl.dtsi
@@ -2694,6 +2694,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f767i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767i(g-i)tx-pinctrl.dtsi
@@ -2694,6 +2694,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f767n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767n(g-i)hx-pinctrl.dtsi
@@ -2822,6 +2822,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f767vghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vghx-pinctrl.dtsi
@@ -1834,6 +1834,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f767vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vgtx-pinctrl.dtsi
@@ -1834,6 +1834,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f767vihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vihx-pinctrl.dtsi
@@ -1834,6 +1834,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f767vitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vitx-pinctrl.dtsi
@@ -1834,6 +1834,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f767zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767zgtx-pinctrl.dtsi
@@ -2281,6 +2281,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f767zitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767zitx-pinctrl.dtsi
@@ -2281,6 +2281,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f768aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f768aiyx-pinctrl.dtsi
@@ -2284,6 +2284,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f769a(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769a(g-i)yx-pinctrl.dtsi
@@ -2284,6 +2284,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f769b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769b(g-i)tx-pinctrl.dtsi
@@ -2786,6 +2786,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f769igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769igtx-pinctrl.dtsi
@@ -2540,6 +2540,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f769iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769iitx-pinctrl.dtsi
@@ -2540,6 +2540,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f769nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769nghx-pinctrl.dtsi
@@ -2786,6 +2786,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f769nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769nihx-pinctrl.dtsi
@@ -2786,6 +2786,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f777bitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777bitx-pinctrl.dtsi
@@ -2822,6 +2822,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f777iikx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777iikx-pinctrl.dtsi
@@ -2694,6 +2694,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f777iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777iitx-pinctrl.dtsi
@@ -2694,6 +2694,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f777nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777nihx-pinctrl.dtsi
@@ -2822,6 +2822,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f777vihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777vihx-pinctrl.dtsi
@@ -1834,6 +1834,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f777vitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777vitx-pinctrl.dtsi
@@ -1834,6 +1834,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f777zitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777zitx-pinctrl.dtsi
@@ -2281,6 +2281,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f778aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f778aiyx-pinctrl.dtsi
@@ -2284,6 +2284,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f779aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779aiyx-pinctrl.dtsi
@@ -2284,6 +2284,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f779bitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779bitx-pinctrl.dtsi
@@ -2786,6 +2786,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f779iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779iitx-pinctrl.dtsi
@@ -2540,6 +2540,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/f7/stm32f779nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779nihx-pinctrl.dtsi
@@ -2786,6 +2786,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g030c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g030c(6-8)tx-pinctrl.dtsi
@@ -576,6 +576,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g030f6px-pinctrl.dtsi
+++ b/dts/st/g0/stm32g030f6px-pinctrl.dtsi
@@ -428,6 +428,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g030j6mx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g030j6mx-pinctrl.dtsi
@@ -297,6 +297,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g030k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g030k(6-8)tx-pinctrl.dtsi
@@ -462,6 +462,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g031c(4-6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031c(4-6-8)tx-pinctrl.dtsi
@@ -632,6 +632,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g031c(4-6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031c(4-6-8)ux-pinctrl.dtsi
@@ -632,6 +632,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g031f(4-6-8)px-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031f(4-6-8)px-pinctrl.dtsi
@@ -462,6 +462,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g031g(4-6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031g(4-6-8)ux-pinctrl.dtsi
@@ -446,6 +446,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g031j(4-6)mx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031j(4-6)mx-pinctrl.dtsi
@@ -313,6 +313,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g031k(4-6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031k(4-6-8)tx-pinctrl.dtsi
@@ -500,6 +500,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g031k(4-6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031k(4-6-8)ux-pinctrl.dtsi
@@ -500,6 +500,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g031y8yx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031y8yx-pinctrl.dtsi
@@ -462,6 +462,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g041c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041c(6-8)tx-pinctrl.dtsi
@@ -632,6 +632,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g041c(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041c(6-8)ux-pinctrl.dtsi
@@ -632,6 +632,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g041f(6-8)px-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041f(6-8)px-pinctrl.dtsi
@@ -462,6 +462,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g041g(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041g(6-8)ux-pinctrl.dtsi
@@ -446,6 +446,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g041j6mx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041j6mx-pinctrl.dtsi
@@ -313,6 +313,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g041k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041k(6-8)tx-pinctrl.dtsi
@@ -500,6 +500,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g041k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041k(6-8)ux-pinctrl.dtsi
@@ -500,6 +500,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g041y8yx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041y8yx-pinctrl.dtsi
@@ -462,6 +462,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g050c6tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g050c6tx-pinctrl.dtsi
@@ -620,6 +620,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g050c8tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g050c8tx-pinctrl.dtsi
@@ -620,6 +620,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g050f6px-pinctrl.dtsi
+++ b/dts/st/g0/stm32g050f6px-pinctrl.dtsi
@@ -440,6 +440,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g050k6tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g050k6tx-pinctrl.dtsi
@@ -474,6 +474,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g050k8tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g050k8tx-pinctrl.dtsi
@@ -474,6 +474,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g051c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g051c(6-8)tx-pinctrl.dtsi
@@ -686,6 +686,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g051c(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g051c(6-8)ux-pinctrl.dtsi
@@ -686,6 +686,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g051f(6-8)px-pinctrl.dtsi
+++ b/dts/st/g0/stm32g051f(6-8)px-pinctrl.dtsi
@@ -484,6 +484,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g051f8yx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g051f8yx-pinctrl.dtsi
@@ -484,6 +484,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g051g(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g051g(6-8)ux-pinctrl.dtsi
@@ -468,6 +468,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g051k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g051k(6-8)tx-pinctrl.dtsi
@@ -522,6 +522,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g051k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g051k(6-8)ux-pinctrl.dtsi
@@ -522,6 +522,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g061c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g061c(6-8)tx-pinctrl.dtsi
@@ -686,6 +686,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g061c(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g061c(6-8)ux-pinctrl.dtsi
@@ -686,6 +686,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g061f(6-8)px-pinctrl.dtsi
+++ b/dts/st/g0/stm32g061f(6-8)px-pinctrl.dtsi
@@ -484,6 +484,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g061f8yx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g061f8yx-pinctrl.dtsi
@@ -484,6 +484,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g061g(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g061g(6-8)ux-pinctrl.dtsi
@@ -468,6 +468,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g061k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g061k(6-8)tx-pinctrl.dtsi
@@ -522,6 +522,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g061k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g061k(6-8)ux-pinctrl.dtsi
@@ -522,6 +522,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g070cbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g070cbtx-pinctrl.dtsi
@@ -618,6 +618,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g070kbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g070kbtx-pinctrl.dtsi
@@ -466,6 +466,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g070rbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g070rbtx-pinctrl.dtsi
@@ -715,6 +715,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g071c(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071c(6-8-b)tx-pinctrl.dtsi
@@ -684,6 +684,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g071c(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071c(6-8-b)ux-pinctrl.dtsi
@@ -684,6 +684,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g071ebyx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071ebyx-pinctrl.dtsi
@@ -418,6 +418,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g071g(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071g(6-8-b)ux-pinctrl.dtsi
@@ -460,6 +460,43 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g071g(8-b)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071g(8-b)uxn-pinctrl.dtsi
@@ -439,6 +439,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g071k(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071k(6-8-b)tx-pinctrl.dtsi
@@ -514,6 +514,43 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g071k(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071k(6-8-b)ux-pinctrl.dtsi
@@ -514,6 +514,43 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g071k(8-b)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071k(8-b)txn-pinctrl.dtsi
@@ -500,6 +500,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g071k(8-b)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071k(8-b)uxn-pinctrl.dtsi
@@ -500,6 +500,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g071r(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071r(6-8-b)tx-pinctrl.dtsi
@@ -789,6 +789,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g071rbix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071rbix-pinctrl.dtsi
@@ -789,6 +789,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g081cbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081cbtx-pinctrl.dtsi
@@ -684,6 +684,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g081cbux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081cbux-pinctrl.dtsi
@@ -684,6 +684,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g081ebyx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081ebyx-pinctrl.dtsi
@@ -418,6 +418,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g081gbux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081gbux-pinctrl.dtsi
@@ -460,6 +460,43 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g081gbuxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081gbuxn-pinctrl.dtsi
@@ -439,6 +439,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g081kbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081kbtx-pinctrl.dtsi
@@ -514,6 +514,43 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g081kbtxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081kbtxn-pinctrl.dtsi
@@ -500,6 +500,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g081kbux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081kbux-pinctrl.dtsi
@@ -514,6 +514,43 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g081kbuxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081kbuxn-pinctrl.dtsi
@@ -500,6 +500,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g081rbix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081rbix-pinctrl.dtsi
@@ -789,6 +789,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g081rbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081rbtx-pinctrl.dtsi
@@ -789,6 +789,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0b0cetx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b0cetx-pinctrl.dtsi
@@ -815,6 +815,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pb14: usart6_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0b0ketx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b0ketx-pinctrl.dtsi
@@ -626,6 +626,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0b0retx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b0retx-pinctrl.dtsi
@@ -954,6 +954,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF8)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pd4: usart5_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pb14: usart6_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0b0vetx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b0vetx-pinctrl.dtsi
@@ -1082,6 +1082,93 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF8)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pd4: usart5_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF3)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pe7: usart5_de_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pb14: usart6_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pf3: usart6_de_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pf11: usart6_de_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0b1c(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1c(b-c-e)tx-pinctrl.dtsi
@@ -939,6 +939,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pb14: usart6_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0b1c(b-c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1c(b-c-e)txn-pinctrl.dtsi
@@ -923,6 +923,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pb14: usart6_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0b1c(b-c-e)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1c(b-c-e)ux-pinctrl.dtsi
@@ -939,6 +939,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pb14: usart6_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0b1c(b-c-e)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1c(b-c-e)uxn-pinctrl.dtsi
@@ -923,6 +923,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pb14: usart6_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0b1c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1c(c-e)tx-pinctrl.dtsi
@@ -939,6 +939,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pb14: usart6_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0b1c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1c(c-e)ux-pinctrl.dtsi
@@ -939,6 +939,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pb14: usart6_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0b1k(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1k(b-c-e)tx-pinctrl.dtsi
@@ -716,6 +716,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0b1k(b-c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1k(b-c-e)txn-pinctrl.dtsi
@@ -667,6 +667,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0b1k(b-c-e)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1k(b-c-e)ux-pinctrl.dtsi
@@ -716,6 +716,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0b1k(b-c-e)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1k(b-c-e)uxn-pinctrl.dtsi
@@ -667,6 +667,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0b1k(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1k(c-e)tx-pinctrl.dtsi
@@ -716,6 +716,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0b1k(c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1k(c-e)txn-pinctrl.dtsi
@@ -667,6 +667,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0b1k(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1k(c-e)ux-pinctrl.dtsi
@@ -716,6 +716,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0b1k(c-e)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1k(c-e)uxn-pinctrl.dtsi
@@ -667,6 +667,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0b1m(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1m(b-c-e)tx-pinctrl.dtsi
@@ -1176,6 +1176,113 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pc9: lpuart2_de_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF3)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pd15: lpuart2_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF8)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pd4: usart5_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF3)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pe7: usart5_de_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pb14: usart6_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0b1m(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1m(c-e)tx-pinctrl.dtsi
@@ -1176,6 +1176,113 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pc9: lpuart2_de_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF3)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pd15: lpuart2_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF8)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pd4: usart5_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF3)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pe7: usart5_de_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pb14: usart6_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0b1neyx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1neyx-pinctrl.dtsi
@@ -963,6 +963,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pb14: usart6_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0b1r(b-c-e)ixn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1r(b-c-e)ixn-pinctrl.dtsi
@@ -1088,6 +1088,98 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pc9: lpuart2_de_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF3)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF8)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pd4: usart5_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pb14: usart6_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0b1r(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1r(b-c-e)tx-pinctrl.dtsi
@@ -1108,6 +1108,98 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pc9: lpuart2_de_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF3)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF8)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pd4: usart5_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pb14: usart6_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0b1r(b-c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1r(b-c-e)txn-pinctrl.dtsi
@@ -1088,6 +1088,98 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pc9: lpuart2_de_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF3)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF8)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pd4: usart5_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pb14: usart6_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0b1r(c-e)ix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1r(c-e)ix-pinctrl.dtsi
@@ -1108,6 +1108,98 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pc9: lpuart2_de_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF3)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF8)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pd4: usart5_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pb14: usart6_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0b1r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1r(c-e)tx-pinctrl.dtsi
@@ -1108,6 +1108,98 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pc9: lpuart2_de_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF3)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF8)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pd4: usart5_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pb14: usart6_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0b1v(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1v(b-c-e)ix-pinctrl.dtsi
@@ -1264,6 +1264,128 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pf6: lpuart1_de_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pc9: lpuart2_de_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF3)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pd15: lpuart2_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF8)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pd4: usart5_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF3)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pe7: usart5_de_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pb14: usart6_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pf3: usart6_de_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pf11: usart6_de_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0b1v(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1v(b-c-e)tx-pinctrl.dtsi
@@ -1264,6 +1264,128 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pf6: lpuart1_de_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pc9: lpuart2_de_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF3)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pd15: lpuart2_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF8)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pd4: usart5_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF3)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pe7: usart5_de_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pb14: usart6_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pf3: usart6_de_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pf11: usart6_de_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0b1v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1v(c-e)ix-pinctrl.dtsi
@@ -1264,6 +1264,128 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pf6: lpuart1_de_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pc9: lpuart2_de_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF3)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pd15: lpuart2_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF8)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pd4: usart5_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF3)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pe7: usart5_de_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pb14: usart6_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pf3: usart6_de_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pf11: usart6_de_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0b1v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1v(c-e)tx-pinctrl.dtsi
@@ -1264,6 +1264,128 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pf6: lpuart1_de_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pc9: lpuart2_de_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF3)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pd15: lpuart2_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF8)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pd4: usart5_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF3)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pe7: usart5_de_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pb14: usart6_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pf3: usart6_de_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pf11: usart6_de_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0c1c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1c(c-e)tx-pinctrl.dtsi
@@ -939,6 +939,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pb14: usart6_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0c1c(c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1c(c-e)txn-pinctrl.dtsi
@@ -923,6 +923,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pb14: usart6_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0c1c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1c(c-e)ux-pinctrl.dtsi
@@ -939,6 +939,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pb14: usart6_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0c1c(c-e)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1c(c-e)uxn-pinctrl.dtsi
@@ -923,6 +923,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pb14: usart6_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0c1k(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1k(c-e)tx-pinctrl.dtsi
@@ -716,6 +716,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0c1k(c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1k(c-e)txn-pinctrl.dtsi
@@ -667,6 +667,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0c1k(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1k(c-e)ux-pinctrl.dtsi
@@ -716,6 +716,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0c1k(c-e)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1k(c-e)uxn-pinctrl.dtsi
@@ -667,6 +667,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0c1m(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1m(c-e)tx-pinctrl.dtsi
@@ -1176,6 +1176,113 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pc9: lpuart2_de_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF3)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pd15: lpuart2_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF8)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pd4: usart5_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF3)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pe7: usart5_de_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pb14: usart6_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0c1neyx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1neyx-pinctrl.dtsi
@@ -963,6 +963,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pb14: usart6_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0c1r(c-e)ix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1r(c-e)ix-pinctrl.dtsi
@@ -1108,6 +1108,98 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pc9: lpuart2_de_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF3)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF8)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pd4: usart5_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pb14: usart6_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0c1r(c-e)ixn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1r(c-e)ixn-pinctrl.dtsi
@@ -1088,6 +1088,98 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pc9: lpuart2_de_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF3)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF8)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pd4: usart5_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pb14: usart6_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0c1r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1r(c-e)tx-pinctrl.dtsi
@@ -1108,6 +1108,98 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pc9: lpuart2_de_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF3)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF8)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pd4: usart5_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pb14: usart6_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0c1r(c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1r(c-e)txn-pinctrl.dtsi
@@ -1088,6 +1088,98 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pc9: lpuart2_de_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF3)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF8)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pd4: usart5_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pb14: usart6_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0c1v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1v(c-e)ix-pinctrl.dtsi
@@ -1264,6 +1264,128 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pf6: lpuart1_de_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pc9: lpuart2_de_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF3)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pd15: lpuart2_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF8)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pd4: usart5_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF3)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pe7: usart5_de_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pb14: usart6_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pf3: usart6_de_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pf11: usart6_de_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g0/stm32g0c1v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1v(c-e)tx-pinctrl.dtsi
@@ -1264,6 +1264,128 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF6)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pf6: lpuart1_de_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF1)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pb1: lpuart2_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pc9: lpuart2_de_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF3)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pd15: lpuart2_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF1)>;
+				drive-push-pull;
+			};
+
+			lpuart2_de_pf2: lpuart2_de_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF3)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF5)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF4)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF8)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pd4: usart5_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF3)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pe7: usart5_de_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pa7: usart6_de_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pb14: usart6_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pf3: usart6_de_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF3)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pf11: usart6_de_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF3)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g431c(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431c(6-8-b)tx-pinctrl.dtsi
@@ -675,6 +675,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g431c(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431c(6-8-b)ux-pinctrl.dtsi
@@ -723,6 +723,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g431cbyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431cbyx-pinctrl.dtsi
@@ -708,6 +708,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g431k(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431k(6-8-b)tx-pinctrl.dtsi
@@ -517,6 +517,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g431k(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431k(6-8-b)ux-pinctrl.dtsi
@@ -517,6 +517,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g431m(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431m(6-8-b)tx-pinctrl.dtsi
@@ -882,6 +882,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g431r(6-8-b)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431r(6-8-b)ix-pinctrl.dtsi
@@ -834,6 +834,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g431r(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431r(6-8-b)tx-pinctrl.dtsi
@@ -834,6 +834,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g431v(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431v(6-8-b)tx-pinctrl.dtsi
@@ -975,6 +975,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g441cbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441cbtx-pinctrl.dtsi
@@ -675,6 +675,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g441cbux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441cbux-pinctrl.dtsi
@@ -723,6 +723,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g441cbyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441cbyx-pinctrl.dtsi
@@ -708,6 +708,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g441kbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441kbtx-pinctrl.dtsi
@@ -517,6 +517,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g441kbux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441kbux-pinctrl.dtsi
@@ -517,6 +517,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g441mbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441mbtx-pinctrl.dtsi
@@ -882,6 +882,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g441rbix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441rbix-pinctrl.dtsi
@@ -834,6 +834,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g441rbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441rbtx-pinctrl.dtsi
@@ -834,6 +834,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g441vbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441vbtx-pinctrl.dtsi
@@ -975,6 +975,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g471c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471c(c-e)tx-pinctrl.dtsi
@@ -782,6 +782,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g471c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471c(c-e)ux-pinctrl.dtsi
@@ -847,6 +847,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g471m(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471m(c-e)tx-pinctrl.dtsi
@@ -1122,6 +1122,43 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g471meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471meyx-pinctrl.dtsi
@@ -1132,6 +1132,43 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g471q(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471q(c-e)tx-pinctrl.dtsi
@@ -1418,6 +1418,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g471r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471r(c-e)tx-pinctrl.dtsi
@@ -983,6 +983,43 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g471v(c-e)hx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471v(c-e)hx-pinctrl.dtsi
@@ -1296,6 +1296,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g471v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471v(c-e)ix-pinctrl.dtsi
@@ -1296,6 +1296,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g471v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471v(c-e)tx-pinctrl.dtsi
@@ -1296,6 +1296,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g473c(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473c(b-c-e)tx-pinctrl.dtsi
@@ -826,6 +826,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g473c(b-c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473c(b-c-e)ux-pinctrl.dtsi
@@ -891,6 +891,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g473m(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473m(b-c-e)tx-pinctrl.dtsi
@@ -1238,6 +1238,43 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g473meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473meyx-pinctrl.dtsi
@@ -1256,6 +1256,43 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g473p(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473p(b-c-e)ix-pinctrl.dtsi
@@ -1917,6 +1917,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g473q(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473q(b-c-e)tx-pinctrl.dtsi
@@ -1986,6 +1986,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g473r(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473r(b-c-e)tx-pinctrl.dtsi
@@ -1035,6 +1035,43 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g473v(b-c-e)hx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473v(b-c-e)hx-pinctrl.dtsi
@@ -1694,6 +1694,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g473v(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473v(b-c-e)ix-pinctrl.dtsi
@@ -1694,6 +1694,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g473v(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473v(b-c-e)tx-pinctrl.dtsi
@@ -1694,6 +1694,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g474c(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474c(b-c-e)tx-pinctrl.dtsi
@@ -908,6 +908,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g474c(b-c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474c(b-c-e)ux-pinctrl.dtsi
@@ -985,6 +985,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g474m(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474m(b-c-e)tx-pinctrl.dtsi
@@ -1352,6 +1352,43 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g474meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474meyx-pinctrl.dtsi
@@ -1370,6 +1370,43 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g474p(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474p(b-c-e)ix-pinctrl.dtsi
@@ -2031,6 +2031,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g474q(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474q(b-c-e)tx-pinctrl.dtsi
@@ -2100,6 +2100,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g474r(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474r(b-c-e)tx-pinctrl.dtsi
@@ -1149,6 +1149,43 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g474v(b-c-e)hx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474v(b-c-e)hx-pinctrl.dtsi
@@ -1808,6 +1808,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g474v(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474v(b-c-e)ix-pinctrl.dtsi
@@ -1808,6 +1808,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g474v(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474v(b-c-e)tx-pinctrl.dtsi
@@ -1808,6 +1808,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g483cetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483cetx-pinctrl.dtsi
@@ -826,6 +826,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g483ceux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483ceux-pinctrl.dtsi
@@ -891,6 +891,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g483metx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483metx-pinctrl.dtsi
@@ -1238,6 +1238,43 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g483meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483meyx-pinctrl.dtsi
@@ -1256,6 +1256,43 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g483peix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483peix-pinctrl.dtsi
@@ -1917,6 +1917,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g483qetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483qetx-pinctrl.dtsi
@@ -1986,6 +1986,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g483retx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483retx-pinctrl.dtsi
@@ -1035,6 +1035,43 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g483vehx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483vehx-pinctrl.dtsi
@@ -1694,6 +1694,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g483veix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483veix-pinctrl.dtsi
@@ -1694,6 +1694,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g483vetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483vetx-pinctrl.dtsi
@@ -1694,6 +1694,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g484cetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484cetx-pinctrl.dtsi
@@ -908,6 +908,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g484ceux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484ceux-pinctrl.dtsi
@@ -985,6 +985,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g484metx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484metx-pinctrl.dtsi
@@ -1352,6 +1352,43 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g484meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484meyx-pinctrl.dtsi
@@ -1370,6 +1370,43 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g484peix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484peix-pinctrl.dtsi
@@ -2031,6 +2031,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g484qetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484qetx-pinctrl.dtsi
@@ -2100,6 +2100,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g484retx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484retx-pinctrl.dtsi
@@ -1149,6 +1149,43 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g484vehx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484vehx-pinctrl.dtsi
@@ -1808,6 +1808,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g484veix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484veix-pinctrl.dtsi
@@ -1808,6 +1808,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g484vetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484vetx-pinctrl.dtsi
@@ -1808,6 +1808,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g491c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491c(c-e)tx-pinctrl.dtsi
@@ -754,6 +754,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g491c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491c(c-e)ux-pinctrl.dtsi
@@ -807,6 +807,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g491k(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491k(c-e)ux-pinctrl.dtsi
@@ -556,6 +556,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g491m(c-e)sx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491m(c-e)sx-pinctrl.dtsi
@@ -1057,6 +1057,43 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g491m(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491m(c-e)tx-pinctrl.dtsi
@@ -1057,6 +1057,43 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g491r(c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491r(c-e)ix-pinctrl.dtsi
@@ -947,6 +947,43 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g491r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491r(c-e)tx-pinctrl.dtsi
@@ -947,6 +947,43 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g491reyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491reyx-pinctrl.dtsi
@@ -947,6 +947,43 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g491v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491v(c-e)tx-pinctrl.dtsi
@@ -1233,6 +1233,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g4a1cetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1cetx-pinctrl.dtsi
@@ -754,6 +754,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g4a1ceux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1ceux-pinctrl.dtsi
@@ -807,6 +807,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g4a1keux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1keux-pinctrl.dtsi
@@ -556,6 +556,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g4a1mesx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1mesx-pinctrl.dtsi
@@ -1057,6 +1057,43 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g4a1metx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1metx-pinctrl.dtsi
@@ -1057,6 +1057,43 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g4a1reix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1reix-pinctrl.dtsi
@@ -947,6 +947,43 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g4a1retx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1retx-pinctrl.dtsi
@@ -947,6 +947,43 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g4a1reyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1reyx-pinctrl.dtsi
@@ -947,6 +947,43 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32g4a1vetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1vetx-pinctrl.dtsi
@@ -1233,6 +1233,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/g4/stm32gbk1cbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32gbk1cbtx-pinctrl.dtsi
@@ -739,6 +739,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF12)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/h7/stm32h723vehx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vehx-pinctrl.dtsi
@@ -1988,6 +1988,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h723vetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vetx-pinctrl.dtsi
@@ -1988,6 +1988,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h723vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vghx-pinctrl.dtsi
@@ -1988,6 +1988,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h723vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vgtx-pinctrl.dtsi
@@ -1988,6 +1988,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h723zeix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zeix-pinctrl.dtsi
@@ -2596,6 +2596,88 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h723zetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zetx-pinctrl.dtsi
@@ -2568,6 +2568,88 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h723zgix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zgix-pinctrl.dtsi
@@ -2596,6 +2596,88 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h723zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zgtx-pinctrl.dtsi
@@ -2568,6 +2568,88 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h725aeix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725aeix-pinctrl.dtsi
@@ -2856,6 +2856,88 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h725agix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725agix-pinctrl.dtsi
@@ -2856,6 +2856,88 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h725iekx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725iekx-pinctrl.dtsi
@@ -2996,6 +2996,93 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h725ietx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725ietx-pinctrl.dtsi
@@ -2665,6 +2665,88 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h725igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725igkx-pinctrl.dtsi
@@ -2996,6 +2996,93 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h725igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725igtx-pinctrl.dtsi
@@ -2665,6 +2665,88 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h725revx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725revx-pinctrl.dtsi
@@ -1192,6 +1192,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h725rgvx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725rgvx-pinctrl.dtsi
@@ -1192,6 +1192,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h725vehx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vehx-pinctrl.dtsi
@@ -1895,6 +1895,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h725vetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vetx-pinctrl.dtsi
@@ -1786,6 +1786,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h725vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vghx-pinctrl.dtsi
@@ -1895,6 +1895,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h725vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vgtx-pinctrl.dtsi
@@ -1786,6 +1786,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h725vgyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vgyx-pinctrl.dtsi
@@ -1724,6 +1724,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h725zetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725zetx-pinctrl.dtsi
@@ -2396,6 +2396,88 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h725zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725zgtx-pinctrl.dtsi
@@ -2396,6 +2396,88 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h730abixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730abixq-pinctrl.dtsi
@@ -2758,6 +2758,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h730ibkxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730ibkxq-pinctrl.dtsi
@@ -2898,6 +2898,88 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h730ibtxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730ibtxq-pinctrl.dtsi
@@ -2629,6 +2629,88 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h730vbhx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730vbhx-pinctrl.dtsi
@@ -1952,6 +1952,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h730vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730vbtx-pinctrl.dtsi
@@ -1952,6 +1952,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h730zbix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730zbix-pinctrl.dtsi
@@ -2596,6 +2596,88 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h730zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730zbtx-pinctrl.dtsi
@@ -2532,6 +2532,88 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h733vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733vghx-pinctrl.dtsi
@@ -1988,6 +1988,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h733vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733vgtx-pinctrl.dtsi
@@ -1988,6 +1988,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h733zgix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733zgix-pinctrl.dtsi
@@ -2596,6 +2596,88 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h733zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733zgtx-pinctrl.dtsi
@@ -2568,6 +2568,88 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h735agix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735agix-pinctrl.dtsi
@@ -2856,6 +2856,88 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h735igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735igkx-pinctrl.dtsi
@@ -2996,6 +2996,93 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h735igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735igtx-pinctrl.dtsi
@@ -2665,6 +2665,88 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h735rgvx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735rgvx-pinctrl.dtsi
@@ -1192,6 +1192,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h735vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vghx-pinctrl.dtsi
@@ -1901,6 +1901,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h735vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vgtx-pinctrl.dtsi
@@ -1792,6 +1792,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h735vgyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vgyx-pinctrl.dtsi
@@ -1724,6 +1724,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h735zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735zgtx-pinctrl.dtsi
@@ -2396,6 +2396,88 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
@@ -2327,6 +2327,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
@@ -2544,6 +2544,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
@@ -2467,6 +2467,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
@@ -2467,6 +2467,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
@@ -1677,6 +1677,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
@@ -1677,6 +1677,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
@@ -2698,6 +2698,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
@@ -2120,6 +2120,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
@@ -2601,6 +2601,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
@@ -2962,6 +2962,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h743bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bitx-pinctrl.dtsi
@@ -2962,6 +2962,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h743igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igkx-pinctrl.dtsi
@@ -2757,6 +2757,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h743igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igtx-pinctrl.dtsi
@@ -2757,6 +2757,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h743iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iikx-pinctrl.dtsi
@@ -2757,6 +2757,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h743iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iitx-pinctrl.dtsi
@@ -2757,6 +2757,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
@@ -1835,6 +1835,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
@@ -1835,6 +1835,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h743vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vitx-pinctrl.dtsi
@@ -1835,6 +1835,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h743xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xghx-pinctrl.dtsi
@@ -3114,6 +3114,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h743xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xihx-pinctrl.dtsi
@@ -3114,6 +3114,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
@@ -2322,6 +2322,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h743zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zitx-pinctrl.dtsi
@@ -2322,6 +2322,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
@@ -2878,6 +2878,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h745bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bitx-pinctrl.dtsi
@@ -2878,6 +2878,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h745igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igkx-pinctrl.dtsi
@@ -2750,6 +2750,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h745igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igtx-pinctrl.dtsi
@@ -2419,6 +2419,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h745iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iikx-pinctrl.dtsi
@@ -2750,6 +2750,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h745iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iitx-pinctrl.dtsi
@@ -2419,6 +2419,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h745xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xghx-pinctrl.dtsi
@@ -3114,6 +3114,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h745xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xihx-pinctrl.dtsi
@@ -3114,6 +3114,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
@@ -2186,6 +2186,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h745zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zitx-pinctrl.dtsi
@@ -2186,6 +2186,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
@@ -2322,6 +2322,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
@@ -2765,6 +2765,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h747bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bitx-pinctrl.dtsi
@@ -2765,6 +2765,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h747igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747igtx-pinctrl.dtsi
@@ -2322,6 +2322,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h747iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747iitx-pinctrl.dtsi
@@ -2322,6 +2322,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h747xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xghx-pinctrl.dtsi
@@ -3114,6 +3114,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h747xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xihx-pinctrl.dtsi
@@ -3114,6 +3114,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
@@ -2033,6 +2033,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
@@ -2757,6 +2757,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
@@ -2757,6 +2757,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
@@ -1835,6 +1835,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
@@ -3114,6 +3114,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
@@ -2322,6 +2322,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h753aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753aiix-pinctrl.dtsi
@@ -2601,6 +2601,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h753bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753bitx-pinctrl.dtsi
@@ -2962,6 +2962,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h753iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iikx-pinctrl.dtsi
@@ -2757,6 +2757,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h753iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iitx-pinctrl.dtsi
@@ -2757,6 +2757,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h753vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vihx-pinctrl.dtsi
@@ -1835,6 +1835,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h753vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vitx-pinctrl.dtsi
@@ -1835,6 +1835,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h753xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753xihx-pinctrl.dtsi
@@ -3114,6 +3114,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h753zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753zitx-pinctrl.dtsi
@@ -2322,6 +2322,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h755bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755bitx-pinctrl.dtsi
@@ -2878,6 +2878,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h755iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iikx-pinctrl.dtsi
@@ -2750,6 +2750,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h755iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iitx-pinctrl.dtsi
@@ -2419,6 +2419,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h755xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755xihx-pinctrl.dtsi
@@ -3114,6 +3114,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h755zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755zitx-pinctrl.dtsi
@@ -2186,6 +2186,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h757aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757aiix-pinctrl.dtsi
@@ -2322,6 +2322,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h757bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757bitx-pinctrl.dtsi
@@ -2765,6 +2765,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h757iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757iitx-pinctrl.dtsi
@@ -2322,6 +2322,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h757xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757xihx-pinctrl.dtsi
@@ -3114,6 +3114,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
@@ -2033,6 +2033,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
@@ -2363,6 +2363,93 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
@@ -2514,6 +2514,88 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
@@ -2471,6 +2471,93 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
@@ -2514,6 +2514,88 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
@@ -2239,6 +2239,88 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
@@ -2836,6 +2836,98 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pj3: uart9_de_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
@@ -2725,6 +2725,93 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pj3: uart9_de_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h7a3qiyxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3qiyxq-pinctrl.dtsi
@@ -1877,6 +1877,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h7a3r(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3r(g-i)tx-pinctrl.dtsi
@@ -1194,6 +1194,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h7a3v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)hx-pinctrl.dtsi
@@ -1723,6 +1723,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h7a3v(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)hxq-pinctrl.dtsi
@@ -1636,6 +1636,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h7a3v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)tx-pinctrl.dtsi
@@ -1723,6 +1723,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h7a3v(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)txq-pinctrl.dtsi
@@ -1537,6 +1537,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
@@ -2142,6 +2142,88 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h7a3z(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)txq-pinctrl.dtsi
@@ -2022,6 +2022,88 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
@@ -2363,6 +2363,93 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
@@ -2471,6 +2471,93 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
@@ -2514,6 +2514,88 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h7b0rbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0rbtx-pinctrl.dtsi
@@ -1194,6 +1194,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h7b0vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0vbtx-pinctrl.dtsi
@@ -1723,6 +1723,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
@@ -2142,6 +2142,88 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
@@ -2363,6 +2363,93 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
@@ -2514,6 +2514,88 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
@@ -2471,6 +2471,93 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
@@ -2514,6 +2514,88 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
@@ -2239,6 +2239,88 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
@@ -2836,6 +2836,98 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pj3: uart9_de_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
@@ -2725,6 +2725,93 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pj3: uart9_de_pj3 {
+				pinmux = <STM32_PINMUX('J', 3, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h7b3qiyxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3qiyxq-pinctrl.dtsi
@@ -1877,6 +1877,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h7b3ritx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3ritx-pinctrl.dtsi
@@ -1194,6 +1194,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h7b3vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vihx-pinctrl.dtsi
@@ -1723,6 +1723,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h7b3vihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vihxq-pinctrl.dtsi
@@ -1636,6 +1636,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h7b3vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vitx-pinctrl.dtsi
@@ -1723,6 +1723,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h7b3vitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vitxq-pinctrl.dtsi
@@ -1537,6 +1537,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa12: lpuart1_rts_pa12 {

--- a/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
@@ -2142,6 +2142,88 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/h7/stm32h7b3zitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitxq-pinctrl.dtsi
@@ -2022,6 +2022,88 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart10_de_pg14: usart10_de_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF11)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pa12: lpuart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF3)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pb14: uart4_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pd15: uart8_de_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart9_de_pd13: uart9_de_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF11)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart10_rts_pg14: usart10_rts_pg14 {

--- a/dts/st/l0/stm32l010c6tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l010c6tx-pinctrl.dtsi
@@ -289,6 +289,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa12: usart2_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pb0: usart2_de_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {

--- a/dts/st/l0/stm32l010f4px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l010f4px-pinctrl.dtsi
@@ -187,6 +187,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {

--- a/dts/st/l0/stm32l010k4tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l010k4tx-pinctrl.dtsi
@@ -281,6 +281,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa12: usart2_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pb0: usart2_de_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {

--- a/dts/st/l0/stm32l010k8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l010k8tx-pinctrl.dtsi
@@ -174,6 +174,13 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart2_rts_pa1: usart2_rts_pa1 {

--- a/dts/st/l0/stm32l010r8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l010r8tx-pinctrl.dtsi
@@ -238,6 +238,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd2: lpuart1_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {

--- a/dts/st/l0/stm32l010rbtx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l010rbtx-pinctrl.dtsi
@@ -274,6 +274,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd2: lpuart1_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {

--- a/dts/st/l0/stm32l011d(3-4)px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011d(3-4)px-pinctrl.dtsi
@@ -121,6 +121,13 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart2_rts_pa1: usart2_rts_pa1 {

--- a/dts/st/l0/stm32l011e(3-4)yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011e(3-4)yx-pinctrl.dtsi
@@ -238,6 +238,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pb0: usart2_de_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {

--- a/dts/st/l0/stm32l011f(3-4)px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011f(3-4)px-pinctrl.dtsi
@@ -187,6 +187,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {

--- a/dts/st/l0/stm32l011f(3-4)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011f(3-4)ux-pinctrl.dtsi
@@ -183,6 +183,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {

--- a/dts/st/l0/stm32l011g(3-4)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011g(3-4)ux-pinctrl.dtsi
@@ -261,6 +261,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pb0: usart2_de_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {

--- a/dts/st/l0/stm32l011k(3-4)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011k(3-4)tx-pinctrl.dtsi
@@ -281,6 +281,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa12: usart2_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pb0: usart2_de_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {

--- a/dts/st/l0/stm32l011k(3-4)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l011k(3-4)ux-pinctrl.dtsi
@@ -292,6 +292,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa12: usart2_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pb0: usart2_de_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {

--- a/dts/st/l0/stm32l021d4px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l021d4px-pinctrl.dtsi
@@ -121,6 +121,13 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart2_rts_pa1: usart2_rts_pa1 {

--- a/dts/st/l0/stm32l021f4px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l021f4px-pinctrl.dtsi
@@ -187,6 +187,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {

--- a/dts/st/l0/stm32l021f4ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l021f4ux-pinctrl.dtsi
@@ -183,6 +183,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {

--- a/dts/st/l0/stm32l021g4ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l021g4ux-pinctrl.dtsi
@@ -261,6 +261,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pb0: usart2_de_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {

--- a/dts/st/l0/stm32l021k4tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l021k4tx-pinctrl.dtsi
@@ -281,6 +281,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa12: usart2_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pb0: usart2_de_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {

--- a/dts/st/l0/stm32l021k4ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l021k4ux-pinctrl.dtsi
@@ -292,6 +292,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa12: usart2_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pb0: usart2_de_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {

--- a/dts/st/l0/stm32l031c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031c(4-6)tx-pinctrl.dtsi
@@ -313,6 +313,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa12: usart2_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pb0: usart2_de_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {

--- a/dts/st/l0/stm32l031c(4-6)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031c(4-6)ux-pinctrl.dtsi
@@ -313,6 +313,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa12: usart2_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pb0: usart2_de_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {

--- a/dts/st/l0/stm32l031e(4-6)yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031e(4-6)yx-pinctrl.dtsi
@@ -211,6 +211,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pb0: usart2_de_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {

--- a/dts/st/l0/stm32l031f(4-6)px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031f(4-6)px-pinctrl.dtsi
@@ -168,6 +168,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {

--- a/dts/st/l0/stm32l031g(4-6)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031g(4-6)ux-pinctrl.dtsi
@@ -220,6 +220,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pb0: usart2_de_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {

--- a/dts/st/l0/stm32l031g6uxs-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031g6uxs-pinctrl.dtsi
@@ -238,6 +238,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pb0: usart2_de_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {

--- a/dts/st/l0/stm32l031k(4-6)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031k(4-6)tx-pinctrl.dtsi
@@ -258,6 +258,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa12: usart2_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pb0: usart2_de_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {

--- a/dts/st/l0/stm32l031k(4-6)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l031k(4-6)ux-pinctrl.dtsi
@@ -264,6 +264,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa12: usart2_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pb0: usart2_de_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {

--- a/dts/st/l0/stm32l041c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041c(4-6)tx-pinctrl.dtsi
@@ -313,6 +313,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa12: usart2_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pb0: usart2_de_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {

--- a/dts/st/l0/stm32l041c6ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041c6ux-pinctrl.dtsi
@@ -313,6 +313,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF6)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa12: usart2_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pb0: usart2_de_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {

--- a/dts/st/l0/stm32l041e6yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041e6yx-pinctrl.dtsi
@@ -211,6 +211,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pb0: usart2_de_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {

--- a/dts/st/l0/stm32l041f6px-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041f6px-pinctrl.dtsi
@@ -168,6 +168,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {

--- a/dts/st/l0/stm32l041g6ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041g6ux-pinctrl.dtsi
@@ -220,6 +220,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pb0: usart2_de_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {

--- a/dts/st/l0/stm32l041g6uxs-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041g6uxs-pinctrl.dtsi
@@ -238,6 +238,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pb0: usart2_de_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {

--- a/dts/st/l0/stm32l041k6tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041k6tx-pinctrl.dtsi
@@ -258,6 +258,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa12: usart2_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pb0: usart2_de_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {

--- a/dts/st/l0/stm32l041k6ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l041k6ux-pinctrl.dtsi
@@ -264,6 +264,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa12: usart2_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pb0: usart2_de_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pb1: lpuart1_rts_pb1 {

--- a/dts/st/l0/stm32l051c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l051c(6-8)tx-pinctrl.dtsi
@@ -315,6 +315,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l051c(6-8)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l051c(6-8)ux-pinctrl.dtsi
@@ -315,6 +315,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l051k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l051k(6-8)tx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l051k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l051k(6-8)ux-pinctrl.dtsi
@@ -202,6 +202,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l051r(6-8)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l051r(6-8)hx-pinctrl.dtsi
@@ -348,6 +348,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd2: lpuart1_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l051r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l051r(6-8)tx-pinctrl.dtsi
@@ -361,6 +361,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd2: lpuart1_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l051t(6-8)yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l051t(6-8)yx-pinctrl.dtsi
@@ -228,6 +228,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l052c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052c(6-8)tx-pinctrl.dtsi
@@ -321,6 +321,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l052c(6-8)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052c(6-8)ux-pinctrl.dtsi
@@ -321,6 +321,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l052k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052k(6-8)tx-pinctrl.dtsi
@@ -202,6 +202,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l052k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052k(6-8)ux-pinctrl.dtsi
@@ -208,6 +208,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l052r(6-8)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052r(6-8)hx-pinctrl.dtsi
@@ -354,6 +354,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd2: lpuart1_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l052r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052r(6-8)tx-pinctrl.dtsi
@@ -367,6 +367,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd2: lpuart1_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l052t(6-8)yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052t(6-8)yx-pinctrl.dtsi
@@ -234,6 +234,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l052t8fx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052t8fx-pinctrl.dtsi
@@ -234,6 +234,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l053c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l053c(6-8)tx-pinctrl.dtsi
@@ -321,6 +321,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l053c(6-8)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l053c(6-8)ux-pinctrl.dtsi
@@ -321,6 +321,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l053r(6-8)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l053r(6-8)hx-pinctrl.dtsi
@@ -354,6 +354,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd2: lpuart1_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l053r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l053r(6-8)tx-pinctrl.dtsi
@@ -367,6 +367,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd2: lpuart1_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l062c8ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l062c8ux-pinctrl.dtsi
@@ -321,6 +321,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l062k8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l062k8tx-pinctrl.dtsi
@@ -202,6 +202,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l062k8ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l062k8ux-pinctrl.dtsi
@@ -208,6 +208,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l063c8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l063c8tx-pinctrl.dtsi
@@ -321,6 +321,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l063c8ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l063c8ux-pinctrl.dtsi
@@ -321,6 +321,33 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l063r8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l063r8tx-pinctrl.dtsi
@@ -367,6 +367,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd2: lpuart1_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l071c(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071c(b-z)tx-pinctrl.dtsi
@@ -375,6 +375,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l071c(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071c(b-z)ux-pinctrl.dtsi
@@ -375,6 +375,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l071c(b-z)yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071c(b-z)yx-pinctrl.dtsi
@@ -404,6 +404,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l071c8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071c8tx-pinctrl.dtsi
@@ -375,6 +375,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l071c8ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071c8ux-pinctrl.dtsi
@@ -375,6 +375,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l071k(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071k(b-z)tx-pinctrl.dtsi
@@ -262,6 +262,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l071k(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071k(b-z)ux-pinctrl.dtsi
@@ -243,6 +243,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l071k8ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071k8ux-pinctrl.dtsi
@@ -243,6 +243,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l071r(b-z)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071r(b-z)hx-pinctrl.dtsi
@@ -442,6 +442,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd2: lpuart1_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l071r(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071r(b-z)tx-pinctrl.dtsi
@@ -455,6 +455,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd2: lpuart1_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l071v(b-z)ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071v(b-z)ix-pinctrl.dtsi
@@ -578,6 +578,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd2: lpuart1_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd12: lpuart1_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF0)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pe7: usart5_de_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l071v(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071v(b-z)tx-pinctrl.dtsi
@@ -578,6 +578,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd2: lpuart1_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd12: lpuart1_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF0)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pe7: usart5_de_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l071v8ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071v8ix-pinctrl.dtsi
@@ -578,6 +578,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd2: lpuart1_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd12: lpuart1_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF0)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pe7: usart5_de_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l071v8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071v8tx-pinctrl.dtsi
@@ -578,6 +578,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd2: lpuart1_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd12: lpuart1_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF0)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pe7: usart5_de_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l072c(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072c(b-z)tx-pinctrl.dtsi
@@ -385,6 +385,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l072c(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072c(b-z)ux-pinctrl.dtsi
@@ -385,6 +385,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l072c(b-z)yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072c(b-z)yx-pinctrl.dtsi
@@ -414,6 +414,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l072czex-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072czex-pinctrl.dtsi
@@ -414,6 +414,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l072k(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072k(b-z)tx-pinctrl.dtsi
@@ -272,6 +272,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l072k(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072k(b-z)ux-pinctrl.dtsi
@@ -253,6 +253,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l072r(b-z)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072r(b-z)hx-pinctrl.dtsi
@@ -452,6 +452,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd2: lpuart1_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l072r(b-z)ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072r(b-z)ix-pinctrl.dtsi
@@ -452,6 +452,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd2: lpuart1_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l072r(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072r(b-z)tx-pinctrl.dtsi
@@ -465,6 +465,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd2: lpuart1_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l072v(b-z)ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072v(b-z)ix-pinctrl.dtsi
@@ -588,6 +588,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd2: lpuart1_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd12: lpuart1_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF0)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pe7: usart5_de_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l072v(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072v(b-z)tx-pinctrl.dtsi
@@ -588,6 +588,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd2: lpuart1_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd12: lpuart1_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF0)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pe7: usart5_de_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l072v8ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072v8ix-pinctrl.dtsi
@@ -588,6 +588,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd2: lpuart1_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd12: lpuart1_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF0)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pe7: usart5_de_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l072v8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072v8tx-pinctrl.dtsi
@@ -588,6 +588,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd2: lpuart1_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd12: lpuart1_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF0)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pe7: usart5_de_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l073c(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073c(b-z)tx-pinctrl.dtsi
@@ -385,6 +385,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l073c(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073c(b-z)ux-pinctrl.dtsi
@@ -385,6 +385,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l073czyx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073czyx-pinctrl.dtsi
@@ -414,6 +414,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l073r(b-z)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073r(b-z)hx-pinctrl.dtsi
@@ -452,6 +452,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd2: lpuart1_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l073r(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073r(b-z)tx-pinctrl.dtsi
@@ -465,6 +465,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd2: lpuart1_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l073rzix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073rzix-pinctrl.dtsi
@@ -452,6 +452,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd2: lpuart1_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l073v(b-z)ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073v(b-z)ix-pinctrl.dtsi
@@ -588,6 +588,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd2: lpuart1_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd12: lpuart1_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF0)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pe7: usart5_de_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l073v(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073v(b-z)tx-pinctrl.dtsi
@@ -588,6 +588,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd2: lpuart1_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd12: lpuart1_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF0)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pe7: usart5_de_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l073v8ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073v8ix-pinctrl.dtsi
@@ -588,6 +588,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd2: lpuart1_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd12: lpuart1_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF0)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pe7: usart5_de_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l073v8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073v8tx-pinctrl.dtsi
@@ -588,6 +588,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd2: lpuart1_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd12: lpuart1_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF0)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pe7: usart5_de_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l081c(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l081c(b-z)tx-pinctrl.dtsi
@@ -375,6 +375,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l081czux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l081czux-pinctrl.dtsi
@@ -375,6 +375,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l081kztx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l081kztx-pinctrl.dtsi
@@ -262,6 +262,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l081kzux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l081kzux-pinctrl.dtsi
@@ -243,6 +243,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l082czux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l082czux-pinctrl.dtsi
@@ -385,6 +385,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l082czyx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l082czyx-pinctrl.dtsi
@@ -414,6 +414,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l082k(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l082k(b-z)tx-pinctrl.dtsi
@@ -272,6 +272,38 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l082k(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l082k(b-z)ux-pinctrl.dtsi
@@ -253,6 +253,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l083c(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083c(b-z)tx-pinctrl.dtsi
@@ -385,6 +385,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l083czux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083czux-pinctrl.dtsi
@@ -385,6 +385,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l083r(b-z)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083r(b-z)hx-pinctrl.dtsi
@@ -452,6 +452,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd2: lpuart1_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l083r(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083r(b-z)tx-pinctrl.dtsi
@@ -465,6 +465,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd2: lpuart1_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l083v(b-z)ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083v(b-z)ix-pinctrl.dtsi
@@ -588,6 +588,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd2: lpuart1_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd12: lpuart1_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF0)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pe7: usart5_de_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l083v(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083v(b-z)tx-pinctrl.dtsi
@@ -588,6 +588,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd2: lpuart1_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd12: lpuart1_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF0)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pe7: usart5_de_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l083v8ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083v8ix-pinctrl.dtsi
@@ -588,6 +588,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd2: lpuart1_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd12: lpuart1_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF0)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pe7: usart5_de_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l0/stm32l083v8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083v8tx-pinctrl.dtsi
@@ -588,6 +588,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF5)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF2)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb14: lpuart1_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF4)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd2: lpuart1_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF0)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pd12: lpuart1_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF0)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF0)>;
+				drive-push-pull;
+			};
+
+			usart4_de_pa15: usart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pb5: usart5_de_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF6)>;
+				drive-push-pull;
+			};
+
+			usart5_de_pe7: usart5_de_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF6)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l412c8tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412c8tx-pinctrl.dtsi
@@ -463,6 +463,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l412c8ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412c8ux-pinctrl.dtsi
@@ -463,6 +463,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l412cbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412cbtx-pinctrl.dtsi
@@ -463,6 +463,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l412cbtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412cbtxp-pinctrl.dtsi
@@ -438,6 +438,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l412cbux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412cbux-pinctrl.dtsi
@@ -463,6 +463,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l412cbuxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412cbuxp-pinctrl.dtsi
@@ -438,6 +438,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l412k8tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412k8tx-pinctrl.dtsi
@@ -331,6 +331,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l412k8ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412k8ux-pinctrl.dtsi
@@ -331,6 +331,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l412kbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412kbtx-pinctrl.dtsi
@@ -331,6 +331,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l412kbux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412kbux-pinctrl.dtsi
@@ -331,6 +331,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l412r8ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412r8ix-pinctrl.dtsi
@@ -533,6 +533,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l412r8tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412r8tx-pinctrl.dtsi
@@ -533,6 +533,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l412rbix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412rbix-pinctrl.dtsi
@@ -533,6 +533,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l412rbixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412rbixp-pinctrl.dtsi
@@ -525,6 +525,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l412rbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412rbtx-pinctrl.dtsi
@@ -533,6 +533,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l412rbtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412rbtxp-pinctrl.dtsi
@@ -525,6 +525,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l412t8yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412t8yx-pinctrl.dtsi
@@ -350,6 +350,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l412tbyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412tbyx-pinctrl.dtsi
@@ -350,6 +350,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l412tbyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412tbyxp-pinctrl.dtsi
@@ -340,6 +340,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l422cbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422cbtx-pinctrl.dtsi
@@ -463,6 +463,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l422cbux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422cbux-pinctrl.dtsi
@@ -463,6 +463,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l422kbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422kbtx-pinctrl.dtsi
@@ -331,6 +331,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l422kbux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422kbux-pinctrl.dtsi
@@ -331,6 +331,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l422rbix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422rbix-pinctrl.dtsi
@@ -533,6 +533,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l422rbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422rbtx-pinctrl.dtsi
@@ -533,6 +533,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l422tbyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422tbyx-pinctrl.dtsi
@@ -350,6 +350,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l431c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431c(b-c)tx-pinctrl.dtsi
@@ -489,6 +489,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l431c(b-c)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431c(b-c)ux-pinctrl.dtsi
@@ -489,6 +489,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l431c(b-c)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431c(b-c)yx-pinctrl.dtsi
@@ -498,6 +498,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l431k(b-c)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431k(b-c)ux-pinctrl.dtsi
@@ -348,6 +348,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l431r(b-c)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431r(b-c)ix-pinctrl.dtsi
@@ -613,6 +613,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l431r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431r(b-c)tx-pinctrl.dtsi
@@ -613,6 +613,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l431r(b-c)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431r(b-c)yx-pinctrl.dtsi
@@ -613,6 +613,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l431vcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431vcix-pinctrl.dtsi
@@ -763,6 +763,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l431vctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431vctx-pinctrl.dtsi
@@ -763,6 +763,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l432k(b-c)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l432k(b-c)ux-pinctrl.dtsi
@@ -348,6 +348,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l433c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433c(b-c)tx-pinctrl.dtsi
@@ -489,6 +489,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l433c(b-c)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433c(b-c)ux-pinctrl.dtsi
@@ -489,6 +489,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l433c(b-c)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433c(b-c)yx-pinctrl.dtsi
@@ -498,6 +498,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l433r(b-c)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433r(b-c)ix-pinctrl.dtsi
@@ -613,6 +613,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l433r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433r(b-c)tx-pinctrl.dtsi
@@ -613,6 +613,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l433r(b-c)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433r(b-c)yx-pinctrl.dtsi
@@ -613,6 +613,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l433rctxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433rctxp-pinctrl.dtsi
@@ -547,6 +547,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l433vcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433vcix-pinctrl.dtsi
@@ -763,6 +763,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l433vctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433vctx-pinctrl.dtsi
@@ -763,6 +763,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l442kcux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l442kcux-pinctrl.dtsi
@@ -348,6 +348,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l443cctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443cctx-pinctrl.dtsi
@@ -489,6 +489,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l443ccux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443ccux-pinctrl.dtsi
@@ -489,6 +489,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l443ccyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443ccyx-pinctrl.dtsi
@@ -498,6 +498,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l443rcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443rcix-pinctrl.dtsi
@@ -613,6 +613,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l443rctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443rctx-pinctrl.dtsi
@@ -613,6 +613,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l443rcyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443rcyx-pinctrl.dtsi
@@ -613,6 +613,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l443vcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443vcix-pinctrl.dtsi
@@ -763,6 +763,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l443vctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443vctx-pinctrl.dtsi
@@ -763,6 +763,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l451c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451c(c-e)ux-pinctrl.dtsi
@@ -557,6 +557,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l451cetx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451cetx-pinctrl.dtsi
@@ -557,6 +557,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l451r(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451r(c-e)ix-pinctrl.dtsi
@@ -709,6 +709,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l451r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451r(c-e)tx-pinctrl.dtsi
@@ -709,6 +709,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l451r(c-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451r(c-e)yx-pinctrl.dtsi
@@ -709,6 +709,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l451v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451v(c-e)ix-pinctrl.dtsi
@@ -887,6 +887,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l451v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451v(c-e)tx-pinctrl.dtsi
@@ -887,6 +887,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l452c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452c(c-e)ux-pinctrl.dtsi
@@ -557,6 +557,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l452cetx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452cetx-pinctrl.dtsi
@@ -557,6 +557,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l452r(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452r(c-e)ix-pinctrl.dtsi
@@ -709,6 +709,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l452r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452r(c-e)tx-pinctrl.dtsi
@@ -709,6 +709,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l452r(c-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452r(c-e)yx-pinctrl.dtsi
@@ -709,6 +709,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l452retxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452retxp-pinctrl.dtsi
@@ -643,6 +643,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l452v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452v(c-e)ix-pinctrl.dtsi
@@ -887,6 +887,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l452v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452v(c-e)tx-pinctrl.dtsi
@@ -887,6 +887,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l462cetx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462cetx-pinctrl.dtsi
@@ -557,6 +557,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l462ceux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462ceux-pinctrl.dtsi
@@ -557,6 +557,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l462reix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462reix-pinctrl.dtsi
@@ -709,6 +709,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l462retx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462retx-pinctrl.dtsi
@@ -709,6 +709,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l462reyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462reyx-pinctrl.dtsi
@@ -709,6 +709,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l462veix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462veix-pinctrl.dtsi
@@ -887,6 +887,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l462vetx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462vetx-pinctrl.dtsi
@@ -887,6 +887,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l471q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471q(e-g)ix-pinctrl.dtsi
@@ -1363,6 +1363,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l471r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471r(e-g)tx-pinctrl.dtsi
@@ -768,6 +768,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l471v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471v(e-g)tx-pinctrl.dtsi
@@ -1123,6 +1123,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l471z(e-g)jx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471z(e-g)jx-pinctrl.dtsi
@@ -1407,6 +1407,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l471z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471z(e-g)tx-pinctrl.dtsi
@@ -1407,6 +1407,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l475r(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l475r(c-e-g)tx-pinctrl.dtsi
@@ -768,6 +768,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l475v(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l475v(c-e-g)tx-pinctrl.dtsi
@@ -1123,6 +1123,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l476j(e-g)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476j(e-g)yx-pinctrl.dtsi
@@ -819,6 +819,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l476jgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476jgyxp-pinctrl.dtsi
@@ -796,6 +796,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l476m(e-g)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476m(e-g)yx-pinctrl.dtsi
@@ -828,6 +828,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l476q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476q(e-g)ix-pinctrl.dtsi
@@ -1363,6 +1363,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l476r(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476r(c-e-g)tx-pinctrl.dtsi
@@ -768,6 +768,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l476v(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476v(c-e-g)tx-pinctrl.dtsi
@@ -1123,6 +1123,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l476z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476z(e-g)tx-pinctrl.dtsi
@@ -1407,6 +1407,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l476zgjx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476zgjx-pinctrl.dtsi
@@ -1407,6 +1407,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l476zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476zgtxp-pinctrl.dtsi
@@ -1392,6 +1392,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l485j(c-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l485j(c-e)yx-pinctrl.dtsi
@@ -819,6 +819,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l486jgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486jgyx-pinctrl.dtsi
@@ -819,6 +819,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l486qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486qgix-pinctrl.dtsi
@@ -1363,6 +1363,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l486rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486rgtx-pinctrl.dtsi
@@ -768,6 +768,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l486vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486vgtx-pinctrl.dtsi
@@ -1123,6 +1123,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l486zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486zgtx-pinctrl.dtsi
@@ -1407,6 +1407,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l496a(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496a(e-g)ix-pinctrl.dtsi
@@ -1696,6 +1696,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l496agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496agixp-pinctrl.dtsi
@@ -1692,6 +1692,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l496q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496q(e-g)ix-pinctrl.dtsi
@@ -1580,6 +1580,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l496qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496qgixp-pinctrl.dtsi
@@ -1547,6 +1547,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l496r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496r(e-g)tx-pinctrl.dtsi
@@ -913,6 +913,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l496rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496rgtxp-pinctrl.dtsi
@@ -843,6 +843,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l496v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496v(e-g)tx-pinctrl.dtsi
@@ -1316,6 +1316,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l496vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgtxp-pinctrl.dtsi
@@ -1285,6 +1285,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l496vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgyx-pinctrl.dtsi
@@ -1269,6 +1269,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l496vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgyxp-pinctrl.dtsi
@@ -1261,6 +1261,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l496wgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496wgyxp-pinctrl.dtsi
@@ -1350,6 +1350,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l496z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496z(e-g)tx-pinctrl.dtsi
@@ -1649,6 +1649,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l496zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496zgtxp-pinctrl.dtsi
@@ -1628,6 +1628,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4a6agix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6agix-pinctrl.dtsi
@@ -1696,6 +1696,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4a6agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6agixp-pinctrl.dtsi
@@ -1692,6 +1692,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4a6qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6qgix-pinctrl.dtsi
@@ -1580,6 +1580,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4a6qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6qgixp-pinctrl.dtsi
@@ -1547,6 +1547,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4a6rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6rgtx-pinctrl.dtsi
@@ -913,6 +913,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4a6rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6rgtxp-pinctrl.dtsi
@@ -899,6 +899,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4a6vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgtx-pinctrl.dtsi
@@ -1316,6 +1316,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4a6vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgtxp-pinctrl.dtsi
@@ -1285,6 +1285,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4a6vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgyx-pinctrl.dtsi
@@ -1269,6 +1269,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4a6vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgyxp-pinctrl.dtsi
@@ -1261,6 +1261,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4a6zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6zgtx-pinctrl.dtsi
@@ -1649,6 +1649,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4a6zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6zgtxp-pinctrl.dtsi
@@ -1628,6 +1628,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4p5a(g-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5a(g-e)ix-pinctrl.dtsi
@@ -1892,6 +1892,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4p5agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5agixp-pinctrl.dtsi
@@ -1888,6 +1888,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4p5c(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5c(g-e)tx-pinctrl.dtsi
@@ -711,6 +711,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4p5c(g-e)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5c(g-e)ux-pinctrl.dtsi
@@ -711,6 +711,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4p5cgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5cgtxp-pinctrl.dtsi
@@ -662,6 +662,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4p5cguxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5cguxp-pinctrl.dtsi
@@ -662,6 +662,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4p5q(g-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5q(g-e)ix-pinctrl.dtsi
@@ -1790,6 +1790,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4p5qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5qgixp-pinctrl.dtsi
@@ -1754,6 +1754,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4p5r(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5r(g-e)tx-pinctrl.dtsi
@@ -972,6 +972,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4p5rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5rgtxp-pinctrl.dtsi
@@ -954,6 +954,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4p5v(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5v(g-e)tx-pinctrl.dtsi
@@ -1458,6 +1458,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4p5v(g-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5v(g-e)yx-pinctrl.dtsi
@@ -1438,6 +1438,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4p5vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5vgtxp-pinctrl.dtsi
@@ -1424,6 +1424,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4p5vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5vgyxp-pinctrl.dtsi
@@ -1426,6 +1426,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4p5z(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5z(g-e)tx-pinctrl.dtsi
@@ -1814,6 +1814,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4p5zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5zgtxp-pinctrl.dtsi
@@ -1794,6 +1794,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4q5agix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5agix-pinctrl.dtsi
@@ -1892,6 +1892,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4q5agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5agixp-pinctrl.dtsi
@@ -1888,6 +1888,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4q5cgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5cgtx-pinctrl.dtsi
@@ -711,6 +711,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4q5cgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5cgtxp-pinctrl.dtsi
@@ -662,6 +662,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4q5cgux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5cgux-pinctrl.dtsi
@@ -711,6 +711,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4q5cguxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5cguxp-pinctrl.dtsi
@@ -662,6 +662,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4q5qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5qgix-pinctrl.dtsi
@@ -1790,6 +1790,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4q5qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5qgixp-pinctrl.dtsi
@@ -1754,6 +1754,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4q5rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5rgtx-pinctrl.dtsi
@@ -972,6 +972,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4q5rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5rgtxp-pinctrl.dtsi
@@ -954,6 +954,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4q5vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgtx-pinctrl.dtsi
@@ -1458,6 +1458,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4q5vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgtxp-pinctrl.dtsi
@@ -1424,6 +1424,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4q5vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgyx-pinctrl.dtsi
@@ -1438,6 +1438,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4q5vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgyxp-pinctrl.dtsi
@@ -1426,6 +1426,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4q5zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5zgtx-pinctrl.dtsi
@@ -1814,6 +1814,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4q5zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5zgtxp-pinctrl.dtsi
@@ -1794,6 +1794,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4r5a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5a(g-i)ix-pinctrl.dtsi
@@ -1468,6 +1468,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4r5q(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5q(g-i)ix-pinctrl.dtsi
@@ -1366,6 +1366,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4r5v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5v(g-i)tx-pinctrl.dtsi
@@ -1114,6 +1114,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4r5z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5z(g-i)tx-pinctrl.dtsi
@@ -1390,6 +1390,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4r5z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5z(g-i)yx-pinctrl.dtsi
@@ -1351,6 +1351,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4r5zitxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5zitxp-pinctrl.dtsi
@@ -1374,6 +1374,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4r7aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7aiix-pinctrl.dtsi
@@ -1626,6 +1626,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4r7vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7vitx-pinctrl.dtsi
@@ -1240,6 +1240,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4r7zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7zitx-pinctrl.dtsi
@@ -1548,6 +1548,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4r9a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9a(g-i)ix-pinctrl.dtsi
@@ -1600,6 +1600,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4r9v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9v(g-i)tx-pinctrl.dtsi
@@ -1150,6 +1150,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4r9z(g-i)jx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)jx-pinctrl.dtsi
@@ -1517,6 +1517,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4r9z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)tx-pinctrl.dtsi
@@ -1500,6 +1500,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4r9z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)yx-pinctrl.dtsi
@@ -1505,6 +1505,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4r9ziyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9ziyxp-pinctrl.dtsi
@@ -1473,6 +1473,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4s5aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5aiix-pinctrl.dtsi
@@ -1468,6 +1468,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4s5qiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5qiix-pinctrl.dtsi
@@ -1366,6 +1366,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4s5vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5vitx-pinctrl.dtsi
@@ -1114,6 +1114,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4s5zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5zitx-pinctrl.dtsi
@@ -1390,6 +1390,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4s5ziyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5ziyx-pinctrl.dtsi
@@ -1351,6 +1351,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4s7aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7aiix-pinctrl.dtsi
@@ -1626,6 +1626,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4s7vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7vitx-pinctrl.dtsi
@@ -1240,6 +1240,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4s7zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7zitx-pinctrl.dtsi
@@ -1548,6 +1548,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4s9aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9aiix-pinctrl.dtsi
@@ -1600,6 +1600,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4s9vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9vitx-pinctrl.dtsi
@@ -1150,6 +1150,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4s9zijx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9zijx-pinctrl.dtsi
@@ -1517,6 +1517,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4s9zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9zitx-pinctrl.dtsi
@@ -1500,6 +1500,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l4/stm32l4s9ziyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9ziyx-pinctrl.dtsi
@@ -1505,6 +1505,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l552c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552c(c-e)tx-pinctrl.dtsi
@@ -601,6 +601,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l552c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552c(c-e)ux-pinctrl.dtsi
@@ -601,6 +601,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l552cetxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552cetxp-pinctrl.dtsi
@@ -562,6 +562,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l552ceuxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552ceuxp-pinctrl.dtsi
@@ -562,6 +562,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l552meyxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552meyxp-pinctrl.dtsi
@@ -889,6 +889,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l552meyxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552meyxq-pinctrl.dtsi
@@ -865,6 +865,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l552q(c-e)ixq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552q(c-e)ixq-pinctrl.dtsi
@@ -1388,6 +1388,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l552qeix-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552qeix-pinctrl.dtsi
@@ -1427,6 +1427,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l552qeixp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552qeixp-pinctrl.dtsi
@@ -1412,6 +1412,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l552r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552r(c-e)tx-pinctrl.dtsi
@@ -822,6 +822,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l552retxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552retxp-pinctrl.dtsi
@@ -722,6 +722,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l552retxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552retxq-pinctrl.dtsi
@@ -750,6 +750,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l552v(c-e)txq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552v(c-e)txq-pinctrl.dtsi
@@ -1144,6 +1144,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l552vetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552vetx-pinctrl.dtsi
@@ -1175,6 +1175,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l552z(c-e)txq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552z(c-e)txq-pinctrl.dtsi
@@ -1415,6 +1415,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l552zetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552zetx-pinctrl.dtsi
@@ -1451,6 +1451,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l562cetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562cetx-pinctrl.dtsi
@@ -601,6 +601,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l562cetxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562cetxp-pinctrl.dtsi
@@ -562,6 +562,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l562ceux-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562ceux-pinctrl.dtsi
@@ -601,6 +601,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l562ceuxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562ceuxp-pinctrl.dtsi
@@ -562,6 +562,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l562meyxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562meyxp-pinctrl.dtsi
@@ -889,6 +889,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l562meyxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562meyxq-pinctrl.dtsi
@@ -865,6 +865,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l562qeix-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeix-pinctrl.dtsi
@@ -1427,6 +1427,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l562qeixp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeixp-pinctrl.dtsi
@@ -1412,6 +1412,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l562qeixq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeixq-pinctrl.dtsi
@@ -1388,6 +1388,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l562retx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562retx-pinctrl.dtsi
@@ -822,6 +822,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l562retxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562retxp-pinctrl.dtsi
@@ -722,6 +722,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l562retxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562retxq-pinctrl.dtsi
@@ -750,6 +750,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l562vetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562vetx-pinctrl.dtsi
@@ -1175,6 +1175,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l562vetxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562vetxq-pinctrl.dtsi
@@ -1144,6 +1144,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l562zetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562zetx-pinctrl.dtsi
@@ -1451,6 +1451,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/l5/stm32l562zetxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562zetxq-pinctrl.dtsi
@@ -1415,6 +1415,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp151aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aaax-pinctrl.dtsi
@@ -3007,6 +3007,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pz5: usart1_de_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp151aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aabx-pinctrl.dtsi
@@ -2139,6 +2139,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp151aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aacx-pinctrl.dtsi
@@ -2802,6 +2802,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pz5: usart1_de_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp151aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aadx-pinctrl.dtsi
@@ -2139,6 +2139,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp151caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151caax-pinctrl.dtsi
@@ -3007,6 +3007,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pz5: usart1_de_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp151cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cabx-pinctrl.dtsi
@@ -2139,6 +2139,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp151cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cacx-pinctrl.dtsi
@@ -2802,6 +2802,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pz5: usart1_de_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp151cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cadx-pinctrl.dtsi
@@ -2139,6 +2139,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp151daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151daax-pinctrl.dtsi
@@ -3007,6 +3007,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pz5: usart1_de_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp151dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dabx-pinctrl.dtsi
@@ -2139,6 +2139,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp151dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dacx-pinctrl.dtsi
@@ -2802,6 +2802,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pz5: usart1_de_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp151dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dadx-pinctrl.dtsi
@@ -2139,6 +2139,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp151faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151faax-pinctrl.dtsi
@@ -3007,6 +3007,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pz5: usart1_de_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp151fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151fabx-pinctrl.dtsi
@@ -2139,6 +2139,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp151facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151facx-pinctrl.dtsi
@@ -2802,6 +2802,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pz5: usart1_de_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp151fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151fadx-pinctrl.dtsi
@@ -2139,6 +2139,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp153aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aaax-pinctrl.dtsi
@@ -3063,6 +3063,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pz5: usart1_de_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp153aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aabx-pinctrl.dtsi
@@ -2183,6 +2183,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp153aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aacx-pinctrl.dtsi
@@ -2858,6 +2858,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pz5: usart1_de_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp153aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aadx-pinctrl.dtsi
@@ -2183,6 +2183,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp153caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153caax-pinctrl.dtsi
@@ -3063,6 +3063,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pz5: usart1_de_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp153cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cabx-pinctrl.dtsi
@@ -2183,6 +2183,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp153cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cacx-pinctrl.dtsi
@@ -2858,6 +2858,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pz5: usart1_de_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp153cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cadx-pinctrl.dtsi
@@ -2183,6 +2183,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp153daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153daax-pinctrl.dtsi
@@ -3063,6 +3063,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pz5: usart1_de_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp153dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dabx-pinctrl.dtsi
@@ -2183,6 +2183,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp153dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dacx-pinctrl.dtsi
@@ -2858,6 +2858,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pz5: usart1_de_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp153dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dadx-pinctrl.dtsi
@@ -2183,6 +2183,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp153faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153faax-pinctrl.dtsi
@@ -3063,6 +3063,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pz5: usart1_de_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp153fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153fabx-pinctrl.dtsi
@@ -2183,6 +2183,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp153facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153facx-pinctrl.dtsi
@@ -2858,6 +2858,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pz5: usart1_de_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp153fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153fadx-pinctrl.dtsi
@@ -2183,6 +2183,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp157aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aaax-pinctrl.dtsi
@@ -3063,6 +3063,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pz5: usart1_de_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp157aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aabx-pinctrl.dtsi
@@ -2183,6 +2183,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp157aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aacx-pinctrl.dtsi
@@ -2858,6 +2858,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pz5: usart1_de_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp157aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aadx-pinctrl.dtsi
@@ -2183,6 +2183,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp157caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157caax-pinctrl.dtsi
@@ -3063,6 +3063,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pz5: usart1_de_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp157cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cabx-pinctrl.dtsi
@@ -2183,6 +2183,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp157cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cacx-pinctrl.dtsi
@@ -2858,6 +2858,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pz5: usart1_de_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp157cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cadx-pinctrl.dtsi
@@ -2183,6 +2183,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp157daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157daax-pinctrl.dtsi
@@ -3063,6 +3063,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pz5: usart1_de_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp157dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dabx-pinctrl.dtsi
@@ -2183,6 +2183,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp157dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dacx-pinctrl.dtsi
@@ -2858,6 +2858,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pz5: usart1_de_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp157dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dadx-pinctrl.dtsi
@@ -2183,6 +2183,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp157faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157faax-pinctrl.dtsi
@@ -3063,6 +3063,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pz5: usart1_de_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp157fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157fabx-pinctrl.dtsi
@@ -2183,6 +2183,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp157facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157facx-pinctrl.dtsi
@@ -2858,6 +2858,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pz5: usart1_de_pz5 {
+				pinmux = <STM32_PINMUX('Z', 5, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/mp1/stm32mp157fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157fadx-pinctrl.dtsi
@@ -2183,6 +2183,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pg8: usart3_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pc8: uart5_de_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF8)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg8: usart6_de_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			usart6_de_pg12: usart6_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pe9: uart7_de_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF7)>;
+				drive-push-pull;
+			};
+
+			uart7_de_pf8: uart7_de_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF7)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pe14: uart8_de_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF8)>;
+				drive-push-pull;
+			};
+
+			uart8_de_pg7: uart8_de_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u575agix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575agix-pinctrl.dtsi
@@ -1676,6 +1676,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u575agixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575agixq-pinctrl.dtsi
@@ -1637,6 +1637,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u575aiix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575aiix-pinctrl.dtsi
@@ -1676,6 +1676,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u575aiixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575aiixq-pinctrl.dtsi
@@ -1637,6 +1637,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u575cgtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575cgtx-pinctrl.dtsi
@@ -583,6 +583,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u575cgtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575cgtxq-pinctrl.dtsi
@@ -525,6 +525,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u575cgux-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575cgux-pinctrl.dtsi
@@ -583,6 +583,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u575cguxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575cguxq-pinctrl.dtsi
@@ -525,6 +525,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u575citx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575citx-pinctrl.dtsi
@@ -583,6 +583,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u575citxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575citxq-pinctrl.dtsi
@@ -525,6 +525,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u575ciux-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575ciux-pinctrl.dtsi
@@ -583,6 +583,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u575ciuxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575ciuxq-pinctrl.dtsi
@@ -525,6 +525,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u575ogyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575ogyxq-pinctrl.dtsi
@@ -1104,6 +1104,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u575oiyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575oiyxq-pinctrl.dtsi
@@ -1104,6 +1104,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u575qgix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575qgix-pinctrl.dtsi
@@ -1543,6 +1543,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u575qgixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575qgixq-pinctrl.dtsi
@@ -1504,6 +1504,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u575qiix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575qiix-pinctrl.dtsi
@@ -1543,6 +1543,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u575qiixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575qiixq-pinctrl.dtsi
@@ -1504,6 +1504,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u575rgtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575rgtx-pinctrl.dtsi
@@ -868,6 +868,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u575rgtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575rgtxq-pinctrl.dtsi
@@ -802,6 +802,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u575ritx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575ritx-pinctrl.dtsi
@@ -868,6 +868,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u575ritxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575ritxq-pinctrl.dtsi
@@ -802,6 +802,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u575vgtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575vgtx-pinctrl.dtsi
@@ -1259,6 +1259,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u575vgtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575vgtxq-pinctrl.dtsi
@@ -1240,6 +1240,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u575vitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575vitx-pinctrl.dtsi
@@ -1259,6 +1259,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u575vitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575vitxq-pinctrl.dtsi
@@ -1240,6 +1240,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u575zgtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575zgtx-pinctrl.dtsi
@@ -1559,6 +1559,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u575zgtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575zgtxq-pinctrl.dtsi
@@ -1535,6 +1535,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u575zitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575zitx-pinctrl.dtsi
@@ -1559,6 +1559,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u575zitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575zitxq-pinctrl.dtsi
@@ -1535,6 +1535,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u585aiix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585aiix-pinctrl.dtsi
@@ -1676,6 +1676,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u585aiixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585aiixq-pinctrl.dtsi
@@ -1637,6 +1637,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u585citx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585citx-pinctrl.dtsi
@@ -583,6 +583,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u585citxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585citxq-pinctrl.dtsi
@@ -525,6 +525,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u585ciux-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585ciux-pinctrl.dtsi
@@ -583,6 +583,53 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u585ciuxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585ciuxq-pinctrl.dtsi
@@ -525,6 +525,48 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u585oiyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585oiyxq-pinctrl.dtsi
@@ -1104,6 +1104,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u585qeixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585qeixq-pinctrl.dtsi
@@ -1504,6 +1504,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u585qiix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585qiix-pinctrl.dtsi
@@ -1543,6 +1543,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u585ritx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585ritx-pinctrl.dtsi
@@ -868,6 +868,63 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u585ritxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585ritxq-pinctrl.dtsi
@@ -802,6 +802,58 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u585vitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585vitx-pinctrl.dtsi
@@ -1259,6 +1259,73 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u585vitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585vitxq-pinctrl.dtsi
@@ -1240,6 +1240,68 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u585zetxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585zetxq-pinctrl.dtsi
@@ -1535,6 +1535,78 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/u5/stm32u585zitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585zitx-pinctrl.dtsi
@@ -1559,6 +1559,83 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pg6: lpuart1_de_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pg12: usart1_de_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pd4: usart2_de_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pa15: usart3_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb1: usart3_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pb14: usart3_de_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd2: usart3_de_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, AF7)>;
+				drive-push-pull;
+			};
+
+			usart3_de_pd12: usart3_de_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			uart4_de_pa15: uart4_de_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, AF8)>;
+				drive-push-pull;
+			};
+
+			uart5_de_pb4: uart5_de_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/wb/stm32wb10ccux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb10ccux-pinctrl.dtsi
@@ -259,6 +259,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/wb/stm32wb15ccux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb15ccux-pinctrl.dtsi
@@ -265,6 +265,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/wb/stm32wb15ccuxe-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb15ccuxe-pinctrl.dtsi
@@ -281,6 +281,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/wb/stm32wb15ccyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb15ccyx-pinctrl.dtsi
@@ -236,6 +236,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/wb/stm32wb30ceuxa-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb30ceuxa-pinctrl.dtsi
@@ -259,6 +259,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/wb/stm32wb35c(c-e)uxa-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb35c(c-e)uxa-pinctrl.dtsi
@@ -309,6 +309,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/wb/stm32wb50cgux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb50cgux-pinctrl.dtsi
@@ -259,6 +259,18 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/wb/stm32wb55ccux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55ccux-pinctrl.dtsi
@@ -309,6 +309,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/wb/stm32wb55ceux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55ceux-pinctrl.dtsi
@@ -309,6 +309,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/wb/stm32wb55cgux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55cgux-pinctrl.dtsi
@@ -309,6 +309,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/wb/stm32wb55rcvx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55rcvx-pinctrl.dtsi
@@ -469,6 +469,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/wb/stm32wb55revx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55revx-pinctrl.dtsi
@@ -469,6 +469,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/wb/stm32wb55rgvx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55rgvx-pinctrl.dtsi
@@ -469,6 +469,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/wb/stm32wb55vcqx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vcqx-pinctrl.dtsi
@@ -526,6 +526,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/wb/stm32wb55vcyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vcyx-pinctrl.dtsi
@@ -526,6 +526,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/wb/stm32wb55veqx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55veqx-pinctrl.dtsi
@@ -526,6 +526,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/wb/stm32wb55veyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55veyx-pinctrl.dtsi
@@ -526,6 +526,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/wb/stm32wb55vgqx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vgqx-pinctrl.dtsi
@@ -526,6 +526,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/wb/stm32wb55vgyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vgyx-pinctrl.dtsi
@@ -526,6 +526,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/wb/stm32wb55vyyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vyyx-pinctrl.dtsi
@@ -526,6 +526,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/wb/stm32wb5mmghx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb5mmghx-pinctrl.dtsi
@@ -526,6 +526,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb12: lpuart1_de_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF8)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			usart1_rts_pa12: usart1_rts_pa12 {

--- a/dts/st/wl/stm32wl54ccux-pinctrl.dtsi
+++ b/dts/st/wl/stm32wl54ccux-pinctrl.dtsi
@@ -349,6 +349,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa1: lpuart1_rts_pa1 {

--- a/dts/st/wl/stm32wl54jcix-pinctrl.dtsi
+++ b/dts/st/wl/stm32wl54jcix-pinctrl.dtsi
@@ -511,6 +511,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa1: lpuart1_rts_pa1 {

--- a/dts/st/wl/stm32wl55ccux-pinctrl.dtsi
+++ b/dts/st/wl/stm32wl55ccux-pinctrl.dtsi
@@ -349,6 +349,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa1: lpuart1_rts_pa1 {

--- a/dts/st/wl/stm32wl55jcix-pinctrl.dtsi
+++ b/dts/st/wl/stm32wl55jcix-pinctrl.dtsi
@@ -511,6 +511,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa1: lpuart1_rts_pa1 {

--- a/dts/st/wl/stm32wl55ucyx-pinctrl.dtsi
+++ b/dts/st/wl/stm32wl55ucyx-pinctrl.dtsi
@@ -292,6 +292,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa1: lpuart1_rts_pa1 {

--- a/dts/st/wl/stm32wle4c8ux-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle4c8ux-pinctrl.dtsi
@@ -349,6 +349,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa1: lpuart1_rts_pa1 {

--- a/dts/st/wl/stm32wle4cbux-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle4cbux-pinctrl.dtsi
@@ -349,6 +349,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa1: lpuart1_rts_pa1 {

--- a/dts/st/wl/stm32wle4ccux-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle4ccux-pinctrl.dtsi
@@ -349,6 +349,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa1: lpuart1_rts_pa1 {

--- a/dts/st/wl/stm32wle4j8ix-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle4j8ix-pinctrl.dtsi
@@ -511,6 +511,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa1: lpuart1_rts_pa1 {

--- a/dts/st/wl/stm32wle4jbix-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle4jbix-pinctrl.dtsi
@@ -511,6 +511,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa1: lpuart1_rts_pa1 {

--- a/dts/st/wl/stm32wle4jcix-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle4jcix-pinctrl.dtsi
@@ -511,6 +511,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa1: lpuart1_rts_pa1 {

--- a/dts/st/wl/stm32wle5c8ux-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle5c8ux-pinctrl.dtsi
@@ -349,6 +349,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa1: lpuart1_rts_pa1 {

--- a/dts/st/wl/stm32wle5cbux-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle5cbux-pinctrl.dtsi
@@ -349,6 +349,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa1: lpuart1_rts_pa1 {

--- a/dts/st/wl/stm32wle5ccux-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle5ccux-pinctrl.dtsi
@@ -349,6 +349,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa1: lpuart1_rts_pa1 {

--- a/dts/st/wl/stm32wle5j8ix-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle5j8ix-pinctrl.dtsi
@@ -511,6 +511,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa1: lpuart1_rts_pa1 {

--- a/dts/st/wl/stm32wle5jbix-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle5jbix-pinctrl.dtsi
@@ -511,6 +511,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa1: lpuart1_rts_pa1 {

--- a/dts/st/wl/stm32wle5jcix-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle5jcix-pinctrl.dtsi
@@ -511,6 +511,28 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			lpuart1_de_pb1: lpuart1_de_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF8)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa1: lpuart1_rts_pa1 {

--- a/dts/st/wl/stm32wle5u8yx-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle5u8yx-pinctrl.dtsi
@@ -292,6 +292,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa1: lpuart1_rts_pa1 {

--- a/dts/st/wl/stm32wle5ubyx-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle5ubyx-pinctrl.dtsi
@@ -292,6 +292,23 @@
 				drive-open-drain;
 			};
 
+			/* UART_DE / USART_DE / LPUART_DE */
+
+			usart1_de_pa12: usart1_de_pa12 {
+				pinmux = <STM32_PINMUX('A', 12, AF7)>;
+				drive-push-pull;
+			};
+
+			usart1_de_pb3: usart1_de_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF7)>;
+				drive-push-pull;
+			};
+
+			usart2_de_pa1: usart2_de_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/* UART_RTS / USART_RTS / LPUART_RTS */
 
 			lpuart1_rts_pa1: lpuart1_rts_pa1 {

--- a/scripts/genpinctrl/stm32-pinctrl-config.yaml
+++ b/scripts/genpinctrl/stm32-pinctrl-config.yaml
@@ -219,6 +219,10 @@
   drive: open-drain
   bias: pull-up
 
+- name: UART_DE / USART_DE / LPUART_DE
+  match: "^(?:LP)?US?ART\\d+_DE$"
+  drive: push-pull
+
 - name: UART_TX / USART_TX / LPUART_TX
   match: "^(?:LP)?US?ART\\d+_TX$"
   bias: pull-up


### PR DESCRIPTION
Updated generation script to provide de (Driver Enable) pin configurations.
The driver enable pin is used for RS-485 and IO-Link communications with the STM32 USART.

There is an ongoing https://github.com/zephyrproject-rtos/zephyr/pull/40907 (RS-485 API PR) and #131 is required to provide RS-484 STM32 implementation.