### PR TITLE
stm32WL gives the right parameter to LL __LL_RCC_CALC_MSI_FREQ

### DIFF
--- a/stm32cube/stm32wlxx/drivers/src/stm32wlxx_ll_utils.c
+++ b/stm32cube/stm32wlxx/drivers/src/stm32wlxx_ll_utils.c
@@ -386,7 +386,7 @@ ErrorStatus LL_PLL_ConfigSystemClock_MSI(LL_UTILS_PLLInitTypeDef *UTILS_PLLInitS
   if (UTILS_PLL_IsBusy() == SUCCESS)
   {
     /* Get the current MSI range */
-    if (LL_RCC_MSI_IsEnabledRangeSelect()  == 0U)
+    if (LL_RCC_MSI_IsEnabledRangeSelect()  != 0U)
     {
       msi_range =  LL_RCC_MSI_GetRange();
       switch (msi_range)


### PR DESCRIPTION
The __LL_RCC_CALC_MSI_FREQ expects MSISEL param to be
LL_RCC_MSIRANGESEL_STANDBY or LL_RCC_MSIRANGESEL_RUN
which is not the value that  LL_RCC_MSI_IsEnabledRangeSelect returns.

The return code from LL_RCC_MSI_IsEnabledRangeSelect is 1 or 0 and the parameter of the __LL_RCC_CALC_MSI_FREQ
is expected to be LL_RCC_MSIRANGESEL_STANDBY or LL_RCC_MSIRANGESEL_RUN
Because of wrong MSIRangeTable entry, the calculated **pllrfreq** is not the right value

Signed-off-by: Francois Ramu <francois.ramu@st.com>