### PR TITLE
Add FMC bank address pinctrl

### DIFF
--- a/dts/st/f4/stm32f427a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427a(g-i)hx-pinctrl.dtsi
@@ -1272,7 +1272,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f427i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427i(g-i)hx-pinctrl.dtsi
@@ -1344,7 +1344,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f427i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427i(g-i)tx-pinctrl.dtsi
@@ -1344,7 +1344,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f427z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427z(g-i)tx-pinctrl.dtsi
@@ -1206,7 +1206,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f429a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429a(g-i)hx-pinctrl.dtsi
@@ -1272,7 +1272,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f429b(e-g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429b(e-g-i)tx-pinctrl.dtsi
@@ -1456,7 +1456,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f429i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429i(e-g)tx-pinctrl.dtsi
@@ -1344,7 +1344,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f429i(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429i(e-g-i)hx-pinctrl.dtsi
@@ -1344,7 +1344,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f429iitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429iitx-pinctrl.dtsi
@@ -1344,7 +1344,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f429n(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429n(e-g)hx-pinctrl.dtsi
@@ -1456,7 +1456,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f429nihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429nihx-pinctrl.dtsi
@@ -1456,7 +1456,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f429z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429z(e-g)tx-pinctrl.dtsi
@@ -1206,7 +1206,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f429zgyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429zgyx-pinctrl.dtsi
@@ -1206,7 +1206,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f429zitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429zitx-pinctrl.dtsi
@@ -1206,7 +1206,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f429ziyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429ziyx-pinctrl.dtsi
@@ -1206,7 +1206,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f437aihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437aihx-pinctrl.dtsi
@@ -1272,7 +1272,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f437i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437i(g-i)hx-pinctrl.dtsi
@@ -1344,7 +1344,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f437i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437i(g-i)tx-pinctrl.dtsi
@@ -1344,7 +1344,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f437z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437z(g-i)tx-pinctrl.dtsi
@@ -1206,7 +1206,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f439aihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439aihx-pinctrl.dtsi
@@ -1272,7 +1272,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f439b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439b(g-i)tx-pinctrl.dtsi
@@ -1456,7 +1456,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f439i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439i(g-i)hx-pinctrl.dtsi
@@ -1344,7 +1344,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f439i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439i(g-i)tx-pinctrl.dtsi
@@ -1344,7 +1344,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f439n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439n(g-i)hx-pinctrl.dtsi
@@ -1456,7 +1456,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f439z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439z(g-i)tx-pinctrl.dtsi
@@ -1206,7 +1206,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f439z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439z(g-i)yx-pinctrl.dtsi
@@ -1206,7 +1206,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f446z(c-e)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)hx-pinctrl.dtsi
@@ -1059,7 +1059,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f446z(c-e)jx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)jx-pinctrl.dtsi
@@ -1059,7 +1059,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f446z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)tx-pinctrl.dtsi
@@ -1059,7 +1059,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f469a(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469a(e-g-i)hx-pinctrl.dtsi
@@ -1038,7 +1038,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f469a(e-g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469a(e-g-i)yx-pinctrl.dtsi
@@ -1038,7 +1038,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f469b(e-g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469b(e-g-i)tx-pinctrl.dtsi
@@ -1432,7 +1432,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f469i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469i(e-g)tx-pinctrl.dtsi
@@ -1316,7 +1316,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f469i(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469i(e-g-i)hx-pinctrl.dtsi
@@ -1316,7 +1316,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f469iitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469iitx-pinctrl.dtsi
@@ -1316,7 +1316,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f469n(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469n(e-g)hx-pinctrl.dtsi
@@ -1432,7 +1432,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f469nihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469nihx-pinctrl.dtsi
@@ -1432,7 +1432,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f469z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469z(e-g)tx-pinctrl.dtsi
@@ -993,7 +993,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f469zitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469zitx-pinctrl.dtsi
@@ -993,7 +993,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f479a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479a(g-i)hx-pinctrl.dtsi
@@ -1038,7 +1038,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f479a(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479a(g-i)yx-pinctrl.dtsi
@@ -1038,7 +1038,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f479b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479b(g-i)tx-pinctrl.dtsi
@@ -1432,7 +1432,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f479i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479i(g-i)hx-pinctrl.dtsi
@@ -1316,7 +1316,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f479i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479i(g-i)tx-pinctrl.dtsi
@@ -1316,7 +1316,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f479n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479n(g-i)hx-pinctrl.dtsi
@@ -1432,7 +1432,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f4/stm32f479z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479z(g-i)tx-pinctrl.dtsi
@@ -993,7 +993,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f722i(c-e)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722i(c-e)kx-pinctrl.dtsi
@@ -1159,7 +1159,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f722i(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722i(c-e)tx-pinctrl.dtsi
@@ -1159,7 +1159,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f722z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722z(c-e)tx-pinctrl.dtsi
@@ -1041,7 +1041,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f723i(c-e)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723i(c-e)kx-pinctrl.dtsi
@@ -1151,7 +1151,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f723i(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723i(c-e)tx-pinctrl.dtsi
@@ -1151,7 +1151,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f723z(c-e)ix-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723z(c-e)ix-pinctrl.dtsi
@@ -1033,7 +1033,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f723z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723z(c-e)tx-pinctrl.dtsi
@@ -1033,7 +1033,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f730i8kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730i8kx-pinctrl.dtsi
@@ -1151,7 +1151,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f730z8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730z8tx-pinctrl.dtsi
@@ -1033,7 +1033,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f732iekx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732iekx-pinctrl.dtsi
@@ -1159,7 +1159,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f732ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732ietx-pinctrl.dtsi
@@ -1159,7 +1159,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f732zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732zetx-pinctrl.dtsi
@@ -1041,7 +1041,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f733iekx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733iekx-pinctrl.dtsi
@@ -1151,7 +1151,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f733ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733ietx-pinctrl.dtsi
@@ -1151,7 +1151,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f733zeix-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733zeix-pinctrl.dtsi
@@ -1033,7 +1033,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f733zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733zetx-pinctrl.dtsi
@@ -1033,7 +1033,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f745i(e-g)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745i(e-g)kx-pinctrl.dtsi
@@ -1362,7 +1362,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f745i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745i(e-g)tx-pinctrl.dtsi
@@ -1362,7 +1362,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f745z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745z(e-g)tx-pinctrl.dtsi
@@ -1224,7 +1224,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f746b(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746b(e-g)tx-pinctrl.dtsi
@@ -1474,7 +1474,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f746i(e-g)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746i(e-g)kx-pinctrl.dtsi
@@ -1362,7 +1362,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f746ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746ietx-pinctrl.dtsi
@@ -1362,7 +1362,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f746igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746igtx-pinctrl.dtsi
@@ -1362,7 +1362,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f746nehx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746nehx-pinctrl.dtsi
@@ -1474,7 +1474,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f746nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746nghx-pinctrl.dtsi
@@ -1474,7 +1474,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f746z(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746z(e-g)yx-pinctrl.dtsi
@@ -1224,7 +1224,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f746zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746zetx-pinctrl.dtsi
@@ -1224,7 +1224,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f746zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746zgtx-pinctrl.dtsi
@@ -1224,7 +1224,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f750n8hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750n8hx-pinctrl.dtsi
@@ -1474,7 +1474,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f750z8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750z8tx-pinctrl.dtsi
@@ -1224,7 +1224,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f756bgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756bgtx-pinctrl.dtsi
@@ -1474,7 +1474,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f756igkx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756igkx-pinctrl.dtsi
@@ -1362,7 +1362,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f756igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756igtx-pinctrl.dtsi
@@ -1362,7 +1362,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f756nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756nghx-pinctrl.dtsi
@@ -1474,7 +1474,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f756zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756zgtx-pinctrl.dtsi
@@ -1224,7 +1224,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f756zgyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756zgyx-pinctrl.dtsi
@@ -1224,7 +1224,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f765b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765b(g-i)tx-pinctrl.dtsi
@@ -1521,7 +1521,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f765i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765i(g-i)kx-pinctrl.dtsi
@@ -1409,7 +1409,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f765i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765i(g-i)tx-pinctrl.dtsi
@@ -1409,7 +1409,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f765n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765n(g-i)hx-pinctrl.dtsi
@@ -1521,7 +1521,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f765z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765z(g-i)tx-pinctrl.dtsi
@@ -1266,7 +1266,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f767b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767b(g-i)tx-pinctrl.dtsi
@@ -1521,7 +1521,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f767i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767i(g-i)kx-pinctrl.dtsi
@@ -1409,7 +1409,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f767i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767i(g-i)tx-pinctrl.dtsi
@@ -1409,7 +1409,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f767n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767n(g-i)hx-pinctrl.dtsi
@@ -1521,7 +1521,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f767zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767zgtx-pinctrl.dtsi
@@ -1266,7 +1266,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f767zitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767zitx-pinctrl.dtsi
@@ -1266,7 +1266,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f768aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f768aiyx-pinctrl.dtsi
@@ -1091,7 +1091,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f769a(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769a(g-i)yx-pinctrl.dtsi
@@ -1091,7 +1091,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f769b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769b(g-i)tx-pinctrl.dtsi
@@ -1485,7 +1485,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f769igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769igtx-pinctrl.dtsi
@@ -1364,7 +1364,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f769iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769iitx-pinctrl.dtsi
@@ -1364,7 +1364,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f769nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769nghx-pinctrl.dtsi
@@ -1485,7 +1485,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f769nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769nihx-pinctrl.dtsi
@@ -1485,7 +1485,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f777bitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777bitx-pinctrl.dtsi
@@ -1521,7 +1521,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f777iikx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777iikx-pinctrl.dtsi
@@ -1409,7 +1409,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f777iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777iitx-pinctrl.dtsi
@@ -1409,7 +1409,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f777nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777nihx-pinctrl.dtsi
@@ -1521,7 +1521,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f777zitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777zitx-pinctrl.dtsi
@@ -1266,7 +1266,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f778aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f778aiyx-pinctrl.dtsi
@@ -1091,7 +1091,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f779aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779aiyx-pinctrl.dtsi
@@ -1091,7 +1091,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f779bitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779bitx-pinctrl.dtsi
@@ -1485,7 +1485,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f779iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779iitx-pinctrl.dtsi
@@ -1364,7 +1364,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/f7/stm32f779nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779nihx-pinctrl.dtsi
@@ -1485,7 +1485,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h723zeix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zeix-pinctrl.dtsi
@@ -1418,7 +1418,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h723zetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zetx-pinctrl.dtsi
@@ -1390,7 +1390,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h723zgix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zgix-pinctrl.dtsi
@@ -1418,7 +1418,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h723zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zgtx-pinctrl.dtsi
@@ -1390,7 +1390,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h725aeix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725aeix-pinctrl.dtsi
@@ -1571,7 +1571,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h725agix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725agix-pinctrl.dtsi
@@ -1571,7 +1571,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h725iekx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725iekx-pinctrl.dtsi
@@ -1625,7 +1625,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h725ietx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725ietx-pinctrl.dtsi
@@ -1418,7 +1418,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h725igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725igkx-pinctrl.dtsi
@@ -1625,7 +1625,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h725igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725igtx-pinctrl.dtsi
@@ -1418,7 +1418,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h730abixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730abixq-pinctrl.dtsi
@@ -1571,7 +1571,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h730ibkxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730ibkxq-pinctrl.dtsi
@@ -1625,7 +1625,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h730ibtxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730ibtxq-pinctrl.dtsi
@@ -1418,7 +1418,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h730zbix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730zbix-pinctrl.dtsi
@@ -1418,7 +1418,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h730zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730zbtx-pinctrl.dtsi
@@ -1390,7 +1390,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h733zgix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733zgix-pinctrl.dtsi
@@ -1418,7 +1418,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h733zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733zgtx-pinctrl.dtsi
@@ -1390,7 +1390,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h735agix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735agix-pinctrl.dtsi
@@ -1571,7 +1571,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h735igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735igkx-pinctrl.dtsi
@@ -1625,7 +1625,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h735igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735igtx-pinctrl.dtsi
@@ -1418,7 +1418,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
@@ -1410,7 +1410,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
@@ -1581,7 +1581,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
@@ -1469,7 +1469,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
@@ -1469,7 +1469,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
@@ -1698,7 +1698,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
@@ -1300,7 +1300,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
@@ -1410,7 +1410,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
@@ -1581,7 +1581,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h743bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bitx-pinctrl.dtsi
@@ -1581,7 +1581,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h743igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igkx-pinctrl.dtsi
@@ -1469,7 +1469,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h743igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igtx-pinctrl.dtsi
@@ -1469,7 +1469,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h743iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iikx-pinctrl.dtsi
@@ -1469,7 +1469,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h743iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iitx-pinctrl.dtsi
@@ -1469,7 +1469,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h743xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xghx-pinctrl.dtsi
@@ -1698,7 +1698,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h743xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xihx-pinctrl.dtsi
@@ -1698,7 +1698,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
@@ -1300,7 +1300,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h743zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zitx-pinctrl.dtsi
@@ -1300,7 +1300,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
@@ -1509,7 +1509,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h745bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bitx-pinctrl.dtsi
@@ -1509,7 +1509,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h745igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igkx-pinctrl.dtsi
@@ -1529,7 +1529,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h745igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igtx-pinctrl.dtsi
@@ -1328,7 +1328,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h745iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iikx-pinctrl.dtsi
@@ -1529,7 +1529,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h745iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iitx-pinctrl.dtsi
@@ -1328,7 +1328,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h745xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xghx-pinctrl.dtsi
@@ -1698,7 +1698,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h745xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xihx-pinctrl.dtsi
@@ -1698,7 +1698,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
@@ -1300,7 +1300,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
@@ -1473,7 +1473,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h747bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bitx-pinctrl.dtsi
@@ -1473,7 +1473,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h747igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747igtx-pinctrl.dtsi
@@ -1300,7 +1300,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h747iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747iitx-pinctrl.dtsi
@@ -1300,7 +1300,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h747xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xghx-pinctrl.dtsi
@@ -1698,7 +1698,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h747xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xihx-pinctrl.dtsi
@@ -1698,7 +1698,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
@@ -1196,7 +1196,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
@@ -1469,7 +1469,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
@@ -1469,7 +1469,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
@@ -1698,7 +1698,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
@@ -1300,7 +1300,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h753aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753aiix-pinctrl.dtsi
@@ -1410,7 +1410,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h753bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753bitx-pinctrl.dtsi
@@ -1581,7 +1581,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h753iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iikx-pinctrl.dtsi
@@ -1469,7 +1469,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h753iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iitx-pinctrl.dtsi
@@ -1469,7 +1469,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h753xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753xihx-pinctrl.dtsi
@@ -1698,7 +1698,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h753zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753zitx-pinctrl.dtsi
@@ -1300,7 +1300,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h755bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755bitx-pinctrl.dtsi
@@ -1509,7 +1509,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h755iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iikx-pinctrl.dtsi
@@ -1529,7 +1529,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h755iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iitx-pinctrl.dtsi
@@ -1328,7 +1328,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h755xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755xihx-pinctrl.dtsi
@@ -1698,7 +1698,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h757aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757aiix-pinctrl.dtsi
@@ -1300,7 +1300,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h757bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757bitx-pinctrl.dtsi
@@ -1473,7 +1473,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h757iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757iitx-pinctrl.dtsi
@@ -1300,7 +1300,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h757xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757xihx-pinctrl.dtsi
@@ -1698,7 +1698,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
@@ -1196,7 +1196,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
@@ -1174,7 +1174,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
@@ -1182,7 +1182,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
@@ -1202,7 +1202,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
@@ -1182,7 +1182,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
@@ -1094,7 +1094,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
@@ -1366,7 +1366,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
@@ -1294,7 +1294,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
@@ -1066,7 +1066,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
@@ -1174,7 +1174,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
@@ -1202,7 +1202,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
@@ -1182,7 +1182,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
@@ -1066,7 +1066,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
@@ -1174,7 +1174,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
@@ -1182,7 +1182,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
@@ -1202,7 +1202,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
@@ -1182,7 +1182,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
@@ -1094,7 +1094,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
@@ -1366,7 +1366,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
@@ -1294,7 +1294,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
@@ -1066,7 +1066,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_ba0_pg4: fmc_ba0_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_ba1_pg5: fmc_ba1_pg5 {
 				pinmux = <STM32_PINMUX('G', 5, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";

--- a/scripts/genpinctrl/stm32-pinctrl-config.yaml
+++ b/scripts/genpinctrl/stm32-pinctrl-config.yaml
@@ -139,7 +139,7 @@
   match: "^FDCAN\\d+_TX$"
 
 - name: FMC
-  match: "^FMC_(?:NL|NADV|CLK|NBL[0-3]|A\\d+|D\\d+|NE[1-4]|NOE|NWE|NWAIT|NCE|INT|SDCLK|SDNWE|SDCKE[0-1]|SDNE[0-1]|SDNRAS|SDNCAS)$"
+  match: "^FMC_(?:NL|NADV|CLK|NBL[0-3]|BA[0-1]|A\\d+|D\\d+|NE[1-4]|NOE|NWE|NWAIT|NCE|INT|SDCLK|SDNWE|SDCKE[0-1]|SDNE[0-1]|SDNRAS|SDNCAS)$"
   bias: pull-up
   slew-rate: very-high-speed
 


### PR DESCRIPTION
`FMC_BA0` and `FMC_BA1` (bank address signals) are actually shared with `FMC_A14` and `FMC_A15` (meaning A14 and A15 pinctrl nodes can be referenced instead of BA0 and BA1 nodes), so feel free to decline this PR if you think having redundant pinctrl nodes (differing only in name) is unnecessary.