### PR TITLE
scripts: dependencies: do not specify any version and update tested Python versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v1
       - name: Set up Python

--- a/scripts/requirements-test.txt
+++ b/scripts/requirements-test.txt
@@ -1,3 +1,3 @@
-pytest~=6.0
-pytest-cov~=2.10
-pytest-mock~=3.3
+pytest
+pytest-cov
+pytest-mock

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,2 +1,2 @@
-Jinja2~=2.11
-pyyaml~=5.3
+Jinja2
+pyyaml


### PR DESCRIPTION
Allow for more flexibility when it comes to dependencies. The scripts do
not have any strong dependency or known compatibility issues, so do not
specify any version. This means the latest version will be downloaded.
If anything comes up, scripts can always be updated or versions until
scripts are updated.

Update Python versions tested on CI as well.