### PR TITLE
dts/st: Add support for UCPD CC Pins

### DIFF
--- a/dts/st/g0/stm32g071c(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071c(6-8-b)tx-pinctrl.dtsi
@@ -1092,6 +1092,24 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc1_pd0: ucpd2_cc1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc2_pd2: ucpd2_cc2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g0/stm32g071c(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071c(6-8-b)ux-pinctrl.dtsi
@@ -1092,6 +1092,24 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc1_pd0: ucpd2_cc1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc2_pd2: ucpd2_cc2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g0/stm32g071ebyx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071ebyx-pinctrl.dtsi
@@ -662,6 +662,12 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g0/stm32g071g(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071g(6-8-b)ux-pinctrl.dtsi
@@ -727,6 +727,12 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g0/stm32g071g(8-b)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071g(8-b)uxn-pinctrl.dtsi
@@ -658,6 +658,24 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc1_pd0: ucpd2_cc1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc2_pd2: ucpd2_cc2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g0/stm32g071k(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071k(6-8-b)tx-pinctrl.dtsi
@@ -815,6 +815,12 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g0/stm32g071k(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071k(6-8-b)ux-pinctrl.dtsi
@@ -815,6 +815,12 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g0/stm32g071k(8-b)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071k(8-b)txn-pinctrl.dtsi
@@ -770,6 +770,24 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc1_pd0: ucpd2_cc1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc2_pd2: ucpd2_cc2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g0/stm32g071k(8-b)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071k(8-b)uxn-pinctrl.dtsi
@@ -770,6 +770,24 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc1_pd0: ucpd2_cc1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc2_pd2: ucpd2_cc2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g0/stm32g071r(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071r(6-8-b)tx-pinctrl.dtsi
@@ -1335,6 +1335,24 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc1_pd0: ucpd2_cc1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc2_pd2: ucpd2_cc2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g0/stm32g071rbix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071rbix-pinctrl.dtsi
@@ -1335,6 +1335,24 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc1_pd0: ucpd2_cc1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc2_pd2: ucpd2_cc2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g0/stm32g081cbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081cbtx-pinctrl.dtsi
@@ -1092,6 +1092,24 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc1_pd0: ucpd2_cc1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc2_pd2: ucpd2_cc2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g0/stm32g081cbux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081cbux-pinctrl.dtsi
@@ -1092,6 +1092,24 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc1_pd0: ucpd2_cc1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc2_pd2: ucpd2_cc2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g0/stm32g081ebyx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081ebyx-pinctrl.dtsi
@@ -662,6 +662,12 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g0/stm32g081gbux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081gbux-pinctrl.dtsi
@@ -727,6 +727,12 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g0/stm32g081gbuxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081gbuxn-pinctrl.dtsi
@@ -658,6 +658,24 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc1_pd0: ucpd2_cc1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc2_pd2: ucpd2_cc2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g0/stm32g081kbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081kbtx-pinctrl.dtsi
@@ -815,6 +815,12 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g0/stm32g081kbtxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081kbtxn-pinctrl.dtsi
@@ -770,6 +770,24 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc1_pd0: ucpd2_cc1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc2_pd2: ucpd2_cc2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g0/stm32g081kbux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081kbux-pinctrl.dtsi
@@ -815,6 +815,12 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g0/stm32g081kbuxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081kbuxn-pinctrl.dtsi
@@ -770,6 +770,24 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc1_pd0: ucpd2_cc1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc2_pd2: ucpd2_cc2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g0/stm32g081rbix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081rbix-pinctrl.dtsi
@@ -1335,6 +1335,24 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc1_pd0: ucpd2_cc1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc2_pd2: ucpd2_cc2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g0/stm32g081rbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081rbtx-pinctrl.dtsi
@@ -1335,6 +1335,24 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc1_pd0: ucpd2_cc1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc2_pd2: ucpd2_cc2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
 		};
 	};
 };

--- a/dts/st/g0/stm32g0b1c(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1c(b-c-e)tx-pinctrl.dtsi
@@ -1479,6 +1479,24 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc1_pd0: ucpd2_cc1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc2_pd2: ucpd2_cc2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_noe_pa4: usb_noe_pa4 {

--- a/dts/st/g0/stm32g0b1c(b-c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1c(b-c-e)txn-pinctrl.dtsi
@@ -1446,6 +1446,24 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc1_pd0: ucpd2_cc1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc2_pd2: ucpd2_cc2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_noe_pa4: usb_noe_pa4 {

--- a/dts/st/g0/stm32g0b1c(b-c-e)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1c(b-c-e)ux-pinctrl.dtsi
@@ -1479,6 +1479,24 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc1_pd0: ucpd2_cc1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc2_pd2: ucpd2_cc2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_noe_pa4: usb_noe_pa4 {

--- a/dts/st/g0/stm32g0b1c(b-c-e)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1c(b-c-e)uxn-pinctrl.dtsi
@@ -1446,6 +1446,24 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc1_pd0: ucpd2_cc1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc2_pd2: ucpd2_cc2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_noe_pa4: usb_noe_pa4 {

--- a/dts/st/g0/stm32g0b1k(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1k(b-c-e)tx-pinctrl.dtsi
@@ -1125,6 +1125,12 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_noe_pa4: usb_noe_pa4 {

--- a/dts/st/g0/stm32g0b1k(b-c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1k(b-c-e)txn-pinctrl.dtsi
@@ -1025,6 +1025,24 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc1_pd0: ucpd2_cc1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc2_pd2: ucpd2_cc2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_noe_pa4: usb_noe_pa4 {

--- a/dts/st/g0/stm32g0b1k(b-c-e)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1k(b-c-e)ux-pinctrl.dtsi
@@ -1125,6 +1125,12 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_noe_pa4: usb_noe_pa4 {

--- a/dts/st/g0/stm32g0b1k(b-c-e)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1k(b-c-e)uxn-pinctrl.dtsi
@@ -1025,6 +1025,24 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc1_pd0: ucpd2_cc1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc2_pd2: ucpd2_cc2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_noe_pa4: usb_noe_pa4 {

--- a/dts/st/g0/stm32g0b1m(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1m(b-c-e)tx-pinctrl.dtsi
@@ -2002,6 +2002,24 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc1_pd0: ucpd2_cc1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc2_pd2: ucpd2_cc2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_noe_pa4: usb_noe_pa4 {

--- a/dts/st/g0/stm32g0b1neyx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1neyx-pinctrl.dtsi
@@ -1529,6 +1529,24 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc1_pd0: ucpd2_cc1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc2_pd2: ucpd2_cc2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_noe_pa4: usb_noe_pa4 {

--- a/dts/st/g0/stm32g0b1r(b-c-e)ixn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1r(b-c-e)ixn-pinctrl.dtsi
@@ -1794,6 +1794,24 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc1_pd0: ucpd2_cc1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc2_pd2: ucpd2_cc2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_noe_pa4: usb_noe_pa4 {

--- a/dts/st/g0/stm32g0b1r(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1r(b-c-e)tx-pinctrl.dtsi
@@ -1831,6 +1831,24 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc1_pd0: ucpd2_cc1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc2_pd2: ucpd2_cc2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_noe_pa4: usb_noe_pa4 {

--- a/dts/st/g0/stm32g0b1r(b-c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1r(b-c-e)txn-pinctrl.dtsi
@@ -1794,6 +1794,24 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc1_pd0: ucpd2_cc1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc2_pd2: ucpd2_cc2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_noe_pa4: usb_noe_pa4 {

--- a/dts/st/g0/stm32g0b1v(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1v(b-c-e)ix-pinctrl.dtsi
@@ -2229,6 +2229,24 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc1_pd0: ucpd2_cc1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc2_pd2: ucpd2_cc2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_noe_pa4: usb_noe_pa4 {

--- a/dts/st/g0/stm32g0b1v(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1v(b-c-e)tx-pinctrl.dtsi
@@ -2229,6 +2229,24 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc1_pd0: ucpd2_cc1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc2_pd2: ucpd2_cc2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_noe_pa4: usb_noe_pa4 {

--- a/dts/st/g0/stm32g0c1c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1c(c-e)tx-pinctrl.dtsi
@@ -1479,6 +1479,24 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc1_pd0: ucpd2_cc1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc2_pd2: ucpd2_cc2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_noe_pa4: usb_noe_pa4 {

--- a/dts/st/g0/stm32g0c1c(c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1c(c-e)txn-pinctrl.dtsi
@@ -1446,6 +1446,24 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc1_pd0: ucpd2_cc1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc2_pd2: ucpd2_cc2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_noe_pa4: usb_noe_pa4 {

--- a/dts/st/g0/stm32g0c1c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1c(c-e)ux-pinctrl.dtsi
@@ -1479,6 +1479,24 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc1_pd0: ucpd2_cc1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc2_pd2: ucpd2_cc2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_noe_pa4: usb_noe_pa4 {

--- a/dts/st/g0/stm32g0c1c(c-e)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1c(c-e)uxn-pinctrl.dtsi
@@ -1446,6 +1446,24 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc1_pd0: ucpd2_cc1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc2_pd2: ucpd2_cc2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_noe_pa4: usb_noe_pa4 {

--- a/dts/st/g0/stm32g0c1k(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1k(c-e)tx-pinctrl.dtsi
@@ -1125,6 +1125,12 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_noe_pa4: usb_noe_pa4 {

--- a/dts/st/g0/stm32g0c1k(c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1k(c-e)txn-pinctrl.dtsi
@@ -1025,6 +1025,24 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc1_pd0: ucpd2_cc1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc2_pd2: ucpd2_cc2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_noe_pa4: usb_noe_pa4 {

--- a/dts/st/g0/stm32g0c1k(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1k(c-e)ux-pinctrl.dtsi
@@ -1125,6 +1125,12 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_noe_pa4: usb_noe_pa4 {

--- a/dts/st/g0/stm32g0c1k(c-e)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1k(c-e)uxn-pinctrl.dtsi
@@ -1025,6 +1025,24 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc1_pd0: ucpd2_cc1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc2_pd2: ucpd2_cc2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_noe_pa4: usb_noe_pa4 {

--- a/dts/st/g0/stm32g0c1m(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1m(c-e)tx-pinctrl.dtsi
@@ -2002,6 +2002,24 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc1_pd0: ucpd2_cc1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc2_pd2: ucpd2_cc2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_noe_pa4: usb_noe_pa4 {

--- a/dts/st/g0/stm32g0c1neyx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1neyx-pinctrl.dtsi
@@ -1529,6 +1529,24 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc1_pd0: ucpd2_cc1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc2_pd2: ucpd2_cc2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_noe_pa4: usb_noe_pa4 {

--- a/dts/st/g0/stm32g0c1r(c-e)ixn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1r(c-e)ixn-pinctrl.dtsi
@@ -1794,6 +1794,24 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc1_pd0: ucpd2_cc1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc2_pd2: ucpd2_cc2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_noe_pa4: usb_noe_pa4 {

--- a/dts/st/g0/stm32g0c1r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1r(c-e)tx-pinctrl.dtsi
@@ -1831,6 +1831,24 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc1_pd0: ucpd2_cc1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc2_pd2: ucpd2_cc2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_noe_pa4: usb_noe_pa4 {

--- a/dts/st/g0/stm32g0c1r(c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1r(c-e)txn-pinctrl.dtsi
@@ -1794,6 +1794,24 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc1_pd0: ucpd2_cc1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc2_pd2: ucpd2_cc2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_noe_pa4: usb_noe_pa4 {

--- a/dts/st/g0/stm32g0c1v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1v(c-e)ix-pinctrl.dtsi
@@ -2229,6 +2229,24 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc1_pd0: ucpd2_cc1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc2_pd2: ucpd2_cc2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_noe_pa4: usb_noe_pa4 {

--- a/dts/st/g0/stm32g0c1v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1v(c-e)tx-pinctrl.dtsi
@@ -2229,6 +2229,24 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa8: ucpd1_cc1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc1_pd0: ucpd2_cc1_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd2_cc2_pd2: ucpd2_cc2_pd2 {
+				pinmux = <STM32_PINMUX('D', 2, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_noe_pa4: usb_noe_pa4 {

--- a/dts/st/g4/stm32g431c(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431c(6-8-b)tx-pinctrl.dtsi
@@ -973,6 +973,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g431c(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431c(6-8-b)ux-pinctrl.dtsi
@@ -1051,6 +1051,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g431cbyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431cbyx-pinctrl.dtsi
@@ -1027,6 +1027,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g431k(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431k(6-8-b)tx-pinctrl.dtsi
@@ -707,6 +707,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g431k(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431k(6-8-b)ux-pinctrl.dtsi
@@ -707,6 +707,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g431m(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431m(6-8-b)tx-pinctrl.dtsi
@@ -1352,6 +1352,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g431r(6-8-b)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431r(6-8-b)ix-pinctrl.dtsi
@@ -1235,6 +1235,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g431r(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431r(6-8-b)tx-pinctrl.dtsi
@@ -1235,6 +1235,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g431v(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431v(6-8-b)tx-pinctrl.dtsi
@@ -1565,6 +1565,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g441cbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441cbtx-pinctrl.dtsi
@@ -973,6 +973,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g441cbux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441cbux-pinctrl.dtsi
@@ -1051,6 +1051,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g441cbyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441cbyx-pinctrl.dtsi
@@ -1027,6 +1027,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g441kbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441kbtx-pinctrl.dtsi
@@ -707,6 +707,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g441kbux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441kbux-pinctrl.dtsi
@@ -707,6 +707,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g441mbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441mbtx-pinctrl.dtsi
@@ -1352,6 +1352,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g441rbix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441rbix-pinctrl.dtsi
@@ -1235,6 +1235,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g441rbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441rbtx-pinctrl.dtsi
@@ -1235,6 +1235,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g441vbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441vbtx-pinctrl.dtsi
@@ -1565,6 +1565,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g471c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471c(c-e)tx-pinctrl.dtsi
@@ -1064,6 +1064,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g471c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471c(c-e)ux-pinctrl.dtsi
@@ -1179,6 +1179,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g471m(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471m(c-e)tx-pinctrl.dtsi
@@ -1592,6 +1592,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g471meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471meyx-pinctrl.dtsi
@@ -1606,6 +1606,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g471q(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471q(c-e)tx-pinctrl.dtsi
@@ -2183,6 +2183,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g471r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471r(c-e)tx-pinctrl.dtsi
@@ -1392,6 +1392,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g471v(c-e)hx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471v(c-e)hx-pinctrl.dtsi
@@ -1914,6 +1914,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g471v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471v(c-e)ix-pinctrl.dtsi
@@ -1914,6 +1914,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g471v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471v(c-e)tx-pinctrl.dtsi
@@ -1914,6 +1914,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g473c(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473c(b-c-e)tx-pinctrl.dtsi
@@ -1124,6 +1124,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g473c(b-c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473c(b-c-e)ux-pinctrl.dtsi
@@ -1239,6 +1239,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g473m(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473m(b-c-e)tx-pinctrl.dtsi
@@ -1728,6 +1728,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g473meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473meyx-pinctrl.dtsi
@@ -1750,6 +1750,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g473p(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473p(b-c-e)ix-pinctrl.dtsi
@@ -2597,6 +2597,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g473q(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473q(b-c-e)tx-pinctrl.dtsi
@@ -2711,6 +2711,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g473r(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473r(b-c-e)tx-pinctrl.dtsi
@@ -1456,6 +1456,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g473v(b-c-e)hx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473v(b-c-e)hx-pinctrl.dtsi
@@ -2304,6 +2304,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g473v(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473v(b-c-e)tx-pinctrl.dtsi
@@ -2304,6 +2304,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g474c(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474c(b-c-e)tx-pinctrl.dtsi
@@ -1206,6 +1206,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g474c(b-c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474c(b-c-e)ux-pinctrl.dtsi
@@ -1333,6 +1333,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g474m(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474m(b-c-e)tx-pinctrl.dtsi
@@ -1842,6 +1842,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g474meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474meyx-pinctrl.dtsi
@@ -1864,6 +1864,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g474p(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474p(b-c-e)ix-pinctrl.dtsi
@@ -2711,6 +2711,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g474q(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474q(b-c-e)tx-pinctrl.dtsi
@@ -2825,6 +2825,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g474r(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474r(b-c-e)tx-pinctrl.dtsi
@@ -1570,6 +1570,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g474v(b-c-e)hx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474v(b-c-e)hx-pinctrl.dtsi
@@ -2418,6 +2418,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g474v(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474v(b-c-e)tx-pinctrl.dtsi
@@ -2418,6 +2418,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g483cetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483cetx-pinctrl.dtsi
@@ -1124,6 +1124,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g483ceux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483ceux-pinctrl.dtsi
@@ -1239,6 +1239,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g483metx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483metx-pinctrl.dtsi
@@ -1728,6 +1728,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g483meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483meyx-pinctrl.dtsi
@@ -1750,6 +1750,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g483peix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483peix-pinctrl.dtsi
@@ -2597,6 +2597,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g483qetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483qetx-pinctrl.dtsi
@@ -2711,6 +2711,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g483retx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483retx-pinctrl.dtsi
@@ -1456,6 +1456,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g483vehx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483vehx-pinctrl.dtsi
@@ -2304,6 +2304,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g483vetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483vetx-pinctrl.dtsi
@@ -2304,6 +2304,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g484cetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484cetx-pinctrl.dtsi
@@ -1206,6 +1206,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g484ceux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484ceux-pinctrl.dtsi
@@ -1333,6 +1333,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g484metx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484metx-pinctrl.dtsi
@@ -1842,6 +1842,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g484meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484meyx-pinctrl.dtsi
@@ -1864,6 +1864,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g484peix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484peix-pinctrl.dtsi
@@ -2711,6 +2711,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g484qetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484qetx-pinctrl.dtsi
@@ -2825,6 +2825,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g484retx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484retx-pinctrl.dtsi
@@ -1570,6 +1570,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g484vehx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484vehx-pinctrl.dtsi
@@ -2418,6 +2418,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g484vetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484vetx-pinctrl.dtsi
@@ -2418,6 +2418,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g491c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491c(c-e)tx-pinctrl.dtsi
@@ -1052,6 +1052,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g491c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491c(c-e)ux-pinctrl.dtsi
@@ -1135,6 +1135,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g491k(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491k(c-e)ux-pinctrl.dtsi
@@ -746,6 +746,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g491m(c-e)sx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491m(c-e)sx-pinctrl.dtsi
@@ -1547,6 +1547,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g491m(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491m(c-e)tx-pinctrl.dtsi
@@ -1547,6 +1547,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g491r(c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491r(c-e)ix-pinctrl.dtsi
@@ -1368,6 +1368,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g491r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491r(c-e)tx-pinctrl.dtsi
@@ -1368,6 +1368,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g491reyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491reyx-pinctrl.dtsi
@@ -1368,6 +1368,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g491v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491v(c-e)tx-pinctrl.dtsi
@@ -1843,6 +1843,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g4a1cetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1cetx-pinctrl.dtsi
@@ -1052,6 +1052,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g4a1ceux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1ceux-pinctrl.dtsi
@@ -1135,6 +1135,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g4a1keux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1keux-pinctrl.dtsi
@@ -746,6 +746,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g4a1mesx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1mesx-pinctrl.dtsi
@@ -1547,6 +1547,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g4a1metx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1metx-pinctrl.dtsi
@@ -1547,6 +1547,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g4a1reix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1reix-pinctrl.dtsi
@@ -1368,6 +1368,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g4a1retx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1retx-pinctrl.dtsi
@@ -1368,6 +1368,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g4a1reyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1reyx-pinctrl.dtsi
@@ -1368,6 +1368,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/g4/stm32g4a1vetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1vetx-pinctrl.dtsi
@@ -1843,6 +1843,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc2_pb4: ucpd1_cc2_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc1_pb6: ucpd1_cc1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/l5/stm32l552c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552c(c-e)tx-pinctrl.dtsi
@@ -996,6 +996,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/l5/stm32l552c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552c(c-e)ux-pinctrl.dtsi
@@ -996,6 +996,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/l5/stm32l552cetxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552cetxp-pinctrl.dtsi
@@ -935,6 +935,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/l5/stm32l552ceuxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552ceuxp-pinctrl.dtsi
@@ -935,6 +935,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/l5/stm32l552meyxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552meyxp-pinctrl.dtsi
@@ -1509,6 +1509,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/l5/stm32l552meyxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552meyxq-pinctrl.dtsi
@@ -1458,6 +1458,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/l5/stm32l552q(c-e)ixq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552q(c-e)ixq-pinctrl.dtsi
@@ -2302,6 +2302,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/l5/stm32l552qeix-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552qeix-pinctrl.dtsi
@@ -2362,6 +2362,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/l5/stm32l552qeixp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552qeixp-pinctrl.dtsi
@@ -2334,6 +2334,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/l5/stm32l552r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552r(c-e)tx-pinctrl.dtsi
@@ -1370,6 +1370,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/l5/stm32l552retxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552retxp-pinctrl.dtsi
@@ -1243,6 +1243,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/l5/stm32l552retxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552retxq-pinctrl.dtsi
@@ -1234,6 +1234,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/l5/stm32l552v(c-e)txq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552v(c-e)txq-pinctrl.dtsi
@@ -1870,6 +1870,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/l5/stm32l552vetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552vetx-pinctrl.dtsi
@@ -1947,6 +1947,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/l5/stm32l552z(c-e)txq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552z(c-e)txq-pinctrl.dtsi
@@ -2344,6 +2344,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/l5/stm32l552zetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552zetx-pinctrl.dtsi
@@ -2431,6 +2431,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/l5/stm32l562cetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562cetx-pinctrl.dtsi
@@ -996,6 +996,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/l5/stm32l562cetxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562cetxp-pinctrl.dtsi
@@ -935,6 +935,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/l5/stm32l562ceux-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562ceux-pinctrl.dtsi
@@ -996,6 +996,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/l5/stm32l562ceuxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562ceuxp-pinctrl.dtsi
@@ -935,6 +935,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/l5/stm32l562meyxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562meyxp-pinctrl.dtsi
@@ -1509,6 +1509,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/l5/stm32l562meyxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562meyxq-pinctrl.dtsi
@@ -1458,6 +1458,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/l5/stm32l562qeix-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeix-pinctrl.dtsi
@@ -2362,6 +2362,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/l5/stm32l562qeixp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeixp-pinctrl.dtsi
@@ -2334,6 +2334,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/l5/stm32l562qeixq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeixq-pinctrl.dtsi
@@ -2302,6 +2302,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/l5/stm32l562retx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562retx-pinctrl.dtsi
@@ -1370,6 +1370,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/l5/stm32l562retxp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562retxp-pinctrl.dtsi
@@ -1243,6 +1243,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/l5/stm32l562retxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562retxq-pinctrl.dtsi
@@ -1234,6 +1234,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/l5/stm32l562vetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562vetx-pinctrl.dtsi
@@ -1947,6 +1947,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/l5/stm32l562vetxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562vetxq-pinctrl.dtsi
@@ -1870,6 +1870,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/l5/stm32l562zetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562zetx-pinctrl.dtsi
@@ -2431,6 +2431,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/l5/stm32l562zetxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562zetxq-pinctrl.dtsi
@@ -2344,6 +2344,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB */
 
 			/omit-if-no-ref/ usb_dm_pa11: usb_dm_pa11 {

--- a/dts/st/u5/stm32u575agix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575agix-pinctrl.dtsi
@@ -2924,6 +2924,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u575agixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575agixq-pinctrl.dtsi
@@ -2868,6 +2868,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u575aiix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575aiix-pinctrl.dtsi
@@ -2924,6 +2924,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u575aiixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575aiixq-pinctrl.dtsi
@@ -2868,6 +2868,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u575cgtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575cgtx-pinctrl.dtsi
@@ -979,6 +979,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u575cgtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575cgtxq-pinctrl.dtsi
@@ -870,6 +870,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u575cgux-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575cgux-pinctrl.dtsi
@@ -979,6 +979,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u575cguxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575cguxq-pinctrl.dtsi
@@ -870,6 +870,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u575citx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575citx-pinctrl.dtsi
@@ -979,6 +979,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u575citxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575citxq-pinctrl.dtsi
@@ -870,6 +870,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u575ciux-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575ciux-pinctrl.dtsi
@@ -979,6 +979,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u575ciuxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575ciuxq-pinctrl.dtsi
@@ -870,6 +870,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u575ogyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575ogyxq-pinctrl.dtsi
@@ -1780,6 +1780,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u575oiyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575oiyxq-pinctrl.dtsi
@@ -1780,6 +1780,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u575qgix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575qgix-pinctrl.dtsi
@@ -2572,6 +2572,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u575qgixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575qgixq-pinctrl.dtsi
@@ -2507,6 +2507,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u575qiix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575qiix-pinctrl.dtsi
@@ -2572,6 +2572,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u575qiixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575qiixq-pinctrl.dtsi
@@ -2507,6 +2507,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u575rgtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575rgtx-pinctrl.dtsi
@@ -1417,6 +1417,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u575rgtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575rgtxq-pinctrl.dtsi
@@ -1305,6 +1305,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u575ritx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575ritx-pinctrl.dtsi
@@ -1417,6 +1417,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u575ritxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575ritxq-pinctrl.dtsi
@@ -1305,6 +1305,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u575vgtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575vgtx-pinctrl.dtsi
@@ -2037,6 +2037,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u575vgtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575vgtxq-pinctrl.dtsi
@@ -1990,6 +1990,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u575vitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575vitx-pinctrl.dtsi
@@ -2037,6 +2037,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u575vitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575vitxq-pinctrl.dtsi
@@ -1990,6 +1990,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u575zgtx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575zgtx-pinctrl.dtsi
@@ -2620,6 +2620,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u575zgtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575zgtxq-pinctrl.dtsi
@@ -2563,6 +2563,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u575zitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575zitx-pinctrl.dtsi
@@ -2620,6 +2620,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u575zitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u575zitxq-pinctrl.dtsi
@@ -2563,6 +2563,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u585aiix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585aiix-pinctrl.dtsi
@@ -2924,6 +2924,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u585aiixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585aiixq-pinctrl.dtsi
@@ -2868,6 +2868,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u585citx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585citx-pinctrl.dtsi
@@ -979,6 +979,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u585citxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585citxq-pinctrl.dtsi
@@ -870,6 +870,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u585ciux-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585ciux-pinctrl.dtsi
@@ -979,6 +979,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u585ciuxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585ciuxq-pinctrl.dtsi
@@ -870,6 +870,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u585oiyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585oiyxq-pinctrl.dtsi
@@ -1780,6 +1780,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u585qiix-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585qiix-pinctrl.dtsi
@@ -2572,6 +2572,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u585qiixq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585qiixq-pinctrl.dtsi
@@ -2507,6 +2507,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u585ritx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585ritx-pinctrl.dtsi
@@ -1417,6 +1417,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u585ritxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585ritxq-pinctrl.dtsi
@@ -1305,6 +1305,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u585vitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585vitx-pinctrl.dtsi
@@ -2037,6 +2037,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u585vitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585vitxq-pinctrl.dtsi
@@ -1990,6 +1990,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u585zitx-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585zitx-pinctrl.dtsi
@@ -2620,6 +2620,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u585zitxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u585zitxq-pinctrl.dtsi
@@ -2563,6 +2563,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_FS */
 
 			/omit-if-no-ref/ usb_otg_fs_sof_pa8: usb_otg_fs_sof_pa8 {

--- a/dts/st/u5/stm32u595zjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u595zjtxq-pinctrl.dtsi
@@ -2761,6 +2761,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_HS */
 
 			/omit-if-no-ref/ usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {

--- a/dts/st/u5/stm32u599bjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599bjyxq-pinctrl.dtsi
@@ -3340,6 +3340,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_HS */
 
 			/omit-if-no-ref/ usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {

--- a/dts/st/u5/stm32u599nihxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599nihxq-pinctrl.dtsi
@@ -3434,6 +3434,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_HS */
 
 			/omit-if-no-ref/ usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {

--- a/dts/st/u5/stm32u599njhxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u599njhxq-pinctrl.dtsi
@@ -3434,6 +3434,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_HS */
 
 			/omit-if-no-ref/ usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {

--- a/dts/st/u5/stm32u5a5zjtxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a5zjtxq-pinctrl.dtsi
@@ -2761,6 +2761,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_HS */
 
 			/omit-if-no-ref/ usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {

--- a/dts/st/u5/stm32u5a9bjyxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a9bjyxq-pinctrl.dtsi
@@ -3340,6 +3340,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_HS */
 
 			/omit-if-no-ref/ usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {

--- a/dts/st/u5/stm32u5a9njhxq-pinctrl.dtsi
+++ b/dts/st/u5/stm32u5a9njhxq-pinctrl.dtsi
@@ -3434,6 +3434,16 @@
 				bias-pull-up;
 			};
 
+			/* UCPD */
+
+			/omit-if-no-ref/ ucpd1_cc1_pa15: ucpd1_cc1_pa15 {
+				pinmux = <STM32_PINMUX('A', 15, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ ucpd1_cc2_pb15: ucpd1_cc2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, ANALOG)>;
+			};
+
 			/* USB_OTG_HS */
 
 			/omit-if-no-ref/ usb_otg_hs_sof_pa8: usb_otg_hs_sof_pa8 {

--- a/scripts/genpinctrl/stm32-pinctrl-config.yaml
+++ b/scripts/genpinctrl/stm32-pinctrl-config.yaml
@@ -240,6 +240,10 @@
 - name: UART_RX / USART_RX / LPUART_RX
   match: "^(?:LP)?US?ART\\d+_RX$"
 
+- name: UCPD
+  match: "^UCPD\\d+_CC\\d+N?$"
+  mode: analog
+
 - name: USB_OTG_FS
   match: "^USB_OTG_FS_(?:DM)?(?:DP)?(?:SOF)?(?:ID)?(?:VBUS)?$"
 


### PR DESCRIPTION
New version of -pinctrl.dtsi files with UCPD_CC pins generated.