### PR TITLE
dts: stm32f1: Add remap information in pin configuration names

### DIFF
--- a/dts/st/f1/stm32f100c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100c(4-6)tx-pinctrl.dtsi
@@ -219,7 +219,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -231,7 +231,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -243,7 +243,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -254,7 +254,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -264,7 +264,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -274,7 +274,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -284,7 +284,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -294,7 +294,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -305,7 +305,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -316,13 +316,13 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -330,7 +330,7 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -338,7 +338,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -346,7 +346,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -354,15 +354,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -382,7 +382,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -390,7 +390,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -398,7 +398,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -406,11 +406,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -418,7 +418,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -426,7 +426,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -434,7 +434,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -454,7 +454,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -462,15 +462,15 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -482,7 +482,7 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM15_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			/omit-if-no-ref/ tim15_ch1_remap1_pwm_pb14: tim15_ch1_remap1_pwm_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM15_REMAP1)>;
 			};
 
@@ -490,11 +490,11 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			/omit-if-no-ref/ tim15_ch2_remap1_pwm_pb15: tim15_ch2_remap1_pwm_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM15_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim16_ch1_remap1_pwm_pa6: tim16_ch1_remap1_pwm_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM16_REMAP1)>;
 			};
 
@@ -506,7 +506,7 @@
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM16_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			/omit-if-no-ref/ tim17_ch1_remap1_pwm_pa7: tim17_ch1_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM17_REMAP1)>;
 			};
 
@@ -548,7 +548,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -562,7 +562,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f100c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100c(8-b)tx-pinctrl.dtsi
@@ -219,7 +219,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -236,7 +236,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -253,7 +253,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -269,7 +269,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -283,7 +283,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -297,7 +297,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -311,7 +311,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -325,7 +325,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -340,7 +340,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -356,7 +356,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -366,7 +366,7 @@
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -374,7 +374,7 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -382,7 +382,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -390,7 +390,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -398,15 +398,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -426,7 +426,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -434,7 +434,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -442,7 +442,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -450,11 +450,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -462,7 +462,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -470,7 +470,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -478,7 +478,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -498,7 +498,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -506,15 +506,15 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -542,7 +542,7 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM15_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			/omit-if-no-ref/ tim15_ch1_remap1_pwm_pb14: tim15_ch1_remap1_pwm_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM15_REMAP1)>;
 			};
 
@@ -550,11 +550,11 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			/omit-if-no-ref/ tim15_ch2_remap1_pwm_pb15: tim15_ch2_remap1_pwm_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM15_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim16_ch1_remap1_pwm_pa6: tim16_ch1_remap1_pwm_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM16_REMAP1)>;
 			};
 
@@ -566,7 +566,7 @@
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM16_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			/omit-if-no-ref/ tim17_ch1_remap1_pwm_pa7: tim17_ch1_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM17_REMAP1)>;
 			};
 
@@ -598,7 +598,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -618,7 +618,7 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
@@ -628,7 +628,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -646,7 +646,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f100r(4-6)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(4-6)hx-pinctrl.dtsi
@@ -291,7 +291,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -303,7 +303,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -315,7 +315,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -326,7 +326,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -336,7 +336,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -346,7 +346,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -356,7 +356,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -366,7 +366,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -377,7 +377,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -388,13 +388,13 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -402,7 +402,7 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -410,7 +410,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -418,7 +418,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -426,15 +426,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -454,7 +454,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -462,7 +462,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -470,7 +470,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -478,11 +478,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -490,7 +490,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -498,7 +498,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -506,7 +506,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -526,7 +526,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -534,31 +534,31 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
@@ -570,7 +570,7 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM15_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			/omit-if-no-ref/ tim15_ch1_remap1_pwm_pb14: tim15_ch1_remap1_pwm_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM15_REMAP1)>;
 			};
 
@@ -578,11 +578,11 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			/omit-if-no-ref/ tim15_ch2_remap1_pwm_pb15: tim15_ch2_remap1_pwm_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM15_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim16_ch1_remap1_pwm_pa6: tim16_ch1_remap1_pwm_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM16_REMAP1)>;
 			};
 
@@ -594,7 +594,7 @@
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM16_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			/omit-if-no-ref/ tim17_ch1_remap1_pwm_pa7: tim17_ch1_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM17_REMAP1)>;
 			};
 
@@ -636,7 +636,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -650,7 +650,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f100r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(4-6)tx-pinctrl.dtsi
@@ -299,7 +299,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -311,7 +311,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -323,7 +323,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -334,7 +334,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -344,7 +344,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -354,7 +354,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -364,7 +364,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -374,7 +374,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -385,7 +385,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -396,13 +396,13 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -410,7 +410,7 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -418,7 +418,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -426,7 +426,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -434,15 +434,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -462,7 +462,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -470,7 +470,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -478,7 +478,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -486,11 +486,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -498,7 +498,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -506,7 +506,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -514,7 +514,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -534,7 +534,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -542,31 +542,31 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
@@ -578,7 +578,7 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM15_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			/omit-if-no-ref/ tim15_ch1_remap1_pwm_pb14: tim15_ch1_remap1_pwm_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM15_REMAP1)>;
 			};
 
@@ -586,11 +586,11 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			/omit-if-no-ref/ tim15_ch2_remap1_pwm_pb15: tim15_ch2_remap1_pwm_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM15_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim16_ch1_remap1_pwm_pa6: tim16_ch1_remap1_pwm_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM16_REMAP1)>;
 			};
 
@@ -602,7 +602,7 @@
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM16_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			/omit-if-no-ref/ tim17_ch1_remap1_pwm_pa7: tim17_ch1_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM17_REMAP1)>;
 			};
 
@@ -644,7 +644,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -658,7 +658,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f100r(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(8-b)hx-pinctrl.dtsi
@@ -291,7 +291,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -308,7 +308,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -325,7 +325,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -341,7 +341,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -355,7 +355,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -369,7 +369,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -383,7 +383,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -397,7 +397,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -412,7 +412,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -428,7 +428,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -438,7 +438,7 @@
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -446,7 +446,7 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -454,7 +454,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -462,7 +462,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -470,15 +470,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -498,7 +498,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -506,7 +506,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -514,7 +514,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -522,11 +522,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -534,7 +534,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -542,7 +542,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -550,7 +550,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -570,7 +570,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -578,31 +578,31 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
@@ -630,7 +630,7 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM15_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			/omit-if-no-ref/ tim15_ch1_remap1_pwm_pb14: tim15_ch1_remap1_pwm_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM15_REMAP1)>;
 			};
 
@@ -638,11 +638,11 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			/omit-if-no-ref/ tim15_ch2_remap1_pwm_pb15: tim15_ch2_remap1_pwm_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM15_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim16_ch1_remap1_pwm_pa6: tim16_ch1_remap1_pwm_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM16_REMAP1)>;
 			};
 
@@ -654,7 +654,7 @@
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM16_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			/omit-if-no-ref/ tim17_ch1_remap1_pwm_pa7: tim17_ch1_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM17_REMAP1)>;
 			};
 
@@ -686,7 +686,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -706,7 +706,7 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
@@ -716,7 +716,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -728,7 +728,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pc11: usart3_rx_pc11 {
+			/omit-if-no-ref/ usart3_rx_remap1_pc11: usart3_rx_remap1_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
@@ -738,7 +738,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
@@ -750,7 +750,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pc10: usart3_tx_pc10 {
+			/omit-if-no-ref/ usart3_tx_remap1_pc10: usart3_tx_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f100r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(8-b)tx-pinctrl.dtsi
@@ -299,7 +299,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -316,7 +316,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -333,7 +333,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -349,7 +349,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -363,7 +363,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -377,7 +377,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -391,7 +391,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -405,7 +405,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -420,7 +420,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -436,7 +436,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -446,7 +446,7 @@
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -454,7 +454,7 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -462,7 +462,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -470,7 +470,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -478,15 +478,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -506,7 +506,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -514,7 +514,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -522,7 +522,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -530,11 +530,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -542,7 +542,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -550,7 +550,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -558,7 +558,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -578,7 +578,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -586,31 +586,31 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
@@ -638,7 +638,7 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM15_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			/omit-if-no-ref/ tim15_ch1_remap1_pwm_pb14: tim15_ch1_remap1_pwm_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM15_REMAP1)>;
 			};
 
@@ -646,11 +646,11 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			/omit-if-no-ref/ tim15_ch2_remap1_pwm_pb15: tim15_ch2_remap1_pwm_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM15_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim16_ch1_remap1_pwm_pa6: tim16_ch1_remap1_pwm_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM16_REMAP1)>;
 			};
 
@@ -662,7 +662,7 @@
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM16_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			/omit-if-no-ref/ tim17_ch1_remap1_pwm_pa7: tim17_ch1_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM17_REMAP1)>;
 			};
 
@@ -694,7 +694,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -714,7 +714,7 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
@@ -724,7 +724,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -736,7 +736,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pc11: usart3_rx_pc11 {
+			/omit-if-no-ref/ usart3_rx_remap1_pc11: usart3_rx_remap1_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
@@ -746,7 +746,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
@@ -758,7 +758,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pc10: usart3_tx_pc10 {
+			/omit-if-no-ref/ usart3_tx_remap1_pc10: usart3_tx_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f100r(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(c-d-e)tx-pinctrl.dtsi
@@ -299,7 +299,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -316,7 +316,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -333,7 +333,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -354,7 +354,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -372,7 +372,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -390,7 +390,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -408,7 +408,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -426,7 +426,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -445,7 +445,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -466,7 +466,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -480,7 +480,7 @@
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -488,7 +488,7 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -496,7 +496,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -504,7 +504,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -512,15 +512,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -540,7 +540,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -548,7 +548,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -556,7 +556,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -564,11 +564,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -576,7 +576,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -584,7 +584,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -592,7 +592,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -600,11 +600,11 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim12_ch1_pwm_pb12: tim12_ch1_pwm_pb12 {
+			/omit-if-no-ref/ tim12_ch1_remap1_pwm_pb12: tim12_ch1_remap1_pwm_pb12 {
 				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, TIM12_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim12_ch2_pwm_pb13: tim12_ch2_pwm_pb13 {
+			/omit-if-no-ref/ tim12_ch2_remap1_pwm_pb13: tim12_ch2_remap1_pwm_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM12_REMAP1)>;
 			};
 
@@ -624,7 +624,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim13_ch1_pwm_pb0: tim13_ch1_pwm_pb0 {
+			/omit-if-no-ref/ tim13_ch1_remap1_pwm_pb0: tim13_ch1_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM13_REMAP1)>;
 			};
 
@@ -632,7 +632,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -640,23 +640,23 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
@@ -664,15 +664,15 @@
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM13_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			/omit-if-no-ref/ tim14_ch1_remap1_pwm_pb1: tim14_ch1_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM14_REMAP1)>;
 			};
 
@@ -720,7 +720,7 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			/omit-if-no-ref/ tim15_ch1_remap1_pwm_pb14: tim15_ch1_remap1_pwm_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM15_REMAP1)>;
 			};
 
@@ -728,11 +728,11 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			/omit-if-no-ref/ tim15_ch2_remap1_pwm_pb15: tim15_ch2_remap1_pwm_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM15_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim16_ch1_remap1_pwm_pa6: tim16_ch1_remap1_pwm_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM16_REMAP1)>;
 			};
 
@@ -744,7 +744,7 @@
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM16_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			/omit-if-no-ref/ tim17_ch1_remap1_pwm_pa7: tim17_ch1_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM17_REMAP1)>;
 			};
 
@@ -776,7 +776,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -796,7 +796,7 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
@@ -806,7 +806,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -818,7 +818,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pc11: usart3_rx_pc11 {
+			/omit-if-no-ref/ usart3_rx_remap1_pc11: usart3_rx_remap1_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
@@ -836,7 +836,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
@@ -848,7 +848,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pc10: usart3_tx_pc10 {
+			/omit-if-no-ref/ usart3_tx_remap1_pc10: usart3_tx_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f100v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100v(8-b)tx-pinctrl.dtsi
@@ -415,7 +415,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -432,7 +432,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -449,7 +449,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -465,7 +465,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -479,7 +479,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -493,7 +493,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -507,7 +507,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -521,7 +521,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -536,7 +536,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -552,7 +552,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -562,7 +562,7 @@
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -570,7 +570,7 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -578,7 +578,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -586,7 +586,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -594,15 +594,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -618,31 +618,31 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_pe8: tim1_ch1n_remap2_pwm_pe8 {
 				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_pe9: tim1_ch1_remap2_pwm_pe9 {
 				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_pe10: tim1_ch2n_remap2_pwm_pe10 {
 				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_pe11: tim1_ch2_remap2_pwm_pe11 {
 				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_pe12: tim1_ch3n_remap2_pwm_pe12 {
 				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_pe13: tim1_ch3_remap2_pwm_pe13 {
 				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_pe14: tim1_ch4_remap2_pwm_pe14 {
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
@@ -650,7 +650,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -658,7 +658,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -666,7 +666,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -674,11 +674,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -686,7 +686,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -694,7 +694,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -702,7 +702,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -722,7 +722,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -730,31 +730,31 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
@@ -774,19 +774,19 @@
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
@@ -798,7 +798,7 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM15_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			/omit-if-no-ref/ tim15_ch1_remap1_pwm_pb14: tim15_ch1_remap1_pwm_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM15_REMAP1)>;
 			};
 
@@ -806,11 +806,11 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			/omit-if-no-ref/ tim15_ch2_remap1_pwm_pb15: tim15_ch2_remap1_pwm_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM15_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim16_ch1_remap1_pwm_pa6: tim16_ch1_remap1_pwm_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM16_REMAP1)>;
 			};
 
@@ -822,7 +822,7 @@
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM16_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			/omit-if-no-ref/ tim17_ch1_remap1_pwm_pa7: tim17_ch1_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM17_REMAP1)>;
 			};
 
@@ -848,7 +848,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
+			/omit-if-no-ref/ usart2_cts_remap1_pd3: usart2_cts_remap1_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -860,13 +860,13 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
+			/omit-if-no-ref/ usart3_cts_remap2_pd11: usart3_cts_remap2_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -882,7 +882,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
+			/omit-if-no-ref/ usart2_rts_remap1_pd4: usart2_rts_remap1_pd4 {
 				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -890,11 +890,11 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
+			/omit-if-no-ref/ usart3_rts_remap2_pd12: usart3_rts_remap2_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
@@ -904,7 +904,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -912,7 +912,7 @@
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rx_pd6: usart2_rx_pd6 {
+			/omit-if-no-ref/ usart2_rx_remap1_pd6: usart2_rx_remap1_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
@@ -920,11 +920,11 @@
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pc11: usart3_rx_pc11 {
+			/omit-if-no-ref/ usart3_rx_remap1_pc11: usart3_rx_remap1_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pd9: usart3_rx_pd9 {
+			/omit-if-no-ref/ usart3_rx_remap2_pd9: usart3_rx_remap2_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
@@ -934,7 +934,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
@@ -942,7 +942,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_tx_pd5: usart2_tx_pd5 {
+			/omit-if-no-ref/ usart2_tx_remap1_pd5: usart2_tx_remap1_pd5 {
 				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -950,11 +950,11 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pc10: usart3_tx_pc10 {
+			/omit-if-no-ref/ usart3_tx_remap1_pc10: usart3_tx_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
+			/omit-if-no-ref/ usart3_tx_remap2_pd8: usart3_tx_remap2_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 

--- a/dts/st/f1/stm32f100v(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100v(c-d-e)tx-pinctrl.dtsi
@@ -415,7 +415,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -432,7 +432,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -449,7 +449,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -470,7 +470,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -488,7 +488,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -506,7 +506,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -524,7 +524,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -542,7 +542,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -561,7 +561,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -582,7 +582,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -596,7 +596,7 @@
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -604,7 +604,7 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -612,7 +612,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -620,7 +620,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -628,15 +628,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -652,31 +652,31 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_pe8: tim1_ch1n_remap2_pwm_pe8 {
 				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_pe9: tim1_ch1_remap2_pwm_pe9 {
 				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_pe10: tim1_ch2n_remap2_pwm_pe10 {
 				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_pe11: tim1_ch2_remap2_pwm_pe11 {
 				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_pe12: tim1_ch3n_remap2_pwm_pe12 {
 				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_pe13: tim1_ch3_remap2_pwm_pe13 {
 				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_pe14: tim1_ch4_remap2_pwm_pe14 {
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
@@ -684,7 +684,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -692,7 +692,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -700,7 +700,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -708,11 +708,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -720,7 +720,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -728,7 +728,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -736,7 +736,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -744,11 +744,11 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim12_ch1_pwm_pb12: tim12_ch1_pwm_pb12 {
+			/omit-if-no-ref/ tim12_ch1_remap1_pwm_pb12: tim12_ch1_remap1_pwm_pb12 {
 				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, TIM12_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim12_ch2_pwm_pb13: tim12_ch2_pwm_pb13 {
+			/omit-if-no-ref/ tim12_ch2_remap1_pwm_pb13: tim12_ch2_remap1_pwm_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM12_REMAP1)>;
 			};
 
@@ -768,7 +768,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim13_ch1_pwm_pb0: tim13_ch1_pwm_pb0 {
+			/omit-if-no-ref/ tim13_ch1_remap1_pwm_pb0: tim13_ch1_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM13_REMAP1)>;
 			};
 
@@ -776,7 +776,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -784,23 +784,23 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
@@ -808,15 +808,15 @@
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM13_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			/omit-if-no-ref/ tim14_ch1_remap1_pwm_pb1: tim14_ch1_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM14_REMAP1)>;
 			};
 
@@ -840,19 +840,19 @@
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM14_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
@@ -880,7 +880,7 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			/omit-if-no-ref/ tim15_ch1_remap1_pwm_pb14: tim15_ch1_remap1_pwm_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM15_REMAP1)>;
 			};
 
@@ -888,11 +888,11 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			/omit-if-no-ref/ tim15_ch2_remap1_pwm_pb15: tim15_ch2_remap1_pwm_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM15_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim16_ch1_remap1_pwm_pa6: tim16_ch1_remap1_pwm_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM16_REMAP1)>;
 			};
 
@@ -904,7 +904,7 @@
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM16_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			/omit-if-no-ref/ tim17_ch1_remap1_pwm_pa7: tim17_ch1_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM17_REMAP1)>;
 			};
 
@@ -930,7 +930,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
+			/omit-if-no-ref/ usart2_cts_remap1_pd3: usart2_cts_remap1_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -942,13 +942,13 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
+			/omit-if-no-ref/ usart3_cts_remap2_pd11: usart3_cts_remap2_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -964,7 +964,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
+			/omit-if-no-ref/ usart2_rts_remap1_pd4: usart2_rts_remap1_pd4 {
 				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -972,11 +972,11 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
+			/omit-if-no-ref/ usart3_rts_remap2_pd12: usart3_rts_remap2_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
@@ -986,7 +986,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -994,7 +994,7 @@
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rx_pd6: usart2_rx_pd6 {
+			/omit-if-no-ref/ usart2_rx_remap1_pd6: usart2_rx_remap1_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
@@ -1002,11 +1002,11 @@
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pc11: usart3_rx_pc11 {
+			/omit-if-no-ref/ usart3_rx_remap1_pc11: usart3_rx_remap1_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pd9: usart3_rx_pd9 {
+			/omit-if-no-ref/ usart3_rx_remap2_pd9: usart3_rx_remap2_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
@@ -1024,7 +1024,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
@@ -1032,7 +1032,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_tx_pd5: usart2_tx_pd5 {
+			/omit-if-no-ref/ usart2_tx_remap1_pd5: usart2_tx_remap1_pd5 {
 				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -1040,11 +1040,11 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pc10: usart3_tx_pc10 {
+			/omit-if-no-ref/ usart3_tx_remap1_pc10: usart3_tx_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
+			/omit-if-no-ref/ usart3_tx_remap2_pd8: usart3_tx_remap2_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 

--- a/dts/st/f1/stm32f100z(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100z(c-d-e)tx-pinctrl.dtsi
@@ -543,7 +543,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -560,7 +560,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -577,7 +577,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -598,7 +598,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -616,7 +616,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -634,7 +634,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -652,7 +652,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -670,7 +670,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -689,7 +689,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -710,7 +710,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -724,7 +724,7 @@
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -732,7 +732,7 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -740,7 +740,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -748,7 +748,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -756,15 +756,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -780,31 +780,31 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_pe8: tim1_ch1n_remap2_pwm_pe8 {
 				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_pe9: tim1_ch1_remap2_pwm_pe9 {
 				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_pe10: tim1_ch2n_remap2_pwm_pe10 {
 				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_pe11: tim1_ch2_remap2_pwm_pe11 {
 				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_pe12: tim1_ch3n_remap2_pwm_pe12 {
 				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_pe13: tim1_ch3_remap2_pwm_pe13 {
 				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_pe14: tim1_ch4_remap2_pwm_pe14 {
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
@@ -812,7 +812,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -820,7 +820,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -828,7 +828,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -836,11 +836,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -848,7 +848,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -856,7 +856,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -864,7 +864,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -872,11 +872,11 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim12_ch1_pwm_pb12: tim12_ch1_pwm_pb12 {
+			/omit-if-no-ref/ tim12_ch1_remap1_pwm_pb12: tim12_ch1_remap1_pwm_pb12 {
 				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, TIM12_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim12_ch2_pwm_pb13: tim12_ch2_pwm_pb13 {
+			/omit-if-no-ref/ tim12_ch2_remap1_pwm_pb13: tim12_ch2_remap1_pwm_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM12_REMAP1)>;
 			};
 
@@ -896,7 +896,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim13_ch1_pwm_pb0: tim13_ch1_pwm_pb0 {
+			/omit-if-no-ref/ tim13_ch1_remap1_pwm_pb0: tim13_ch1_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM13_REMAP1)>;
 			};
 
@@ -904,7 +904,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -912,23 +912,23 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
@@ -936,15 +936,15 @@
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM13_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim14_ch1_pwm_pb1: tim14_ch1_pwm_pb1 {
+			/omit-if-no-ref/ tim14_ch1_remap1_pwm_pb1: tim14_ch1_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM14_REMAP1)>;
 			};
 
@@ -968,19 +968,19 @@
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM14_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
@@ -1008,7 +1008,7 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch1_pwm_pb14: tim15_ch1_pwm_pb14 {
+			/omit-if-no-ref/ tim15_ch1_remap1_pwm_pb14: tim15_ch1_remap1_pwm_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM15_REMAP1)>;
 			};
 
@@ -1016,11 +1016,11 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch2_pwm_pb15: tim15_ch2_pwm_pb15 {
+			/omit-if-no-ref/ tim15_ch2_remap1_pwm_pb15: tim15_ch2_remap1_pwm_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM15_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim16_ch1_pwm_pa6: tim16_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim16_ch1_remap1_pwm_pa6: tim16_ch1_remap1_pwm_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM16_REMAP1)>;
 			};
 
@@ -1032,7 +1032,7 @@
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM16_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim17_ch1_pwm_pa7: tim17_ch1_pwm_pa7 {
+			/omit-if-no-ref/ tim17_ch1_remap1_pwm_pa7: tim17_ch1_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM17_REMAP1)>;
 			};
 
@@ -1058,7 +1058,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
+			/omit-if-no-ref/ usart2_cts_remap1_pd3: usart2_cts_remap1_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -1070,13 +1070,13 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
+			/omit-if-no-ref/ usart3_cts_remap2_pd11: usart3_cts_remap2_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -1092,7 +1092,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
+			/omit-if-no-ref/ usart2_rts_remap1_pd4: usart2_rts_remap1_pd4 {
 				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -1100,11 +1100,11 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
+			/omit-if-no-ref/ usart3_rts_remap2_pd12: usart3_rts_remap2_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
@@ -1114,7 +1114,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -1122,7 +1122,7 @@
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rx_pd6: usart2_rx_pd6 {
+			/omit-if-no-ref/ usart2_rx_remap1_pd6: usart2_rx_remap1_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
@@ -1130,11 +1130,11 @@
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pc11: usart3_rx_pc11 {
+			/omit-if-no-ref/ usart3_rx_remap1_pc11: usart3_rx_remap1_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pd9: usart3_rx_pd9 {
+			/omit-if-no-ref/ usart3_rx_remap2_pd9: usart3_rx_remap2_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
@@ -1152,7 +1152,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
@@ -1160,7 +1160,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_tx_pd5: usart2_tx_pd5 {
+			/omit-if-no-ref/ usart2_tx_remap1_pd5: usart2_tx_remap1_pd5 {
 				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -1168,11 +1168,11 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pc10: usart3_tx_pc10 {
+			/omit-if-no-ref/ usart3_tx_remap1_pc10: usart3_tx_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
+			/omit-if-no-ref/ usart3_tx_remap2_pd8: usart3_tx_remap2_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 

--- a/dts/st/f1/stm32f101c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101c(4-6)tx-pinctrl.dtsi
@@ -209,7 +209,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -221,7 +221,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -233,7 +233,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -244,7 +244,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -254,7 +254,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -264,7 +264,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -274,7 +274,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -284,7 +284,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -295,7 +295,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -306,7 +306,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -316,7 +316,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -324,7 +324,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -332,7 +332,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -340,11 +340,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -352,7 +352,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -360,7 +360,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -368,7 +368,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -388,7 +388,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -396,15 +396,15 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -438,7 +438,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -452,7 +452,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f101c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101c(8-b)tx-pinctrl.dtsi
@@ -209,7 +209,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -226,7 +226,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -243,7 +243,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -259,7 +259,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -273,7 +273,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -287,7 +287,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -301,7 +301,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -315,7 +315,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -330,7 +330,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -346,7 +346,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -360,7 +360,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -368,7 +368,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -376,7 +376,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -384,11 +384,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -396,7 +396,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -404,7 +404,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -412,7 +412,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -432,7 +432,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -440,15 +440,15 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -488,7 +488,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -508,7 +508,7 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
@@ -518,7 +518,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -536,7 +536,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f101c(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101c(8-b)ux-pinctrl.dtsi
@@ -209,7 +209,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -226,7 +226,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -243,7 +243,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -259,7 +259,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -273,7 +273,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -287,7 +287,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -301,7 +301,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -315,7 +315,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -330,7 +330,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -346,7 +346,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -360,7 +360,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -368,7 +368,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -376,7 +376,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -384,11 +384,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -396,7 +396,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -404,7 +404,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -412,7 +412,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -432,7 +432,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -440,15 +440,15 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -488,7 +488,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -508,7 +508,7 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
@@ -518,7 +518,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -536,7 +536,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f101r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101r(4-6)tx-pinctrl.dtsi
@@ -289,7 +289,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -301,7 +301,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -313,7 +313,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -324,7 +324,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -334,7 +334,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -344,7 +344,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -354,7 +354,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -364,7 +364,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -375,7 +375,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -386,7 +386,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -396,7 +396,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -404,7 +404,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -412,7 +412,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -420,11 +420,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -432,7 +432,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -440,7 +440,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -448,7 +448,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -468,7 +468,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -476,31 +476,31 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
@@ -534,7 +534,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -548,7 +548,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f101r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101r(8-b)tx-pinctrl.dtsi
@@ -289,7 +289,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -306,7 +306,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -323,7 +323,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -339,7 +339,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -353,7 +353,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -367,7 +367,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -381,7 +381,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -395,7 +395,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -410,7 +410,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -426,7 +426,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -440,7 +440,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -448,7 +448,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -456,7 +456,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -464,11 +464,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -476,7 +476,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -484,7 +484,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -492,7 +492,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -512,7 +512,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -520,31 +520,31 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
@@ -584,7 +584,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -604,7 +604,7 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
@@ -614,7 +614,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -626,7 +626,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pc11: usart3_rx_pc11 {
+			/omit-if-no-ref/ usart3_rx_remap1_pc11: usart3_rx_remap1_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
@@ -636,7 +636,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
@@ -648,7 +648,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pc10: usart3_tx_pc10 {
+			/omit-if-no-ref/ usart3_tx_remap1_pc10: usart3_tx_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f101r(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101r(c-d-e)tx-pinctrl.dtsi
@@ -299,7 +299,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -316,7 +316,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -333,7 +333,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -354,7 +354,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -372,7 +372,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -390,7 +390,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -408,7 +408,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -426,7 +426,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -445,7 +445,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -466,7 +466,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -484,7 +484,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -492,7 +492,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -500,7 +500,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -508,11 +508,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -520,7 +520,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -528,7 +528,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -536,7 +536,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -556,7 +556,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -564,31 +564,31 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
@@ -644,7 +644,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -664,7 +664,7 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
@@ -674,7 +674,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -686,7 +686,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pc11: usart3_rx_pc11 {
+			/omit-if-no-ref/ usart3_rx_remap1_pc11: usart3_rx_remap1_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
@@ -704,7 +704,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
@@ -716,7 +716,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pc10: usart3_tx_pc10 {
+			/omit-if-no-ref/ usart3_tx_remap1_pc10: usart3_tx_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f101r(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101r(f-g)tx-pinctrl.dtsi
@@ -299,7 +299,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -316,7 +316,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -333,7 +333,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -354,7 +354,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -372,7 +372,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -390,7 +390,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -408,7 +408,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -426,7 +426,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -445,7 +445,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -466,7 +466,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -492,7 +492,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -500,7 +500,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -508,7 +508,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -516,11 +516,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -528,7 +528,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -536,7 +536,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -544,7 +544,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -576,7 +576,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -584,31 +584,31 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
@@ -676,7 +676,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -696,7 +696,7 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
@@ -706,7 +706,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -718,7 +718,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pc11: usart3_rx_pc11 {
+			/omit-if-no-ref/ usart3_rx_remap1_pc11: usart3_rx_remap1_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
@@ -736,7 +736,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
@@ -748,7 +748,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pc10: usart3_tx_pc10 {
+			/omit-if-no-ref/ usart3_tx_remap1_pc10: usart3_tx_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f101rbhx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101rbhx-pinctrl.dtsi
@@ -281,7 +281,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -298,7 +298,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -315,7 +315,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -331,7 +331,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -345,7 +345,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -359,7 +359,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -373,7 +373,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -387,7 +387,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -402,7 +402,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -418,7 +418,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -432,7 +432,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -440,7 +440,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -448,7 +448,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -456,11 +456,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -468,7 +468,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -476,7 +476,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -484,7 +484,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -504,7 +504,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -512,31 +512,31 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
@@ -576,7 +576,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -596,7 +596,7 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
@@ -606,7 +606,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -618,7 +618,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pc11: usart3_rx_pc11 {
+			/omit-if-no-ref/ usart3_rx_remap1_pc11: usart3_rx_remap1_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
@@ -628,7 +628,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
@@ -640,7 +640,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pc10: usart3_tx_pc10 {
+			/omit-if-no-ref/ usart3_tx_remap1_pc10: usart3_tx_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f101t(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101t(4-6)ux-pinctrl.dtsi
@@ -179,7 +179,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -190,7 +190,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -200,7 +200,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -210,7 +210,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -220,7 +220,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -230,7 +230,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -241,7 +241,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -252,7 +252,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -262,7 +262,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -270,7 +270,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -278,7 +278,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -286,11 +286,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -298,7 +298,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -318,7 +318,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -326,15 +326,15 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -368,7 +368,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -382,7 +382,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f101t(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101t(8-b)ux-pinctrl.dtsi
@@ -179,7 +179,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -190,7 +190,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -200,7 +200,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -210,7 +210,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -220,7 +220,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -230,7 +230,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -241,7 +241,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -252,7 +252,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -262,7 +262,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -270,7 +270,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -278,7 +278,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -286,11 +286,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -298,7 +298,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -318,7 +318,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -326,15 +326,15 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -376,7 +376,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -390,7 +390,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f101v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101v(8-b)tx-pinctrl.dtsi
@@ -405,7 +405,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -422,7 +422,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -439,7 +439,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -455,7 +455,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -469,7 +469,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -483,7 +483,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -497,7 +497,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -511,7 +511,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -526,7 +526,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -542,7 +542,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -556,7 +556,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -564,7 +564,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -572,7 +572,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -580,11 +580,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -592,7 +592,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -600,7 +600,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -608,7 +608,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -628,7 +628,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -636,31 +636,31 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
@@ -680,19 +680,19 @@
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
@@ -710,7 +710,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
+			/omit-if-no-ref/ usart2_cts_remap1_pd3: usart2_cts_remap1_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -722,13 +722,13 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
+			/omit-if-no-ref/ usart3_cts_remap2_pd11: usart3_cts_remap2_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -744,7 +744,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
+			/omit-if-no-ref/ usart2_rts_remap1_pd4: usart2_rts_remap1_pd4 {
 				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -752,11 +752,11 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
+			/omit-if-no-ref/ usart3_rts_remap2_pd12: usart3_rts_remap2_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
@@ -766,7 +766,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -774,7 +774,7 @@
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rx_pd6: usart2_rx_pd6 {
+			/omit-if-no-ref/ usart2_rx_remap1_pd6: usart2_rx_remap1_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
@@ -782,11 +782,11 @@
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pc11: usart3_rx_pc11 {
+			/omit-if-no-ref/ usart3_rx_remap1_pc11: usart3_rx_remap1_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pd9: usart3_rx_pd9 {
+			/omit-if-no-ref/ usart3_rx_remap2_pd9: usart3_rx_remap2_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
@@ -796,7 +796,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
@@ -804,7 +804,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_tx_pd5: usart2_tx_pd5 {
+			/omit-if-no-ref/ usart2_tx_remap1_pd5: usart2_tx_remap1_pd5 {
 				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -812,11 +812,11 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pc10: usart3_tx_pc10 {
+			/omit-if-no-ref/ usart3_tx_remap1_pc10: usart3_tx_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
+			/omit-if-no-ref/ usart3_tx_remap2_pd8: usart3_tx_remap2_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 

--- a/dts/st/f1/stm32f101v(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101v(c-d-e)tx-pinctrl.dtsi
@@ -415,7 +415,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -432,7 +432,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -449,7 +449,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -470,7 +470,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -488,7 +488,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -506,7 +506,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -524,7 +524,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -542,7 +542,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -561,7 +561,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -582,7 +582,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -600,7 +600,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -608,7 +608,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -616,7 +616,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -624,11 +624,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -636,7 +636,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -644,7 +644,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -652,7 +652,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -672,7 +672,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -680,31 +680,31 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
@@ -724,19 +724,19 @@
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
@@ -770,7 +770,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
+			/omit-if-no-ref/ usart2_cts_remap1_pd3: usart2_cts_remap1_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -782,13 +782,13 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
+			/omit-if-no-ref/ usart3_cts_remap2_pd11: usart3_cts_remap2_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -804,7 +804,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
+			/omit-if-no-ref/ usart2_rts_remap1_pd4: usart2_rts_remap1_pd4 {
 				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -812,11 +812,11 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
+			/omit-if-no-ref/ usart3_rts_remap2_pd12: usart3_rts_remap2_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
@@ -826,7 +826,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -834,7 +834,7 @@
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rx_pd6: usart2_rx_pd6 {
+			/omit-if-no-ref/ usart2_rx_remap1_pd6: usart2_rx_remap1_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
@@ -842,11 +842,11 @@
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pc11: usart3_rx_pc11 {
+			/omit-if-no-ref/ usart3_rx_remap1_pc11: usart3_rx_remap1_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pd9: usart3_rx_pd9 {
+			/omit-if-no-ref/ usart3_rx_remap2_pd9: usart3_rx_remap2_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
@@ -864,7 +864,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
@@ -872,7 +872,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_tx_pd5: usart2_tx_pd5 {
+			/omit-if-no-ref/ usart2_tx_remap1_pd5: usart2_tx_remap1_pd5 {
 				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -880,11 +880,11 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pc10: usart3_tx_pc10 {
+			/omit-if-no-ref/ usart3_tx_remap1_pc10: usart3_tx_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
+			/omit-if-no-ref/ usart3_tx_remap2_pd8: usart3_tx_remap2_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 

--- a/dts/st/f1/stm32f101v(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101v(f-g)tx-pinctrl.dtsi
@@ -415,7 +415,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -432,7 +432,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -449,7 +449,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -470,7 +470,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -488,7 +488,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -506,7 +506,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -524,7 +524,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -542,7 +542,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -561,7 +561,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -582,7 +582,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -608,7 +608,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -616,7 +616,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -624,7 +624,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -632,11 +632,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -644,7 +644,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -652,7 +652,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -660,7 +660,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -692,7 +692,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -700,31 +700,31 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
@@ -748,19 +748,19 @@
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
@@ -788,11 +788,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM9_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			/omit-if-no-ref/ tim9_ch1_remap1_pwm_pe5: tim9_ch1_remap1_pwm_pe5 {
 				pinmux = <STM32F1_PINMUX('E', 5, ALTERNATE, TIM9_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			/omit-if-no-ref/ tim9_ch2_remap1_pwm_pe6: tim9_ch2_remap1_pwm_pe6 {
 				pinmux = <STM32F1_PINMUX('E', 6, ALTERNATE, TIM9_REMAP1)>;
 			};
 
@@ -810,7 +810,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
+			/omit-if-no-ref/ usart2_cts_remap1_pd3: usart2_cts_remap1_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -822,13 +822,13 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
+			/omit-if-no-ref/ usart3_cts_remap2_pd11: usart3_cts_remap2_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -844,7 +844,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
+			/omit-if-no-ref/ usart2_rts_remap1_pd4: usart2_rts_remap1_pd4 {
 				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -852,11 +852,11 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
+			/omit-if-no-ref/ usart3_rts_remap2_pd12: usart3_rts_remap2_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
@@ -866,7 +866,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -874,7 +874,7 @@
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rx_pd6: usart2_rx_pd6 {
+			/omit-if-no-ref/ usart2_rx_remap1_pd6: usart2_rx_remap1_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
@@ -882,11 +882,11 @@
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pc11: usart3_rx_pc11 {
+			/omit-if-no-ref/ usart3_rx_remap1_pc11: usart3_rx_remap1_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pd9: usart3_rx_pd9 {
+			/omit-if-no-ref/ usart3_rx_remap2_pd9: usart3_rx_remap2_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
@@ -904,7 +904,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
@@ -912,7 +912,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_tx_pd5: usart2_tx_pd5 {
+			/omit-if-no-ref/ usart2_tx_remap1_pd5: usart2_tx_remap1_pd5 {
 				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -920,11 +920,11 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pc10: usart3_tx_pc10 {
+			/omit-if-no-ref/ usart3_tx_remap1_pc10: usart3_tx_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
+			/omit-if-no-ref/ usart3_tx_remap2_pd8: usart3_tx_remap2_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 

--- a/dts/st/f1/stm32f101z(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101z(c-d-e)tx-pinctrl.dtsi
@@ -543,7 +543,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -560,7 +560,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -577,7 +577,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -598,7 +598,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -616,7 +616,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -634,7 +634,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -652,7 +652,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -670,7 +670,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -689,7 +689,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -710,7 +710,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -728,7 +728,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -736,7 +736,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -744,7 +744,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -752,11 +752,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -764,7 +764,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -772,7 +772,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -780,7 +780,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -800,7 +800,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -808,31 +808,31 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
@@ -852,19 +852,19 @@
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
@@ -898,7 +898,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
+			/omit-if-no-ref/ usart2_cts_remap1_pd3: usart2_cts_remap1_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -910,13 +910,13 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
+			/omit-if-no-ref/ usart3_cts_remap2_pd11: usart3_cts_remap2_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -932,7 +932,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
+			/omit-if-no-ref/ usart2_rts_remap1_pd4: usart2_rts_remap1_pd4 {
 				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -940,11 +940,11 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
+			/omit-if-no-ref/ usart3_rts_remap2_pd12: usart3_rts_remap2_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
@@ -954,7 +954,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -962,7 +962,7 @@
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rx_pd6: usart2_rx_pd6 {
+			/omit-if-no-ref/ usart2_rx_remap1_pd6: usart2_rx_remap1_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
@@ -970,11 +970,11 @@
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pc11: usart3_rx_pc11 {
+			/omit-if-no-ref/ usart3_rx_remap1_pc11: usart3_rx_remap1_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pd9: usart3_rx_pd9 {
+			/omit-if-no-ref/ usart3_rx_remap2_pd9: usart3_rx_remap2_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
@@ -992,7 +992,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
@@ -1000,7 +1000,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_tx_pd5: usart2_tx_pd5 {
+			/omit-if-no-ref/ usart2_tx_remap1_pd5: usart2_tx_remap1_pd5 {
 				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -1008,11 +1008,11 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pc10: usart3_tx_pc10 {
+			/omit-if-no-ref/ usart3_tx_remap1_pc10: usart3_tx_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
+			/omit-if-no-ref/ usart3_tx_remap2_pd8: usart3_tx_remap2_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 

--- a/dts/st/f1/stm32f101z(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101z(f-g)tx-pinctrl.dtsi
@@ -543,7 +543,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -560,7 +560,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -577,7 +577,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -598,7 +598,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -616,7 +616,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -634,7 +634,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -652,7 +652,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -670,7 +670,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -689,7 +689,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -710,7 +710,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -728,7 +728,7 @@
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM10_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			/omit-if-no-ref/ tim10_ch1_remap1_pwm_pf6: tim10_ch1_remap1_pwm_pf6 {
 				pinmux = <STM32F1_PINMUX('F', 6, ALTERNATE, TIM10_REMAP1)>;
 			};
 
@@ -736,7 +736,7 @@
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM11_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			/omit-if-no-ref/ tim11_ch1_remap1_pwm_pf7: tim11_ch1_remap1_pwm_pf7 {
 				pinmux = <STM32F1_PINMUX('F', 7, ALTERNATE, TIM11_REMAP1)>;
 			};
 
@@ -744,7 +744,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -752,7 +752,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -760,7 +760,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -768,11 +768,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -780,7 +780,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -788,7 +788,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -796,7 +796,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -828,7 +828,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -836,35 +836,35 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			/omit-if-no-ref/ tim13_ch1_remap1_pwm_pf8: tim13_ch1_remap1_pwm_pf8 {
 				pinmux = <STM32F1_PINMUX('F', 8, ALTERNATE, TIM13_REMAP1)>;
 			};
 
@@ -888,23 +888,23 @@
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			/omit-if-no-ref/ tim14_ch1_remap1_pwm_pf9: tim14_ch1_remap1_pwm_pf9 {
 				pinmux = <STM32F1_PINMUX('F', 9, ALTERNATE, TIM14_REMAP1)>;
 			};
 
@@ -932,11 +932,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM9_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			/omit-if-no-ref/ tim9_ch1_remap1_pwm_pe5: tim9_ch1_remap1_pwm_pe5 {
 				pinmux = <STM32F1_PINMUX('E', 5, ALTERNATE, TIM9_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			/omit-if-no-ref/ tim9_ch2_remap1_pwm_pe6: tim9_ch2_remap1_pwm_pe6 {
 				pinmux = <STM32F1_PINMUX('E', 6, ALTERNATE, TIM9_REMAP1)>;
 			};
 
@@ -954,7 +954,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
+			/omit-if-no-ref/ usart2_cts_remap1_pd3: usart2_cts_remap1_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -966,13 +966,13 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
+			/omit-if-no-ref/ usart3_cts_remap2_pd11: usart3_cts_remap2_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -988,7 +988,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
+			/omit-if-no-ref/ usart2_rts_remap1_pd4: usart2_rts_remap1_pd4 {
 				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -996,11 +996,11 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
+			/omit-if-no-ref/ usart3_rts_remap2_pd12: usart3_rts_remap2_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
@@ -1010,7 +1010,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -1018,7 +1018,7 @@
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rx_pd6: usart2_rx_pd6 {
+			/omit-if-no-ref/ usart2_rx_remap1_pd6: usart2_rx_remap1_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
@@ -1026,11 +1026,11 @@
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pc11: usart3_rx_pc11 {
+			/omit-if-no-ref/ usart3_rx_remap1_pc11: usart3_rx_remap1_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pd9: usart3_rx_pd9 {
+			/omit-if-no-ref/ usart3_rx_remap2_pd9: usart3_rx_remap2_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
@@ -1048,7 +1048,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
@@ -1056,7 +1056,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_tx_pd5: usart2_tx_pd5 {
+			/omit-if-no-ref/ usart2_tx_remap1_pd5: usart2_tx_remap1_pd5 {
 				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -1064,11 +1064,11 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pc10: usart3_tx_pc10 {
+			/omit-if-no-ref/ usart3_tx_remap1_pc10: usart3_tx_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
+			/omit-if-no-ref/ usart3_tx_remap2_pd8: usart3_tx_remap2_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 

--- a/dts/st/f1/stm32f102c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102c(4-6)tx-pinctrl.dtsi
@@ -209,7 +209,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -221,7 +221,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -233,7 +233,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -244,7 +244,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -254,7 +254,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -264,7 +264,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -274,7 +274,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -284,7 +284,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -295,7 +295,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -306,7 +306,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -316,7 +316,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -324,7 +324,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -332,7 +332,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -340,11 +340,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -352,7 +352,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -360,7 +360,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -368,7 +368,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -388,7 +388,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -396,15 +396,15 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -438,7 +438,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -452,7 +452,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f102c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102c(8-b)tx-pinctrl.dtsi
@@ -209,7 +209,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -226,7 +226,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -243,7 +243,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -259,7 +259,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -273,7 +273,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -287,7 +287,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -301,7 +301,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -315,7 +315,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -330,7 +330,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -346,7 +346,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -360,7 +360,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -368,7 +368,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -376,7 +376,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -384,11 +384,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -396,7 +396,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -404,7 +404,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -412,7 +412,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -432,7 +432,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -440,15 +440,15 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -488,7 +488,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -508,7 +508,7 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
@@ -518,7 +518,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -536,7 +536,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f102r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102r(4-6)tx-pinctrl.dtsi
@@ -289,7 +289,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -301,7 +301,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -313,7 +313,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -324,7 +324,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -334,7 +334,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -344,7 +344,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -354,7 +354,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -364,7 +364,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -375,7 +375,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -386,7 +386,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -396,7 +396,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -404,7 +404,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -412,7 +412,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -420,11 +420,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -432,7 +432,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -440,7 +440,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -448,7 +448,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -468,7 +468,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -476,31 +476,31 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
@@ -534,7 +534,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -548,7 +548,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f102r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102r(8-b)tx-pinctrl.dtsi
@@ -289,7 +289,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -306,7 +306,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -323,7 +323,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -339,7 +339,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -353,7 +353,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -367,7 +367,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -381,7 +381,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -395,7 +395,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -410,7 +410,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -426,7 +426,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -440,7 +440,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -448,7 +448,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -456,7 +456,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -464,11 +464,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -476,7 +476,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -484,7 +484,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -492,7 +492,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -512,7 +512,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -520,31 +520,31 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
@@ -584,7 +584,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -604,7 +604,7 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
@@ -614,7 +614,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -626,7 +626,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pc11: usart3_rx_pc11 {
+			/omit-if-no-ref/ usart3_rx_remap1_pc11: usart3_rx_remap1_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
@@ -636,7 +636,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
@@ -648,7 +648,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pc10: usart3_tx_pc10 {
+			/omit-if-no-ref/ usart3_tx_remap1_pc10: usart3_tx_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f103c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103c(4-6)tx-pinctrl.dtsi
@@ -248,7 +248,7 @@
 				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_rx_pb8: can_rx_pb8 {
+			/omit-if-no-ref/ can_rx_remap1_pb8: can_rx_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
@@ -258,7 +258,7 @@
 				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_tx_pb9: can_tx_pb9 {
+			/omit-if-no-ref/ can_tx_remap1_pb9: can_tx_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
@@ -269,7 +269,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -281,7 +281,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -293,7 +293,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -304,7 +304,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -314,7 +314,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -324,7 +324,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -334,7 +334,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -344,7 +344,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -355,7 +355,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -366,13 +366,13 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -380,7 +380,7 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -388,7 +388,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -396,7 +396,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -404,15 +404,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -432,7 +432,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -440,7 +440,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -448,7 +448,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -456,11 +456,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -468,7 +468,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -476,7 +476,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -484,7 +484,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -504,7 +504,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -512,15 +512,15 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -554,7 +554,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -568,7 +568,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f103c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103c(8-b)tx-pinctrl.dtsi
@@ -248,7 +248,7 @@
 				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_rx_pb8: can_rx_pb8 {
+			/omit-if-no-ref/ can_rx_remap1_pb8: can_rx_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
@@ -258,7 +258,7 @@
 				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_tx_pb9: can_tx_pb9 {
+			/omit-if-no-ref/ can_tx_remap1_pb9: can_tx_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
@@ -269,7 +269,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -286,7 +286,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -303,7 +303,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -319,7 +319,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -333,7 +333,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -347,7 +347,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -361,7 +361,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -375,7 +375,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -390,7 +390,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -406,7 +406,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -416,7 +416,7 @@
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -424,7 +424,7 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -432,7 +432,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -440,7 +440,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -448,15 +448,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -476,7 +476,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -484,7 +484,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -492,7 +492,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -500,11 +500,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -512,7 +512,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -520,7 +520,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -528,7 +528,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -548,7 +548,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -556,15 +556,15 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -604,7 +604,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -624,7 +624,7 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
@@ -634,7 +634,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -652,7 +652,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f103c6ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103c6ux-pinctrl.dtsi
@@ -248,7 +248,7 @@
 				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_rx_pb8: can_rx_pb8 {
+			/omit-if-no-ref/ can_rx_remap1_pb8: can_rx_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
@@ -258,7 +258,7 @@
 				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_tx_pb9: can_tx_pb9 {
+			/omit-if-no-ref/ can_tx_remap1_pb9: can_tx_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
@@ -269,7 +269,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -281,7 +281,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -293,7 +293,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -304,7 +304,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -314,7 +314,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -324,7 +324,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -334,7 +334,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -344,7 +344,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -355,7 +355,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -366,13 +366,13 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -380,7 +380,7 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -388,7 +388,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -396,7 +396,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -404,15 +404,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -432,7 +432,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -440,7 +440,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -448,7 +448,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -456,11 +456,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -468,7 +468,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -476,7 +476,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -484,7 +484,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -504,7 +504,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -512,15 +512,15 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -554,7 +554,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -568,7 +568,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f103cbux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103cbux-pinctrl.dtsi
@@ -248,7 +248,7 @@
 				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_rx_pb8: can_rx_pb8 {
+			/omit-if-no-ref/ can_rx_remap1_pb8: can_rx_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
@@ -258,7 +258,7 @@
 				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_tx_pb9: can_tx_pb9 {
+			/omit-if-no-ref/ can_tx_remap1_pb9: can_tx_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
@@ -269,7 +269,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -286,7 +286,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -303,7 +303,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -319,7 +319,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -333,7 +333,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -347,7 +347,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -361,7 +361,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -375,7 +375,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -390,7 +390,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -406,7 +406,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -416,7 +416,7 @@
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -424,7 +424,7 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -432,7 +432,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -440,7 +440,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -448,15 +448,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -476,7 +476,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -484,7 +484,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -492,7 +492,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -500,11 +500,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -512,7 +512,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -520,7 +520,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -528,7 +528,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -548,7 +548,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -556,15 +556,15 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -604,7 +604,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -624,7 +624,7 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
@@ -634,7 +634,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -652,7 +652,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f103r(4-6)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(4-6)hx-pinctrl.dtsi
@@ -340,7 +340,7 @@
 				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_rx_pb8: can_rx_pb8 {
+			/omit-if-no-ref/ can_rx_remap1_pb8: can_rx_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
@@ -350,7 +350,7 @@
 				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_tx_pb9: can_tx_pb9 {
+			/omit-if-no-ref/ can_tx_remap1_pb9: can_tx_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
@@ -361,7 +361,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -373,7 +373,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -385,7 +385,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -396,7 +396,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -406,7 +406,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -416,7 +416,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -426,7 +426,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -436,7 +436,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -447,7 +447,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -458,13 +458,13 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -472,7 +472,7 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -480,7 +480,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -488,7 +488,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -496,15 +496,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -524,7 +524,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -532,7 +532,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -540,7 +540,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -548,11 +548,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -560,7 +560,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -568,7 +568,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -576,7 +576,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -596,7 +596,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -604,31 +604,31 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
@@ -662,7 +662,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -676,7 +676,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f103r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(4-6)tx-pinctrl.dtsi
@@ -352,7 +352,7 @@
 				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_rx_pb8: can_rx_pb8 {
+			/omit-if-no-ref/ can_rx_remap1_pb8: can_rx_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
@@ -362,7 +362,7 @@
 				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_tx_pb9: can_tx_pb9 {
+			/omit-if-no-ref/ can_tx_remap1_pb9: can_tx_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
@@ -373,7 +373,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -385,7 +385,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -397,7 +397,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -408,7 +408,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -418,7 +418,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -428,7 +428,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -438,7 +438,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -448,7 +448,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -459,7 +459,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -470,13 +470,13 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -484,7 +484,7 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -492,7 +492,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -500,7 +500,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -508,15 +508,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -536,7 +536,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -544,7 +544,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -552,7 +552,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -560,11 +560,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -572,7 +572,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -580,7 +580,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -588,7 +588,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -608,7 +608,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -616,31 +616,31 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
@@ -674,7 +674,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -688,7 +688,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f103r(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(8-b)hx-pinctrl.dtsi
@@ -340,7 +340,7 @@
 				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_rx_pb8: can_rx_pb8 {
+			/omit-if-no-ref/ can_rx_remap1_pb8: can_rx_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
@@ -350,7 +350,7 @@
 				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_tx_pb9: can_tx_pb9 {
+			/omit-if-no-ref/ can_tx_remap1_pb9: can_tx_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
@@ -361,7 +361,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -378,7 +378,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -395,7 +395,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -411,7 +411,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -425,7 +425,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -439,7 +439,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -453,7 +453,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -467,7 +467,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -482,7 +482,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -498,7 +498,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -508,7 +508,7 @@
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -516,7 +516,7 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -524,7 +524,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -532,7 +532,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -540,15 +540,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -568,7 +568,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -576,7 +576,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -584,7 +584,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -592,11 +592,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -604,7 +604,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -612,7 +612,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -620,7 +620,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -640,7 +640,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -648,31 +648,31 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
@@ -712,7 +712,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -732,7 +732,7 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
@@ -742,7 +742,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -754,7 +754,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pc11: usart3_rx_pc11 {
+			/omit-if-no-ref/ usart3_rx_remap1_pc11: usart3_rx_remap1_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
@@ -764,7 +764,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
@@ -776,7 +776,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pc10: usart3_tx_pc10 {
+			/omit-if-no-ref/ usart3_tx_remap1_pc10: usart3_tx_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f103r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(8-b)tx-pinctrl.dtsi
@@ -352,7 +352,7 @@
 				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_rx_pb8: can_rx_pb8 {
+			/omit-if-no-ref/ can_rx_remap1_pb8: can_rx_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
@@ -362,7 +362,7 @@
 				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_tx_pb9: can_tx_pb9 {
+			/omit-if-no-ref/ can_tx_remap1_pb9: can_tx_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
@@ -373,7 +373,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -390,7 +390,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -407,7 +407,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -423,7 +423,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -437,7 +437,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -451,7 +451,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -465,7 +465,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -479,7 +479,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -494,7 +494,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -510,7 +510,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -520,7 +520,7 @@
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -528,7 +528,7 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -536,7 +536,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -544,7 +544,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -552,15 +552,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -580,7 +580,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -588,7 +588,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -596,7 +596,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -604,11 +604,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -616,7 +616,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -624,7 +624,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -632,7 +632,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -652,7 +652,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -660,31 +660,31 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
@@ -724,7 +724,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -744,7 +744,7 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
@@ -754,7 +754,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -766,7 +766,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pc11: usart3_rx_pc11 {
+			/omit-if-no-ref/ usart3_rx_remap1_pc11: usart3_rx_remap1_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
@@ -776,7 +776,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
@@ -788,7 +788,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pc10: usart3_tx_pc10 {
+			/omit-if-no-ref/ usart3_tx_remap1_pc10: usart3_tx_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f103r(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(c-d-e)tx-pinctrl.dtsi
@@ -384,7 +384,7 @@
 				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_rx_pb8: can_rx_pb8 {
+			/omit-if-no-ref/ can_rx_remap1_pb8: can_rx_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
@@ -394,7 +394,7 @@
 				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_tx_pb9: can_tx_pb9 {
+			/omit-if-no-ref/ can_tx_remap1_pb9: can_tx_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
@@ -415,7 +415,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -432,7 +432,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -479,7 +479,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -500,7 +500,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -518,7 +518,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -536,7 +536,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -554,7 +554,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -572,7 +572,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -591,7 +591,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -612,7 +612,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -626,7 +626,7 @@
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -634,7 +634,7 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -642,7 +642,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -650,7 +650,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -658,15 +658,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -686,7 +686,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -694,7 +694,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -702,7 +702,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -710,11 +710,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -722,7 +722,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -730,7 +730,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -738,7 +738,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -758,7 +758,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -766,31 +766,31 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
@@ -874,7 +874,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -894,7 +894,7 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
@@ -904,7 +904,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -916,7 +916,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pc11: usart3_rx_pc11 {
+			/omit-if-no-ref/ usart3_rx_remap1_pc11: usart3_rx_remap1_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
@@ -934,7 +934,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
@@ -946,7 +946,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pc10: usart3_tx_pc10 {
+			/omit-if-no-ref/ usart3_tx_remap1_pc10: usart3_tx_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f103r(c-d-e)yx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(c-d-e)yx-pinctrl.dtsi
@@ -368,7 +368,7 @@
 				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_rx_pb8: can_rx_pb8 {
+			/omit-if-no-ref/ can_rx_remap1_pb8: can_rx_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
@@ -378,7 +378,7 @@
 				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_tx_pb9: can_tx_pb9 {
+			/omit-if-no-ref/ can_tx_remap1_pb9: can_tx_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
@@ -399,7 +399,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -416,7 +416,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -463,7 +463,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -484,7 +484,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -502,7 +502,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -520,7 +520,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -538,7 +538,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -556,7 +556,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -575,7 +575,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -596,7 +596,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -610,7 +610,7 @@
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -618,7 +618,7 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -626,7 +626,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -634,7 +634,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -642,15 +642,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -670,7 +670,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -678,7 +678,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -686,7 +686,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -694,11 +694,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -706,7 +706,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -714,7 +714,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -722,7 +722,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -742,7 +742,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -750,31 +750,31 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
@@ -858,7 +858,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -878,7 +878,7 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
@@ -888,7 +888,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -900,7 +900,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pc11: usart3_rx_pc11 {
+			/omit-if-no-ref/ usart3_rx_remap1_pc11: usart3_rx_remap1_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
@@ -918,7 +918,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
@@ -930,7 +930,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pc10: usart3_tx_pc10 {
+			/omit-if-no-ref/ usart3_tx_remap1_pc10: usart3_tx_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f103r(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(f-g)tx-pinctrl.dtsi
@@ -384,7 +384,7 @@
 				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_rx_pb8: can_rx_pb8 {
+			/omit-if-no-ref/ can_rx_remap1_pb8: can_rx_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
@@ -394,7 +394,7 @@
 				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_tx_pb9: can_tx_pb9 {
+			/omit-if-no-ref/ can_tx_remap1_pb9: can_tx_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
@@ -415,7 +415,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -432,7 +432,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -479,7 +479,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -500,7 +500,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -518,7 +518,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -536,7 +536,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -554,7 +554,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -572,7 +572,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -591,7 +591,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -612,7 +612,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -630,7 +630,7 @@
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM10_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -638,7 +638,7 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -646,7 +646,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -654,7 +654,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -662,15 +662,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -694,7 +694,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -702,7 +702,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -710,7 +710,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -718,11 +718,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -730,7 +730,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -738,7 +738,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -746,7 +746,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -778,7 +778,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -786,31 +786,31 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
@@ -906,7 +906,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -926,7 +926,7 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
@@ -936,7 +936,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -948,7 +948,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pc11: usart3_rx_pc11 {
+			/omit-if-no-ref/ usart3_rx_remap1_pc11: usart3_rx_remap1_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
@@ -966,7 +966,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
@@ -978,7 +978,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pc10: usart3_tx_pc10 {
+			/omit-if-no-ref/ usart3_tx_remap1_pc10: usart3_tx_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f103t(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103t(4-6)ux-pinctrl.dtsi
@@ -231,7 +231,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -242,7 +242,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -252,7 +252,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -262,7 +262,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -272,7 +272,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -282,7 +282,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -293,7 +293,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -304,13 +304,13 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -318,7 +318,7 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -326,7 +326,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -334,7 +334,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -342,15 +342,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -358,7 +358,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -366,7 +366,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -374,7 +374,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -382,11 +382,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -394,7 +394,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -414,7 +414,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -422,15 +422,15 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -464,7 +464,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -478,7 +478,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f103t(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103t(8-b)ux-pinctrl.dtsi
@@ -231,7 +231,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -242,7 +242,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -252,7 +252,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -262,7 +262,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -272,7 +272,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -282,7 +282,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -293,7 +293,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -304,13 +304,13 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -318,7 +318,7 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -326,7 +326,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -334,7 +334,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -342,15 +342,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -358,7 +358,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -366,7 +366,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -374,7 +374,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -382,11 +382,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -394,7 +394,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -414,7 +414,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -422,15 +422,15 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -472,7 +472,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -486,7 +486,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f103v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(8-b)hx-pinctrl.dtsi
@@ -468,11 +468,11 @@
 				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_rx_pb8: can_rx_pb8 {
+			/omit-if-no-ref/ can_rx_remap1_pb8: can_rx_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ can_rx_pd0: can_rx_pd0 {
+			/omit-if-no-ref/ can_rx_remap2_pd0: can_rx_remap2_pd0 {
 				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, CAN_REMAP2)>;
 			};
 
@@ -482,11 +482,11 @@
 				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_tx_pb9: can_tx_pb9 {
+			/omit-if-no-ref/ can_tx_remap1_pb9: can_tx_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ can_tx_pd1: can_tx_pd1 {
+			/omit-if-no-ref/ can_tx_remap2_pd1: can_tx_remap2_pd1 {
 				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, CAN_REMAP2)>;
 			};
 
@@ -497,7 +497,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -514,7 +514,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -531,7 +531,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -547,7 +547,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -561,7 +561,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -575,7 +575,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -589,7 +589,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -603,7 +603,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -618,7 +618,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -634,7 +634,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -644,7 +644,7 @@
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -652,7 +652,7 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -660,7 +660,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -668,7 +668,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -676,15 +676,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -700,31 +700,31 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_pe8: tim1_ch1n_remap2_pwm_pe8 {
 				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_pe9: tim1_ch1_remap2_pwm_pe9 {
 				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_pe10: tim1_ch2n_remap2_pwm_pe10 {
 				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_pe11: tim1_ch2_remap2_pwm_pe11 {
 				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_pe12: tim1_ch3n_remap2_pwm_pe12 {
 				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_pe13: tim1_ch3_remap2_pwm_pe13 {
 				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_pe14: tim1_ch4_remap2_pwm_pe14 {
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
@@ -732,7 +732,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -740,7 +740,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -748,7 +748,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -756,11 +756,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -768,7 +768,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -776,7 +776,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -784,7 +784,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -804,7 +804,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -812,31 +812,31 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
@@ -856,19 +856,19 @@
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
@@ -886,7 +886,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
+			/omit-if-no-ref/ usart2_cts_remap1_pd3: usart2_cts_remap1_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -898,13 +898,13 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
+			/omit-if-no-ref/ usart3_cts_remap2_pd11: usart3_cts_remap2_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -920,7 +920,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
+			/omit-if-no-ref/ usart2_rts_remap1_pd4: usart2_rts_remap1_pd4 {
 				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -928,11 +928,11 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
+			/omit-if-no-ref/ usart3_rts_remap2_pd12: usart3_rts_remap2_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
@@ -942,7 +942,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -950,7 +950,7 @@
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rx_pd6: usart2_rx_pd6 {
+			/omit-if-no-ref/ usart2_rx_remap1_pd6: usart2_rx_remap1_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
@@ -958,11 +958,11 @@
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pc11: usart3_rx_pc11 {
+			/omit-if-no-ref/ usart3_rx_remap1_pc11: usart3_rx_remap1_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pd9: usart3_rx_pd9 {
+			/omit-if-no-ref/ usart3_rx_remap2_pd9: usart3_rx_remap2_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
@@ -972,7 +972,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
@@ -980,7 +980,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_tx_pd5: usart2_tx_pd5 {
+			/omit-if-no-ref/ usart2_tx_remap1_pd5: usart2_tx_remap1_pd5 {
 				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -988,11 +988,11 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pc10: usart3_tx_pc10 {
+			/omit-if-no-ref/ usart3_tx_remap1_pc10: usart3_tx_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
+			/omit-if-no-ref/ usart3_tx_remap2_pd8: usart3_tx_remap2_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 

--- a/dts/st/f1/stm32f103v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(8-b)tx-pinctrl.dtsi
@@ -468,11 +468,11 @@
 				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_rx_pb8: can_rx_pb8 {
+			/omit-if-no-ref/ can_rx_remap1_pb8: can_rx_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ can_rx_pd0: can_rx_pd0 {
+			/omit-if-no-ref/ can_rx_remap2_pd0: can_rx_remap2_pd0 {
 				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, CAN_REMAP2)>;
 			};
 
@@ -482,11 +482,11 @@
 				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_tx_pb9: can_tx_pb9 {
+			/omit-if-no-ref/ can_tx_remap1_pb9: can_tx_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ can_tx_pd1: can_tx_pd1 {
+			/omit-if-no-ref/ can_tx_remap2_pd1: can_tx_remap2_pd1 {
 				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, CAN_REMAP2)>;
 			};
 
@@ -497,7 +497,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -514,7 +514,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -531,7 +531,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -547,7 +547,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -561,7 +561,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -575,7 +575,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -589,7 +589,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -603,7 +603,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -618,7 +618,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -634,7 +634,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -644,7 +644,7 @@
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -652,7 +652,7 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -660,7 +660,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -668,7 +668,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -676,15 +676,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -700,31 +700,31 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_pe8: tim1_ch1n_remap2_pwm_pe8 {
 				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_pe9: tim1_ch1_remap2_pwm_pe9 {
 				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_pe10: tim1_ch2n_remap2_pwm_pe10 {
 				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_pe11: tim1_ch2_remap2_pwm_pe11 {
 				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_pe12: tim1_ch3n_remap2_pwm_pe12 {
 				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_pe13: tim1_ch3_remap2_pwm_pe13 {
 				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_pe14: tim1_ch4_remap2_pwm_pe14 {
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
@@ -732,7 +732,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -740,7 +740,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -748,7 +748,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -756,11 +756,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -768,7 +768,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -776,7 +776,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -784,7 +784,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -804,7 +804,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -812,31 +812,31 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
@@ -856,19 +856,19 @@
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
@@ -886,7 +886,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
+			/omit-if-no-ref/ usart2_cts_remap1_pd3: usart2_cts_remap1_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -898,13 +898,13 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
+			/omit-if-no-ref/ usart3_cts_remap2_pd11: usart3_cts_remap2_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -920,7 +920,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
+			/omit-if-no-ref/ usart2_rts_remap1_pd4: usart2_rts_remap1_pd4 {
 				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -928,11 +928,11 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
+			/omit-if-no-ref/ usart3_rts_remap2_pd12: usart3_rts_remap2_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
@@ -942,7 +942,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -950,7 +950,7 @@
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rx_pd6: usart2_rx_pd6 {
+			/omit-if-no-ref/ usart2_rx_remap1_pd6: usart2_rx_remap1_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
@@ -958,11 +958,11 @@
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pc11: usart3_rx_pc11 {
+			/omit-if-no-ref/ usart3_rx_remap1_pc11: usart3_rx_remap1_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pd9: usart3_rx_pd9 {
+			/omit-if-no-ref/ usart3_rx_remap2_pd9: usart3_rx_remap2_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
@@ -972,7 +972,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
@@ -980,7 +980,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_tx_pd5: usart2_tx_pd5 {
+			/omit-if-no-ref/ usart2_tx_remap1_pd5: usart2_tx_remap1_pd5 {
 				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -988,11 +988,11 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pc10: usart3_tx_pc10 {
+			/omit-if-no-ref/ usart3_tx_remap1_pc10: usart3_tx_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
+			/omit-if-no-ref/ usart3_tx_remap2_pd8: usart3_tx_remap2_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 

--- a/dts/st/f1/stm32f103v(c-d-e)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(c-d-e)hx-pinctrl.dtsi
@@ -500,11 +500,11 @@
 				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_rx_pb8: can_rx_pb8 {
+			/omit-if-no-ref/ can_rx_remap1_pb8: can_rx_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ can_rx_pd0: can_rx_pd0 {
+			/omit-if-no-ref/ can_rx_remap2_pd0: can_rx_remap2_pd0 {
 				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, CAN_REMAP2)>;
 			};
 
@@ -514,11 +514,11 @@
 				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_tx_pb9: can_tx_pb9 {
+			/omit-if-no-ref/ can_tx_remap1_pb9: can_tx_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ can_tx_pd1: can_tx_pd1 {
+			/omit-if-no-ref/ can_tx_remap2_pd1: can_tx_remap2_pd1 {
 				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, CAN_REMAP2)>;
 			};
 
@@ -539,7 +539,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -556,7 +556,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -603,7 +603,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -624,7 +624,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -642,7 +642,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -660,7 +660,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -678,7 +678,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -696,7 +696,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -715,7 +715,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -736,7 +736,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -750,7 +750,7 @@
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -758,7 +758,7 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -766,7 +766,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -774,7 +774,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -782,15 +782,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -806,31 +806,31 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_pe8: tim1_ch1n_remap2_pwm_pe8 {
 				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_pe9: tim1_ch1_remap2_pwm_pe9 {
 				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_pe10: tim1_ch2n_remap2_pwm_pe10 {
 				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_pe11: tim1_ch2_remap2_pwm_pe11 {
 				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_pe12: tim1_ch3n_remap2_pwm_pe12 {
 				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_pe13: tim1_ch3_remap2_pwm_pe13 {
 				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_pe14: tim1_ch4_remap2_pwm_pe14 {
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
@@ -838,7 +838,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -846,7 +846,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -854,7 +854,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -862,11 +862,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -874,7 +874,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -882,7 +882,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -890,7 +890,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -910,7 +910,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -918,31 +918,31 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
@@ -962,19 +962,19 @@
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
@@ -1036,7 +1036,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
+			/omit-if-no-ref/ usart2_cts_remap1_pd3: usart2_cts_remap1_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -1048,13 +1048,13 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
+			/omit-if-no-ref/ usart3_cts_remap2_pd11: usart3_cts_remap2_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -1070,7 +1070,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
+			/omit-if-no-ref/ usart2_rts_remap1_pd4: usart2_rts_remap1_pd4 {
 				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -1078,11 +1078,11 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
+			/omit-if-no-ref/ usart3_rts_remap2_pd12: usart3_rts_remap2_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
@@ -1092,7 +1092,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -1100,7 +1100,7 @@
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rx_pd6: usart2_rx_pd6 {
+			/omit-if-no-ref/ usart2_rx_remap1_pd6: usart2_rx_remap1_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
@@ -1108,11 +1108,11 @@
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pc11: usart3_rx_pc11 {
+			/omit-if-no-ref/ usart3_rx_remap1_pc11: usart3_rx_remap1_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pd9: usart3_rx_pd9 {
+			/omit-if-no-ref/ usart3_rx_remap2_pd9: usart3_rx_remap2_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
@@ -1130,7 +1130,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
@@ -1138,7 +1138,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_tx_pd5: usart2_tx_pd5 {
+			/omit-if-no-ref/ usart2_tx_remap1_pd5: usart2_tx_remap1_pd5 {
 				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -1146,11 +1146,11 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pc10: usart3_tx_pc10 {
+			/omit-if-no-ref/ usart3_tx_remap1_pc10: usart3_tx_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
+			/omit-if-no-ref/ usart3_tx_remap2_pd8: usart3_tx_remap2_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 

--- a/dts/st/f1/stm32f103v(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(c-d-e)tx-pinctrl.dtsi
@@ -500,11 +500,11 @@
 				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_rx_pb8: can_rx_pb8 {
+			/omit-if-no-ref/ can_rx_remap1_pb8: can_rx_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ can_rx_pd0: can_rx_pd0 {
+			/omit-if-no-ref/ can_rx_remap2_pd0: can_rx_remap2_pd0 {
 				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, CAN_REMAP2)>;
 			};
 
@@ -514,11 +514,11 @@
 				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_tx_pb9: can_tx_pb9 {
+			/omit-if-no-ref/ can_tx_remap1_pb9: can_tx_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ can_tx_pd1: can_tx_pd1 {
+			/omit-if-no-ref/ can_tx_remap2_pd1: can_tx_remap2_pd1 {
 				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, CAN_REMAP2)>;
 			};
 
@@ -539,7 +539,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -556,7 +556,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -603,7 +603,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -624,7 +624,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -642,7 +642,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -660,7 +660,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -678,7 +678,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -696,7 +696,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -715,7 +715,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -736,7 +736,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -750,7 +750,7 @@
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -758,7 +758,7 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -766,7 +766,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -774,7 +774,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -782,15 +782,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -806,31 +806,31 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_pe8: tim1_ch1n_remap2_pwm_pe8 {
 				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_pe9: tim1_ch1_remap2_pwm_pe9 {
 				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_pe10: tim1_ch2n_remap2_pwm_pe10 {
 				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_pe11: tim1_ch2_remap2_pwm_pe11 {
 				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_pe12: tim1_ch3n_remap2_pwm_pe12 {
 				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_pe13: tim1_ch3_remap2_pwm_pe13 {
 				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_pe14: tim1_ch4_remap2_pwm_pe14 {
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
@@ -838,7 +838,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -846,7 +846,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -854,7 +854,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -862,11 +862,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -874,7 +874,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -882,7 +882,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -890,7 +890,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -910,7 +910,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -918,31 +918,31 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
@@ -962,19 +962,19 @@
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
@@ -1036,7 +1036,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
+			/omit-if-no-ref/ usart2_cts_remap1_pd3: usart2_cts_remap1_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -1048,13 +1048,13 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
+			/omit-if-no-ref/ usart3_cts_remap2_pd11: usart3_cts_remap2_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -1070,7 +1070,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
+			/omit-if-no-ref/ usart2_rts_remap1_pd4: usart2_rts_remap1_pd4 {
 				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -1078,11 +1078,11 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
+			/omit-if-no-ref/ usart3_rts_remap2_pd12: usart3_rts_remap2_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
@@ -1092,7 +1092,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -1100,7 +1100,7 @@
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rx_pd6: usart2_rx_pd6 {
+			/omit-if-no-ref/ usart2_rx_remap1_pd6: usart2_rx_remap1_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
@@ -1108,11 +1108,11 @@
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pc11: usart3_rx_pc11 {
+			/omit-if-no-ref/ usart3_rx_remap1_pc11: usart3_rx_remap1_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pd9: usart3_rx_pd9 {
+			/omit-if-no-ref/ usart3_rx_remap2_pd9: usart3_rx_remap2_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
@@ -1130,7 +1130,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
@@ -1138,7 +1138,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_tx_pd5: usart2_tx_pd5 {
+			/omit-if-no-ref/ usart2_tx_remap1_pd5: usart2_tx_remap1_pd5 {
 				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -1146,11 +1146,11 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pc10: usart3_tx_pc10 {
+			/omit-if-no-ref/ usart3_tx_remap1_pc10: usart3_tx_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
+			/omit-if-no-ref/ usart3_tx_remap2_pd8: usart3_tx_remap2_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 

--- a/dts/st/f1/stm32f103v(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(f-g)tx-pinctrl.dtsi
@@ -500,11 +500,11 @@
 				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_rx_pb8: can_rx_pb8 {
+			/omit-if-no-ref/ can_rx_remap1_pb8: can_rx_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ can_rx_pd0: can_rx_pd0 {
+			/omit-if-no-ref/ can_rx_remap2_pd0: can_rx_remap2_pd0 {
 				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, CAN_REMAP2)>;
 			};
 
@@ -514,11 +514,11 @@
 				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_tx_pb9: can_tx_pb9 {
+			/omit-if-no-ref/ can_tx_remap1_pb9: can_tx_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ can_tx_pd1: can_tx_pd1 {
+			/omit-if-no-ref/ can_tx_remap2_pd1: can_tx_remap2_pd1 {
 				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, CAN_REMAP2)>;
 			};
 
@@ -539,7 +539,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -556,7 +556,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -603,7 +603,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -624,7 +624,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -642,7 +642,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -660,7 +660,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -678,7 +678,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -696,7 +696,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -715,7 +715,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -736,7 +736,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -754,7 +754,7 @@
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM10_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -762,7 +762,7 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -770,7 +770,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -778,7 +778,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -786,15 +786,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -814,31 +814,31 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_pe8: tim1_ch1n_remap2_pwm_pe8 {
 				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_pe9: tim1_ch1_remap2_pwm_pe9 {
 				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_pe10: tim1_ch2n_remap2_pwm_pe10 {
 				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_pe11: tim1_ch2_remap2_pwm_pe11 {
 				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_pe12: tim1_ch3n_remap2_pwm_pe12 {
 				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_pe13: tim1_ch3_remap2_pwm_pe13 {
 				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_pe14: tim1_ch4_remap2_pwm_pe14 {
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
@@ -846,7 +846,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -854,7 +854,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -862,7 +862,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -870,11 +870,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -882,7 +882,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -890,7 +890,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -898,7 +898,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -930,7 +930,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -938,31 +938,31 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
@@ -986,19 +986,19 @@
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
@@ -1054,11 +1054,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM9_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			/omit-if-no-ref/ tim9_ch1_remap1_pwm_pe5: tim9_ch1_remap1_pwm_pe5 {
 				pinmux = <STM32F1_PINMUX('E', 5, ALTERNATE, TIM9_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			/omit-if-no-ref/ tim9_ch2_remap1_pwm_pe6: tim9_ch2_remap1_pwm_pe6 {
 				pinmux = <STM32F1_PINMUX('E', 6, ALTERNATE, TIM9_REMAP1)>;
 			};
 
@@ -1076,7 +1076,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
+			/omit-if-no-ref/ usart2_cts_remap1_pd3: usart2_cts_remap1_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -1088,13 +1088,13 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
+			/omit-if-no-ref/ usart3_cts_remap2_pd11: usart3_cts_remap2_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -1110,7 +1110,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
+			/omit-if-no-ref/ usart2_rts_remap1_pd4: usart2_rts_remap1_pd4 {
 				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -1118,11 +1118,11 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
+			/omit-if-no-ref/ usart3_rts_remap2_pd12: usart3_rts_remap2_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
@@ -1132,7 +1132,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -1140,7 +1140,7 @@
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rx_pd6: usart2_rx_pd6 {
+			/omit-if-no-ref/ usart2_rx_remap1_pd6: usart2_rx_remap1_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
@@ -1148,11 +1148,11 @@
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pc11: usart3_rx_pc11 {
+			/omit-if-no-ref/ usart3_rx_remap1_pc11: usart3_rx_remap1_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pd9: usart3_rx_pd9 {
+			/omit-if-no-ref/ usart3_rx_remap2_pd9: usart3_rx_remap2_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
@@ -1170,7 +1170,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
@@ -1178,7 +1178,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_tx_pd5: usart2_tx_pd5 {
+			/omit-if-no-ref/ usart2_tx_remap1_pd5: usart2_tx_remap1_pd5 {
 				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -1186,11 +1186,11 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pc10: usart3_tx_pc10 {
+			/omit-if-no-ref/ usart3_tx_remap1_pc10: usart3_tx_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
+			/omit-if-no-ref/ usart3_tx_remap2_pd8: usart3_tx_remap2_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 

--- a/dts/st/f1/stm32f103vbix-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103vbix-pinctrl.dtsi
@@ -468,11 +468,11 @@
 				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_rx_pb8: can_rx_pb8 {
+			/omit-if-no-ref/ can_rx_remap1_pb8: can_rx_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ can_rx_pd0: can_rx_pd0 {
+			/omit-if-no-ref/ can_rx_remap2_pd0: can_rx_remap2_pd0 {
 				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, CAN_REMAP2)>;
 			};
 
@@ -482,11 +482,11 @@
 				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_tx_pb9: can_tx_pb9 {
+			/omit-if-no-ref/ can_tx_remap1_pb9: can_tx_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ can_tx_pd1: can_tx_pd1 {
+			/omit-if-no-ref/ can_tx_remap2_pd1: can_tx_remap2_pd1 {
 				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, CAN_REMAP2)>;
 			};
 
@@ -497,7 +497,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -514,7 +514,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -531,7 +531,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -547,7 +547,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -561,7 +561,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -575,7 +575,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -589,7 +589,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -603,7 +603,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -618,7 +618,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -634,7 +634,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -644,7 +644,7 @@
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -652,7 +652,7 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -660,7 +660,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -668,7 +668,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -676,15 +676,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -700,31 +700,31 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_pe8: tim1_ch1n_remap2_pwm_pe8 {
 				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_pe9: tim1_ch1_remap2_pwm_pe9 {
 				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_pe10: tim1_ch2n_remap2_pwm_pe10 {
 				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_pe11: tim1_ch2_remap2_pwm_pe11 {
 				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_pe12: tim1_ch3n_remap2_pwm_pe12 {
 				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_pe13: tim1_ch3_remap2_pwm_pe13 {
 				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_pe14: tim1_ch4_remap2_pwm_pe14 {
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
@@ -732,7 +732,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -740,7 +740,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -748,7 +748,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -756,11 +756,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -768,7 +768,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -776,7 +776,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -784,7 +784,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -804,7 +804,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -812,31 +812,31 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
@@ -856,19 +856,19 @@
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
@@ -886,7 +886,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
+			/omit-if-no-ref/ usart2_cts_remap1_pd3: usart2_cts_remap1_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -898,13 +898,13 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
+			/omit-if-no-ref/ usart3_cts_remap2_pd11: usart3_cts_remap2_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -920,7 +920,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
+			/omit-if-no-ref/ usart2_rts_remap1_pd4: usart2_rts_remap1_pd4 {
 				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -928,11 +928,11 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
+			/omit-if-no-ref/ usart3_rts_remap2_pd12: usart3_rts_remap2_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
@@ -942,7 +942,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -950,7 +950,7 @@
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rx_pd6: usart2_rx_pd6 {
+			/omit-if-no-ref/ usart2_rx_remap1_pd6: usart2_rx_remap1_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
@@ -958,11 +958,11 @@
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pc11: usart3_rx_pc11 {
+			/omit-if-no-ref/ usart3_rx_remap1_pc11: usart3_rx_remap1_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pd9: usart3_rx_pd9 {
+			/omit-if-no-ref/ usart3_rx_remap2_pd9: usart3_rx_remap2_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
@@ -972,7 +972,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
@@ -980,7 +980,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_tx_pd5: usart2_tx_pd5 {
+			/omit-if-no-ref/ usart2_tx_remap1_pd5: usart2_tx_remap1_pd5 {
 				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -988,11 +988,11 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pc10: usart3_tx_pc10 {
+			/omit-if-no-ref/ usart3_tx_remap1_pc10: usart3_tx_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
+			/omit-if-no-ref/ usart3_tx_remap2_pd8: usart3_tx_remap2_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 

--- a/dts/st/f1/stm32f103z(c-d-e)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(c-d-e)hx-pinctrl.dtsi
@@ -648,11 +648,11 @@
 				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_rx_pb8: can_rx_pb8 {
+			/omit-if-no-ref/ can_rx_remap1_pb8: can_rx_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ can_rx_pd0: can_rx_pd0 {
+			/omit-if-no-ref/ can_rx_remap2_pd0: can_rx_remap2_pd0 {
 				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, CAN_REMAP2)>;
 			};
 
@@ -662,11 +662,11 @@
 				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_tx_pb9: can_tx_pb9 {
+			/omit-if-no-ref/ can_tx_remap1_pb9: can_tx_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ can_tx_pd1: can_tx_pd1 {
+			/omit-if-no-ref/ can_tx_remap2_pd1: can_tx_remap2_pd1 {
 				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, CAN_REMAP2)>;
 			};
 
@@ -687,7 +687,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -704,7 +704,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -751,7 +751,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -772,7 +772,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -790,7 +790,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -808,7 +808,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -826,7 +826,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -844,7 +844,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -863,7 +863,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -884,7 +884,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -898,7 +898,7 @@
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -906,7 +906,7 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -914,7 +914,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -922,7 +922,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -930,15 +930,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -954,31 +954,31 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_pe8: tim1_ch1n_remap2_pwm_pe8 {
 				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_pe9: tim1_ch1_remap2_pwm_pe9 {
 				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_pe10: tim1_ch2n_remap2_pwm_pe10 {
 				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_pe11: tim1_ch2_remap2_pwm_pe11 {
 				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_pe12: tim1_ch3n_remap2_pwm_pe12 {
 				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_pe13: tim1_ch3_remap2_pwm_pe13 {
 				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_pe14: tim1_ch4_remap2_pwm_pe14 {
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
@@ -986,7 +986,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -994,7 +994,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -1002,7 +1002,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -1010,11 +1010,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -1022,7 +1022,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -1030,7 +1030,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -1038,7 +1038,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -1058,7 +1058,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -1066,31 +1066,31 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
@@ -1110,19 +1110,19 @@
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
@@ -1184,7 +1184,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
+			/omit-if-no-ref/ usart2_cts_remap1_pd3: usart2_cts_remap1_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -1196,13 +1196,13 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
+			/omit-if-no-ref/ usart3_cts_remap2_pd11: usart3_cts_remap2_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -1218,7 +1218,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
+			/omit-if-no-ref/ usart2_rts_remap1_pd4: usart2_rts_remap1_pd4 {
 				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -1226,11 +1226,11 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
+			/omit-if-no-ref/ usart3_rts_remap2_pd12: usart3_rts_remap2_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
@@ -1240,7 +1240,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -1248,7 +1248,7 @@
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rx_pd6: usart2_rx_pd6 {
+			/omit-if-no-ref/ usart2_rx_remap1_pd6: usart2_rx_remap1_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
@@ -1256,11 +1256,11 @@
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pc11: usart3_rx_pc11 {
+			/omit-if-no-ref/ usart3_rx_remap1_pc11: usart3_rx_remap1_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pd9: usart3_rx_pd9 {
+			/omit-if-no-ref/ usart3_rx_remap2_pd9: usart3_rx_remap2_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
@@ -1278,7 +1278,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
@@ -1286,7 +1286,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_tx_pd5: usart2_tx_pd5 {
+			/omit-if-no-ref/ usart2_tx_remap1_pd5: usart2_tx_remap1_pd5 {
 				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -1294,11 +1294,11 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pc10: usart3_tx_pc10 {
+			/omit-if-no-ref/ usart3_tx_remap1_pc10: usart3_tx_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
+			/omit-if-no-ref/ usart3_tx_remap2_pd8: usart3_tx_remap2_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 

--- a/dts/st/f1/stm32f103z(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(c-d-e)tx-pinctrl.dtsi
@@ -648,11 +648,11 @@
 				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_rx_pb8: can_rx_pb8 {
+			/omit-if-no-ref/ can_rx_remap1_pb8: can_rx_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ can_rx_pd0: can_rx_pd0 {
+			/omit-if-no-ref/ can_rx_remap2_pd0: can_rx_remap2_pd0 {
 				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, CAN_REMAP2)>;
 			};
 
@@ -662,11 +662,11 @@
 				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_tx_pb9: can_tx_pb9 {
+			/omit-if-no-ref/ can_tx_remap1_pb9: can_tx_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ can_tx_pd1: can_tx_pd1 {
+			/omit-if-no-ref/ can_tx_remap2_pd1: can_tx_remap2_pd1 {
 				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, CAN_REMAP2)>;
 			};
 
@@ -687,7 +687,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -704,7 +704,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -751,7 +751,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -772,7 +772,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -790,7 +790,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -808,7 +808,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -826,7 +826,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -844,7 +844,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -863,7 +863,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -884,7 +884,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -898,7 +898,7 @@
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -906,7 +906,7 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -914,7 +914,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -922,7 +922,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -930,15 +930,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -954,31 +954,31 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_pe8: tim1_ch1n_remap2_pwm_pe8 {
 				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_pe9: tim1_ch1_remap2_pwm_pe9 {
 				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_pe10: tim1_ch2n_remap2_pwm_pe10 {
 				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_pe11: tim1_ch2_remap2_pwm_pe11 {
 				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_pe12: tim1_ch3n_remap2_pwm_pe12 {
 				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_pe13: tim1_ch3_remap2_pwm_pe13 {
 				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_pe14: tim1_ch4_remap2_pwm_pe14 {
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
@@ -986,7 +986,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -994,7 +994,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -1002,7 +1002,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -1010,11 +1010,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -1022,7 +1022,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -1030,7 +1030,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -1038,7 +1038,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -1058,7 +1058,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -1066,31 +1066,31 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
@@ -1110,19 +1110,19 @@
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
@@ -1184,7 +1184,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
+			/omit-if-no-ref/ usart2_cts_remap1_pd3: usart2_cts_remap1_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -1196,13 +1196,13 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
+			/omit-if-no-ref/ usart3_cts_remap2_pd11: usart3_cts_remap2_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -1218,7 +1218,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
+			/omit-if-no-ref/ usart2_rts_remap1_pd4: usart2_rts_remap1_pd4 {
 				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -1226,11 +1226,11 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
+			/omit-if-no-ref/ usart3_rts_remap2_pd12: usart3_rts_remap2_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
@@ -1240,7 +1240,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -1248,7 +1248,7 @@
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rx_pd6: usart2_rx_pd6 {
+			/omit-if-no-ref/ usart2_rx_remap1_pd6: usart2_rx_remap1_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
@@ -1256,11 +1256,11 @@
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pc11: usart3_rx_pc11 {
+			/omit-if-no-ref/ usart3_rx_remap1_pc11: usart3_rx_remap1_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pd9: usart3_rx_pd9 {
+			/omit-if-no-ref/ usart3_rx_remap2_pd9: usart3_rx_remap2_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
@@ -1278,7 +1278,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
@@ -1286,7 +1286,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_tx_pd5: usart2_tx_pd5 {
+			/omit-if-no-ref/ usart2_tx_remap1_pd5: usart2_tx_remap1_pd5 {
 				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -1294,11 +1294,11 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pc10: usart3_tx_pc10 {
+			/omit-if-no-ref/ usart3_tx_remap1_pc10: usart3_tx_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
+			/omit-if-no-ref/ usart3_tx_remap2_pd8: usart3_tx_remap2_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 

--- a/dts/st/f1/stm32f103z(f-g)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(f-g)hx-pinctrl.dtsi
@@ -648,11 +648,11 @@
 				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_rx_pb8: can_rx_pb8 {
+			/omit-if-no-ref/ can_rx_remap1_pb8: can_rx_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ can_rx_pd0: can_rx_pd0 {
+			/omit-if-no-ref/ can_rx_remap2_pd0: can_rx_remap2_pd0 {
 				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, CAN_REMAP2)>;
 			};
 
@@ -662,11 +662,11 @@
 				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_tx_pb9: can_tx_pb9 {
+			/omit-if-no-ref/ can_tx_remap1_pb9: can_tx_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ can_tx_pd1: can_tx_pd1 {
+			/omit-if-no-ref/ can_tx_remap2_pd1: can_tx_remap2_pd1 {
 				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, CAN_REMAP2)>;
 			};
 
@@ -687,7 +687,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -704,7 +704,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -751,7 +751,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -772,7 +772,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -790,7 +790,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -808,7 +808,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -826,7 +826,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -844,7 +844,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -863,7 +863,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -884,7 +884,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -902,11 +902,11 @@
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM10_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			/omit-if-no-ref/ tim10_ch1_remap1_pwm_pf6: tim10_ch1_remap1_pwm_pf6 {
 				pinmux = <STM32F1_PINMUX('F', 6, ALTERNATE, TIM10_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -914,7 +914,7 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -922,7 +922,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -930,7 +930,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -938,15 +938,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -966,35 +966,35 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_pe8: tim1_ch1n_remap2_pwm_pe8 {
 				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_pe9: tim1_ch1_remap2_pwm_pe9 {
 				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_pe10: tim1_ch2n_remap2_pwm_pe10 {
 				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_pe11: tim1_ch2_remap2_pwm_pe11 {
 				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_pe12: tim1_ch3n_remap2_pwm_pe12 {
 				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_pe13: tim1_ch3_remap2_pwm_pe13 {
 				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_pe14: tim1_ch4_remap2_pwm_pe14 {
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			/omit-if-no-ref/ tim11_ch1_remap1_pwm_pf7: tim11_ch1_remap1_pwm_pf7 {
 				pinmux = <STM32F1_PINMUX('F', 7, ALTERNATE, TIM11_REMAP1)>;
 			};
 
@@ -1002,7 +1002,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -1010,7 +1010,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -1018,7 +1018,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -1026,11 +1026,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -1038,7 +1038,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -1046,7 +1046,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -1054,7 +1054,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -1086,7 +1086,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -1094,35 +1094,35 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			/omit-if-no-ref/ tim13_ch1_remap1_pwm_pf8: tim13_ch1_remap1_pwm_pf8 {
 				pinmux = <STM32F1_PINMUX('F', 8, ALTERNATE, TIM13_REMAP1)>;
 			};
 
@@ -1146,23 +1146,23 @@
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			/omit-if-no-ref/ tim14_ch1_remap1_pwm_pf9: tim14_ch1_remap1_pwm_pf9 {
 				pinmux = <STM32F1_PINMUX('F', 9, ALTERNATE, TIM14_REMAP1)>;
 			};
 
@@ -1218,11 +1218,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM9_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			/omit-if-no-ref/ tim9_ch1_remap1_pwm_pe5: tim9_ch1_remap1_pwm_pe5 {
 				pinmux = <STM32F1_PINMUX('E', 5, ALTERNATE, TIM9_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			/omit-if-no-ref/ tim9_ch2_remap1_pwm_pe6: tim9_ch2_remap1_pwm_pe6 {
 				pinmux = <STM32F1_PINMUX('E', 6, ALTERNATE, TIM9_REMAP1)>;
 			};
 
@@ -1240,7 +1240,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
+			/omit-if-no-ref/ usart2_cts_remap1_pd3: usart2_cts_remap1_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -1252,13 +1252,13 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
+			/omit-if-no-ref/ usart3_cts_remap2_pd11: usart3_cts_remap2_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -1274,7 +1274,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
+			/omit-if-no-ref/ usart2_rts_remap1_pd4: usart2_rts_remap1_pd4 {
 				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -1282,11 +1282,11 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
+			/omit-if-no-ref/ usart3_rts_remap2_pd12: usart3_rts_remap2_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
@@ -1296,7 +1296,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -1304,7 +1304,7 @@
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rx_pd6: usart2_rx_pd6 {
+			/omit-if-no-ref/ usart2_rx_remap1_pd6: usart2_rx_remap1_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
@@ -1312,11 +1312,11 @@
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pc11: usart3_rx_pc11 {
+			/omit-if-no-ref/ usart3_rx_remap1_pc11: usart3_rx_remap1_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pd9: usart3_rx_pd9 {
+			/omit-if-no-ref/ usart3_rx_remap2_pd9: usart3_rx_remap2_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
@@ -1334,7 +1334,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
@@ -1342,7 +1342,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_tx_pd5: usart2_tx_pd5 {
+			/omit-if-no-ref/ usart2_tx_remap1_pd5: usart2_tx_remap1_pd5 {
 				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -1350,11 +1350,11 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pc10: usart3_tx_pc10 {
+			/omit-if-no-ref/ usart3_tx_remap1_pc10: usart3_tx_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
+			/omit-if-no-ref/ usart3_tx_remap2_pd8: usart3_tx_remap2_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 

--- a/dts/st/f1/stm32f103z(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(f-g)tx-pinctrl.dtsi
@@ -648,11 +648,11 @@
 				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_rx_pb8: can_rx_pb8 {
+			/omit-if-no-ref/ can_rx_remap1_pb8: can_rx_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ can_rx_pd0: can_rx_pd0 {
+			/omit-if-no-ref/ can_rx_remap2_pd0: can_rx_remap2_pd0 {
 				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, CAN_REMAP2)>;
 			};
 
@@ -662,11 +662,11 @@
 				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can_tx_pb9: can_tx_pb9 {
+			/omit-if-no-ref/ can_tx_remap1_pb9: can_tx_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ can_tx_pd1: can_tx_pd1 {
+			/omit-if-no-ref/ can_tx_remap2_pd1: can_tx_remap2_pd1 {
 				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, CAN_REMAP2)>;
 			};
 
@@ -687,7 +687,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -704,7 +704,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -751,7 +751,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -772,7 +772,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -790,7 +790,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -808,7 +808,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -826,7 +826,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -844,7 +844,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -863,7 +863,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -884,7 +884,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -902,11 +902,11 @@
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM10_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim10_ch1_pwm_pf6: tim10_ch1_pwm_pf6 {
+			/omit-if-no-ref/ tim10_ch1_remap1_pwm_pf6: tim10_ch1_remap1_pwm_pf6 {
 				pinmux = <STM32F1_PINMUX('F', 6, ALTERNATE, TIM10_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -914,7 +914,7 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -922,7 +922,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -930,7 +930,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -938,15 +938,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -966,35 +966,35 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_pe8: tim1_ch1n_remap2_pwm_pe8 {
 				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_pe9: tim1_ch1_remap2_pwm_pe9 {
 				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_pe10: tim1_ch2n_remap2_pwm_pe10 {
 				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_pe11: tim1_ch2_remap2_pwm_pe11 {
 				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_pe12: tim1_ch3n_remap2_pwm_pe12 {
 				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_pe13: tim1_ch3_remap2_pwm_pe13 {
 				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_pe14: tim1_ch4_remap2_pwm_pe14 {
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim11_ch1_pwm_pf7: tim11_ch1_pwm_pf7 {
+			/omit-if-no-ref/ tim11_ch1_remap1_pwm_pf7: tim11_ch1_remap1_pwm_pf7 {
 				pinmux = <STM32F1_PINMUX('F', 7, ALTERNATE, TIM11_REMAP1)>;
 			};
 
@@ -1002,7 +1002,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -1010,7 +1010,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -1018,7 +1018,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -1026,11 +1026,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -1038,7 +1038,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -1046,7 +1046,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -1054,7 +1054,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -1086,7 +1086,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -1094,35 +1094,35 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim13_ch1_pwm_pf8: tim13_ch1_pwm_pf8 {
+			/omit-if-no-ref/ tim13_ch1_remap1_pwm_pf8: tim13_ch1_remap1_pwm_pf8 {
 				pinmux = <STM32F1_PINMUX('F', 8, ALTERNATE, TIM13_REMAP1)>;
 			};
 
@@ -1146,23 +1146,23 @@
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim14_ch1_pwm_pf9: tim14_ch1_pwm_pf9 {
+			/omit-if-no-ref/ tim14_ch1_remap1_pwm_pf9: tim14_ch1_remap1_pwm_pf9 {
 				pinmux = <STM32F1_PINMUX('F', 9, ALTERNATE, TIM14_REMAP1)>;
 			};
 
@@ -1218,11 +1218,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM9_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim9_ch1_pwm_pe5: tim9_ch1_pwm_pe5 {
+			/omit-if-no-ref/ tim9_ch1_remap1_pwm_pe5: tim9_ch1_remap1_pwm_pe5 {
 				pinmux = <STM32F1_PINMUX('E', 5, ALTERNATE, TIM9_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim9_ch2_pwm_pe6: tim9_ch2_pwm_pe6 {
+			/omit-if-no-ref/ tim9_ch2_remap1_pwm_pe6: tim9_ch2_remap1_pwm_pe6 {
 				pinmux = <STM32F1_PINMUX('E', 6, ALTERNATE, TIM9_REMAP1)>;
 			};
 
@@ -1240,7 +1240,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
+			/omit-if-no-ref/ usart2_cts_remap1_pd3: usart2_cts_remap1_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -1252,13 +1252,13 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
+			/omit-if-no-ref/ usart3_cts_remap2_pd11: usart3_cts_remap2_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -1274,7 +1274,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
+			/omit-if-no-ref/ usart2_rts_remap1_pd4: usart2_rts_remap1_pd4 {
 				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -1282,11 +1282,11 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
+			/omit-if-no-ref/ usart3_rts_remap2_pd12: usart3_rts_remap2_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
@@ -1296,7 +1296,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -1304,7 +1304,7 @@
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rx_pd6: usart2_rx_pd6 {
+			/omit-if-no-ref/ usart2_rx_remap1_pd6: usart2_rx_remap1_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
@@ -1312,11 +1312,11 @@
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pc11: usart3_rx_pc11 {
+			/omit-if-no-ref/ usart3_rx_remap1_pc11: usart3_rx_remap1_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pd9: usart3_rx_pd9 {
+			/omit-if-no-ref/ usart3_rx_remap2_pd9: usart3_rx_remap2_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
@@ -1334,7 +1334,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
@@ -1342,7 +1342,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_tx_pd5: usart2_tx_pd5 {
+			/omit-if-no-ref/ usart2_tx_remap1_pd5: usart2_tx_remap1_pd5 {
 				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -1350,11 +1350,11 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pc10: usart3_tx_pc10 {
+			/omit-if-no-ref/ usart3_tx_remap1_pc10: usart3_tx_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
+			/omit-if-no-ref/ usart3_tx_remap2_pd8: usart3_tx_remap2_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 

--- a/dts/st/f1/stm32f105r(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f105r(8-b-c)tx-pinctrl.dtsi
@@ -352,11 +352,11 @@
 				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can1_rx_pb8: can1_rx_pb8 {
+			/omit-if-no-ref/ can1_rx_remap1_pb8: can1_rx_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ can2_rx_pb5: can2_rx_pb5 {
+			/omit-if-no-ref/ can2_rx_remap1_pb5: can2_rx_remap1_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, CAN2_REMAP1)>;
 			};
 
@@ -370,11 +370,11 @@
 				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can1_tx_pb9: can1_tx_pb9 {
+			/omit-if-no-ref/ can1_tx_remap1_pb9: can1_tx_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ can2_tx_pb6: can2_tx_pb6 {
+			/omit-if-no-ref/ can2_tx_remap1_pb6: can2_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, CAN2_REMAP1)>;
 			};
 
@@ -399,7 +399,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -416,7 +416,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -436,7 +436,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, I2S3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ i2s3_ck_pc10: i2s3_ck_pc10 {
+			/omit-if-no-ref/ i2s3_ck_remap1_pc10: i2s3_ck_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, I2S3_REMAP1)>;
 			};
 
@@ -450,7 +450,7 @@
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, I2S3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ i2s3_sd_pc12: i2s3_sd_pc12 {
+			/omit-if-no-ref/ i2s3_sd_remap1_pc12: i2s3_sd_remap1_pc12 {
 				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, I2S3_REMAP1)>;
 			};
 
@@ -460,7 +460,7 @@
 				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ i2s3_ws_pa4: i2s3_ws_pa4 {
+			/omit-if-no-ref/ i2s3_ws_remap1_pa4: i2s3_ws_remap1_pa4 {
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, I2S3_REMAP1)>;
 			};
 
@@ -475,7 +475,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -490,7 +490,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi3_miso_master_pc11: spi3_miso_master_pc11 {
+			/omit-if-no-ref/ spi3_miso_remap1_master_pc11: spi3_miso_remap1_master_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, SPI3_REMAP1)>;
 				bias-pull-down;
 			};
@@ -501,7 +501,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -513,7 +513,7 @@
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi3_mosi_master_pc12: spi3_mosi_master_pc12 {
+			/omit-if-no-ref/ spi3_mosi_remap1_master_pc12: spi3_mosi_remap1_master_pc12 {
 				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, SPI3_REMAP1)>;
 			};
 
@@ -523,7 +523,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -531,7 +531,7 @@
 				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ spi3_nss_master_pa4: spi3_nss_master_pa4 {
+			/omit-if-no-ref/ spi3_nss_remap1_master_pa4: spi3_nss_remap1_master_pa4 {
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI3_REMAP1)>;
 			};
 
@@ -545,7 +545,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -557,7 +557,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi3_sck_master_pc10: spi3_sck_master_pc10 {
+			/omit-if-no-ref/ spi3_sck_remap1_master_pc10: spi3_sck_remap1_master_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, SPI3_REMAP1)>;
 			};
 
@@ -567,7 +567,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -579,7 +579,7 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi3_miso_slave_pc11: spi3_miso_slave_pc11 {
+			/omit-if-no-ref/ spi3_miso_remap1_slave_pc11: spi3_miso_remap1_slave_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, ALTERNATE, SPI3_REMAP1)>;
 			};
 
@@ -589,7 +589,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -601,7 +601,7 @@
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi3_mosi_slave_pc12: spi3_mosi_slave_pc12 {
+			/omit-if-no-ref/ spi3_mosi_remap1_slave_pc12: spi3_mosi_remap1_slave_pc12 {
 				pinmux = <STM32F1_PINMUX('C', 12, GPIO_IN, SPI3_REMAP1)>;
 			};
 
@@ -612,7 +612,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -622,7 +622,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi3_nss_slave_pa4: spi3_nss_slave_pa4 {
+			/omit-if-no-ref/ spi3_nss_remap1_slave_pa4: spi3_nss_remap1_slave_pa4 {
 				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI3_REMAP1)>;
 				bias-pull-up;
 			};
@@ -638,7 +638,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -650,13 +650,13 @@
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi3_sck_slave_pc10: spi3_sck_slave_pc10 {
+			/omit-if-no-ref/ spi3_sck_remap1_slave_pc10: spi3_sck_remap1_slave_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, GPIO_IN, SPI3_REMAP1)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -664,7 +664,7 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -672,7 +672,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -680,7 +680,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -688,15 +688,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -716,7 +716,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -724,7 +724,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -732,7 +732,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -740,11 +740,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -752,7 +752,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -760,7 +760,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -768,7 +768,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -788,7 +788,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -796,31 +796,31 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
@@ -876,7 +876,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -896,7 +896,7 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
@@ -906,7 +906,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -918,7 +918,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pc11: usart3_rx_pc11 {
+			/omit-if-no-ref/ usart3_rx_remap1_pc11: usart3_rx_remap1_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
@@ -936,7 +936,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
@@ -948,7 +948,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pc10: usart3_tx_pc10 {
+			/omit-if-no-ref/ usart3_tx_remap1_pc10: usart3_tx_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f105v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f105v(8-b)hx-pinctrl.dtsi
@@ -468,15 +468,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can1_rx_pb8: can1_rx_pb8 {
+			/omit-if-no-ref/ can1_rx_remap1_pb8: can1_rx_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ can1_rx_pd0: can1_rx_pd0 {
+			/omit-if-no-ref/ can1_rx_remap2_pd0: can1_rx_remap2_pd0 {
 				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, CAN1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ can2_rx_pb5: can2_rx_pb5 {
+			/omit-if-no-ref/ can2_rx_remap1_pb5: can2_rx_remap1_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, CAN2_REMAP1)>;
 			};
 
@@ -490,15 +490,15 @@
 				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can1_tx_pb9: can1_tx_pb9 {
+			/omit-if-no-ref/ can1_tx_remap1_pb9: can1_tx_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ can1_tx_pd1: can1_tx_pd1 {
+			/omit-if-no-ref/ can1_tx_remap2_pd1: can1_tx_remap2_pd1 {
 				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, CAN1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ can2_tx_pb6: can2_tx_pb6 {
+			/omit-if-no-ref/ can2_tx_remap1_pb6: can2_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, CAN2_REMAP1)>;
 			};
 
@@ -523,7 +523,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -540,7 +540,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -560,7 +560,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, I2S3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ i2s3_ck_pc10: i2s3_ck_pc10 {
+			/omit-if-no-ref/ i2s3_ck_remap1_pc10: i2s3_ck_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, I2S3_REMAP1)>;
 			};
 
@@ -574,7 +574,7 @@
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, I2S3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ i2s3_sd_pc12: i2s3_sd_pc12 {
+			/omit-if-no-ref/ i2s3_sd_remap1_pc12: i2s3_sd_remap1_pc12 {
 				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, I2S3_REMAP1)>;
 			};
 
@@ -584,7 +584,7 @@
 				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ i2s3_ws_pa4: i2s3_ws_pa4 {
+			/omit-if-no-ref/ i2s3_ws_remap1_pa4: i2s3_ws_remap1_pa4 {
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, I2S3_REMAP1)>;
 			};
 
@@ -599,7 +599,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -614,7 +614,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi3_miso_master_pc11: spi3_miso_master_pc11 {
+			/omit-if-no-ref/ spi3_miso_remap1_master_pc11: spi3_miso_remap1_master_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, SPI3_REMAP1)>;
 				bias-pull-down;
 			};
@@ -625,7 +625,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -637,7 +637,7 @@
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi3_mosi_master_pc12: spi3_mosi_master_pc12 {
+			/omit-if-no-ref/ spi3_mosi_remap1_master_pc12: spi3_mosi_remap1_master_pc12 {
 				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, SPI3_REMAP1)>;
 			};
 
@@ -647,7 +647,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -655,7 +655,7 @@
 				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ spi3_nss_master_pa4: spi3_nss_master_pa4 {
+			/omit-if-no-ref/ spi3_nss_remap1_master_pa4: spi3_nss_remap1_master_pa4 {
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI3_REMAP1)>;
 			};
 
@@ -669,7 +669,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -681,7 +681,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi3_sck_master_pc10: spi3_sck_master_pc10 {
+			/omit-if-no-ref/ spi3_sck_remap1_master_pc10: spi3_sck_remap1_master_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, SPI3_REMAP1)>;
 			};
 
@@ -691,7 +691,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -703,7 +703,7 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi3_miso_slave_pc11: spi3_miso_slave_pc11 {
+			/omit-if-no-ref/ spi3_miso_remap1_slave_pc11: spi3_miso_remap1_slave_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, ALTERNATE, SPI3_REMAP1)>;
 			};
 
@@ -713,7 +713,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -725,7 +725,7 @@
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi3_mosi_slave_pc12: spi3_mosi_slave_pc12 {
+			/omit-if-no-ref/ spi3_mosi_remap1_slave_pc12: spi3_mosi_remap1_slave_pc12 {
 				pinmux = <STM32F1_PINMUX('C', 12, GPIO_IN, SPI3_REMAP1)>;
 			};
 
@@ -736,7 +736,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -746,7 +746,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi3_nss_slave_pa4: spi3_nss_slave_pa4 {
+			/omit-if-no-ref/ spi3_nss_remap1_slave_pa4: spi3_nss_remap1_slave_pa4 {
 				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI3_REMAP1)>;
 				bias-pull-up;
 			};
@@ -762,7 +762,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -774,13 +774,13 @@
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi3_sck_slave_pc10: spi3_sck_slave_pc10 {
+			/omit-if-no-ref/ spi3_sck_remap1_slave_pc10: spi3_sck_remap1_slave_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, GPIO_IN, SPI3_REMAP1)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -788,7 +788,7 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -796,7 +796,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -804,7 +804,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -812,15 +812,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -836,31 +836,31 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_pe8: tim1_ch1n_remap2_pwm_pe8 {
 				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_pe9: tim1_ch1_remap2_pwm_pe9 {
 				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_pe10: tim1_ch2n_remap2_pwm_pe10 {
 				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_pe11: tim1_ch2_remap2_pwm_pe11 {
 				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_pe12: tim1_ch3n_remap2_pwm_pe12 {
 				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_pe13: tim1_ch3_remap2_pwm_pe13 {
 				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_pe14: tim1_ch4_remap2_pwm_pe14 {
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
@@ -868,7 +868,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -876,7 +876,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -884,7 +884,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -892,11 +892,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -904,7 +904,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -912,7 +912,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -920,7 +920,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -940,7 +940,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -948,31 +948,31 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
@@ -992,19 +992,19 @@
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
@@ -1038,7 +1038,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
+			/omit-if-no-ref/ usart2_cts_remap1_pd3: usart2_cts_remap1_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -1050,13 +1050,13 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
+			/omit-if-no-ref/ usart3_cts_remap2_pd11: usart3_cts_remap2_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -1072,7 +1072,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
+			/omit-if-no-ref/ usart2_rts_remap1_pd4: usart2_rts_remap1_pd4 {
 				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -1080,11 +1080,11 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
+			/omit-if-no-ref/ usart3_rts_remap2_pd12: usart3_rts_remap2_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
@@ -1094,7 +1094,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -1102,7 +1102,7 @@
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rx_pd6: usart2_rx_pd6 {
+			/omit-if-no-ref/ usart2_rx_remap1_pd6: usart2_rx_remap1_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
@@ -1110,11 +1110,11 @@
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pc11: usart3_rx_pc11 {
+			/omit-if-no-ref/ usart3_rx_remap1_pc11: usart3_rx_remap1_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pd9: usart3_rx_pd9 {
+			/omit-if-no-ref/ usart3_rx_remap2_pd9: usart3_rx_remap2_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
@@ -1132,7 +1132,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
@@ -1140,7 +1140,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_tx_pd5: usart2_tx_pd5 {
+			/omit-if-no-ref/ usart2_tx_remap1_pd5: usart2_tx_remap1_pd5 {
 				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -1148,11 +1148,11 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pc10: usart3_tx_pc10 {
+			/omit-if-no-ref/ usart3_tx_remap1_pc10: usart3_tx_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
+			/omit-if-no-ref/ usart3_tx_remap2_pd8: usart3_tx_remap2_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 

--- a/dts/st/f1/stm32f105v(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f105v(8-b-c)tx-pinctrl.dtsi
@@ -468,15 +468,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can1_rx_pb8: can1_rx_pb8 {
+			/omit-if-no-ref/ can1_rx_remap1_pb8: can1_rx_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ can1_rx_pd0: can1_rx_pd0 {
+			/omit-if-no-ref/ can1_rx_remap2_pd0: can1_rx_remap2_pd0 {
 				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, CAN1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ can2_rx_pb5: can2_rx_pb5 {
+			/omit-if-no-ref/ can2_rx_remap1_pb5: can2_rx_remap1_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, CAN2_REMAP1)>;
 			};
 
@@ -490,15 +490,15 @@
 				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can1_tx_pb9: can1_tx_pb9 {
+			/omit-if-no-ref/ can1_tx_remap1_pb9: can1_tx_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ can1_tx_pd1: can1_tx_pd1 {
+			/omit-if-no-ref/ can1_tx_remap2_pd1: can1_tx_remap2_pd1 {
 				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, CAN1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ can2_tx_pb6: can2_tx_pb6 {
+			/omit-if-no-ref/ can2_tx_remap1_pb6: can2_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, CAN2_REMAP1)>;
 			};
 
@@ -523,7 +523,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -540,7 +540,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -560,7 +560,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, I2S3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ i2s3_ck_pc10: i2s3_ck_pc10 {
+			/omit-if-no-ref/ i2s3_ck_remap1_pc10: i2s3_ck_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, I2S3_REMAP1)>;
 			};
 
@@ -574,7 +574,7 @@
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, I2S3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ i2s3_sd_pc12: i2s3_sd_pc12 {
+			/omit-if-no-ref/ i2s3_sd_remap1_pc12: i2s3_sd_remap1_pc12 {
 				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, I2S3_REMAP1)>;
 			};
 
@@ -584,7 +584,7 @@
 				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ i2s3_ws_pa4: i2s3_ws_pa4 {
+			/omit-if-no-ref/ i2s3_ws_remap1_pa4: i2s3_ws_remap1_pa4 {
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, I2S3_REMAP1)>;
 			};
 
@@ -599,7 +599,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -614,7 +614,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi3_miso_master_pc11: spi3_miso_master_pc11 {
+			/omit-if-no-ref/ spi3_miso_remap1_master_pc11: spi3_miso_remap1_master_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, SPI3_REMAP1)>;
 				bias-pull-down;
 			};
@@ -625,7 +625,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -637,7 +637,7 @@
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi3_mosi_master_pc12: spi3_mosi_master_pc12 {
+			/omit-if-no-ref/ spi3_mosi_remap1_master_pc12: spi3_mosi_remap1_master_pc12 {
 				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, SPI3_REMAP1)>;
 			};
 
@@ -647,7 +647,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -655,7 +655,7 @@
 				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ spi3_nss_master_pa4: spi3_nss_master_pa4 {
+			/omit-if-no-ref/ spi3_nss_remap1_master_pa4: spi3_nss_remap1_master_pa4 {
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI3_REMAP1)>;
 			};
 
@@ -669,7 +669,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -681,7 +681,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi3_sck_master_pc10: spi3_sck_master_pc10 {
+			/omit-if-no-ref/ spi3_sck_remap1_master_pc10: spi3_sck_remap1_master_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, SPI3_REMAP1)>;
 			};
 
@@ -691,7 +691,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -703,7 +703,7 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi3_miso_slave_pc11: spi3_miso_slave_pc11 {
+			/omit-if-no-ref/ spi3_miso_remap1_slave_pc11: spi3_miso_remap1_slave_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, ALTERNATE, SPI3_REMAP1)>;
 			};
 
@@ -713,7 +713,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -725,7 +725,7 @@
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi3_mosi_slave_pc12: spi3_mosi_slave_pc12 {
+			/omit-if-no-ref/ spi3_mosi_remap1_slave_pc12: spi3_mosi_remap1_slave_pc12 {
 				pinmux = <STM32F1_PINMUX('C', 12, GPIO_IN, SPI3_REMAP1)>;
 			};
 
@@ -736,7 +736,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -746,7 +746,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi3_nss_slave_pa4: spi3_nss_slave_pa4 {
+			/omit-if-no-ref/ spi3_nss_remap1_slave_pa4: spi3_nss_remap1_slave_pa4 {
 				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI3_REMAP1)>;
 				bias-pull-up;
 			};
@@ -762,7 +762,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -774,13 +774,13 @@
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi3_sck_slave_pc10: spi3_sck_slave_pc10 {
+			/omit-if-no-ref/ spi3_sck_remap1_slave_pc10: spi3_sck_remap1_slave_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, GPIO_IN, SPI3_REMAP1)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -788,7 +788,7 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -796,7 +796,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -804,7 +804,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -812,15 +812,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -836,31 +836,31 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_pe8: tim1_ch1n_remap2_pwm_pe8 {
 				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_pe9: tim1_ch1_remap2_pwm_pe9 {
 				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_pe10: tim1_ch2n_remap2_pwm_pe10 {
 				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_pe11: tim1_ch2_remap2_pwm_pe11 {
 				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_pe12: tim1_ch3n_remap2_pwm_pe12 {
 				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_pe13: tim1_ch3_remap2_pwm_pe13 {
 				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_pe14: tim1_ch4_remap2_pwm_pe14 {
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
@@ -868,7 +868,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -876,7 +876,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -884,7 +884,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -892,11 +892,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -904,7 +904,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -912,7 +912,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -920,7 +920,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -940,7 +940,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -948,31 +948,31 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
@@ -992,19 +992,19 @@
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
@@ -1038,7 +1038,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
+			/omit-if-no-ref/ usart2_cts_remap1_pd3: usart2_cts_remap1_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -1050,13 +1050,13 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
+			/omit-if-no-ref/ usart3_cts_remap2_pd11: usart3_cts_remap2_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -1072,7 +1072,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
+			/omit-if-no-ref/ usart2_rts_remap1_pd4: usart2_rts_remap1_pd4 {
 				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -1080,11 +1080,11 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
+			/omit-if-no-ref/ usart3_rts_remap2_pd12: usart3_rts_remap2_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
@@ -1094,7 +1094,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -1102,7 +1102,7 @@
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rx_pd6: usart2_rx_pd6 {
+			/omit-if-no-ref/ usart2_rx_remap1_pd6: usart2_rx_remap1_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
@@ -1110,11 +1110,11 @@
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pc11: usart3_rx_pc11 {
+			/omit-if-no-ref/ usart3_rx_remap1_pc11: usart3_rx_remap1_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pd9: usart3_rx_pd9 {
+			/omit-if-no-ref/ usart3_rx_remap2_pd9: usart3_rx_remap2_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
@@ -1132,7 +1132,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
@@ -1140,7 +1140,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_tx_pd5: usart2_tx_pd5 {
+			/omit-if-no-ref/ usart2_tx_remap1_pd5: usart2_tx_remap1_pd5 {
 				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -1148,11 +1148,11 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pc10: usart3_tx_pc10 {
+			/omit-if-no-ref/ usart3_tx_remap1_pc10: usart3_tx_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
+			/omit-if-no-ref/ usart3_tx_remap2_pd8: usart3_tx_remap2_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 

--- a/dts/st/f1/stm32f107r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f107r(b-c)tx-pinctrl.dtsi
@@ -352,11 +352,11 @@
 				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can1_rx_pb8: can1_rx_pb8 {
+			/omit-if-no-ref/ can1_rx_remap1_pb8: can1_rx_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ can2_rx_pb5: can2_rx_pb5 {
+			/omit-if-no-ref/ can2_rx_remap1_pb5: can2_rx_remap1_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, CAN2_REMAP1)>;
 			};
 
@@ -370,11 +370,11 @@
 				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can1_tx_pb9: can1_tx_pb9 {
+			/omit-if-no-ref/ can1_tx_remap1_pb9: can1_tx_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ can2_tx_pb6: can2_tx_pb6 {
+			/omit-if-no-ref/ can2_tx_remap1_pb6: can2_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, CAN2_REMAP1)>;
 			};
 
@@ -527,7 +527,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -539,7 +539,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -554,7 +554,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, I2S3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ i2s3_ck_pc10: i2s3_ck_pc10 {
+			/omit-if-no-ref/ i2s3_ck_remap1_pc10: i2s3_ck_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, I2S3_REMAP1)>;
 			};
 
@@ -568,7 +568,7 @@
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, I2S3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ i2s3_sd_pc12: i2s3_sd_pc12 {
+			/omit-if-no-ref/ i2s3_sd_remap1_pc12: i2s3_sd_remap1_pc12 {
 				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, I2S3_REMAP1)>;
 			};
 
@@ -578,7 +578,7 @@
 				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ i2s3_ws_pa4: i2s3_ws_pa4 {
+			/omit-if-no-ref/ i2s3_ws_remap1_pa4: i2s3_ws_remap1_pa4 {
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, I2S3_REMAP1)>;
 			};
 
@@ -593,7 +593,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -608,7 +608,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi3_miso_master_pc11: spi3_miso_master_pc11 {
+			/omit-if-no-ref/ spi3_miso_remap1_master_pc11: spi3_miso_remap1_master_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, SPI3_REMAP1)>;
 				bias-pull-down;
 			};
@@ -619,7 +619,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -631,7 +631,7 @@
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi3_mosi_master_pc12: spi3_mosi_master_pc12 {
+			/omit-if-no-ref/ spi3_mosi_remap1_master_pc12: spi3_mosi_remap1_master_pc12 {
 				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, SPI3_REMAP1)>;
 			};
 
@@ -641,7 +641,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -649,7 +649,7 @@
 				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ spi3_nss_master_pa4: spi3_nss_master_pa4 {
+			/omit-if-no-ref/ spi3_nss_remap1_master_pa4: spi3_nss_remap1_master_pa4 {
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI3_REMAP1)>;
 			};
 
@@ -663,7 +663,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -675,7 +675,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi3_sck_master_pc10: spi3_sck_master_pc10 {
+			/omit-if-no-ref/ spi3_sck_remap1_master_pc10: spi3_sck_remap1_master_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, SPI3_REMAP1)>;
 			};
 
@@ -685,7 +685,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -697,7 +697,7 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi3_miso_slave_pc11: spi3_miso_slave_pc11 {
+			/omit-if-no-ref/ spi3_miso_remap1_slave_pc11: spi3_miso_remap1_slave_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, ALTERNATE, SPI3_REMAP1)>;
 			};
 
@@ -707,7 +707,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -719,7 +719,7 @@
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi3_mosi_slave_pc12: spi3_mosi_slave_pc12 {
+			/omit-if-no-ref/ spi3_mosi_remap1_slave_pc12: spi3_mosi_remap1_slave_pc12 {
 				pinmux = <STM32F1_PINMUX('C', 12, GPIO_IN, SPI3_REMAP1)>;
 			};
 
@@ -730,7 +730,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -740,7 +740,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi3_nss_slave_pa4: spi3_nss_slave_pa4 {
+			/omit-if-no-ref/ spi3_nss_remap1_slave_pa4: spi3_nss_remap1_slave_pa4 {
 				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI3_REMAP1)>;
 				bias-pull-up;
 			};
@@ -756,7 +756,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -768,13 +768,13 @@
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi3_sck_slave_pc10: spi3_sck_slave_pc10 {
+			/omit-if-no-ref/ spi3_sck_remap1_slave_pc10: spi3_sck_remap1_slave_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, GPIO_IN, SPI3_REMAP1)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -782,7 +782,7 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -790,7 +790,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -798,7 +798,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -806,15 +806,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -834,7 +834,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -842,7 +842,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -850,7 +850,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -858,11 +858,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -870,7 +870,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -878,7 +878,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -886,7 +886,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -906,7 +906,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -914,31 +914,31 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
@@ -994,7 +994,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -1014,7 +1014,7 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
@@ -1024,7 +1024,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -1036,7 +1036,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pc11: usart3_rx_pc11 {
+			/omit-if-no-ref/ usart3_rx_remap1_pc11: usart3_rx_remap1_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
@@ -1054,7 +1054,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
@@ -1066,7 +1066,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pc10: usart3_tx_pc10 {
+			/omit-if-no-ref/ usart3_tx_remap1_pc10: usart3_tx_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f107v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f107v(b-c)tx-pinctrl.dtsi
@@ -468,15 +468,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can1_rx_pb8: can1_rx_pb8 {
+			/omit-if-no-ref/ can1_rx_remap1_pb8: can1_rx_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ can1_rx_pd0: can1_rx_pd0 {
+			/omit-if-no-ref/ can1_rx_remap2_pd0: can1_rx_remap2_pd0 {
 				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, CAN1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ can2_rx_pb5: can2_rx_pb5 {
+			/omit-if-no-ref/ can2_rx_remap1_pb5: can2_rx_remap1_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, CAN2_REMAP1)>;
 			};
 
@@ -490,15 +490,15 @@
 				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can1_tx_pb9: can1_tx_pb9 {
+			/omit-if-no-ref/ can1_tx_remap1_pb9: can1_tx_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ can1_tx_pd1: can1_tx_pd1 {
+			/omit-if-no-ref/ can1_tx_remap2_pd1: can1_tx_remap2_pd1 {
 				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, CAN1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ can2_tx_pb6: can2_tx_pb6 {
+			/omit-if-no-ref/ can2_tx_remap1_pb6: can2_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, CAN2_REMAP1)>;
 			};
 
@@ -534,7 +534,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, ETH_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ eth_crs_dv_pd8: eth_crs_dv_pd8 {
+			/omit-if-no-ref/ eth_crs_dv_remap1_pd8: eth_crs_dv_remap1_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, GPIO_IN, ETH_REMAP1)>;
 			};
 
@@ -571,7 +571,7 @@
 				pinmux = <STM32F1_PINMUX('C', 4, GPIO_IN, ETH_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ eth_rxd0_pd9: eth_rxd0_pd9 {
+			/omit-if-no-ref/ eth_rxd0_remap1_pd9: eth_rxd0_remap1_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, ETH_REMAP1)>;
 			};
 
@@ -581,7 +581,7 @@
 				pinmux = <STM32F1_PINMUX('C', 5, GPIO_IN, ETH_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ eth_rxd1_pd10: eth_rxd1_pd10 {
+			/omit-if-no-ref/ eth_rxd1_remap1_pd10: eth_rxd1_remap1_pd10 {
 				pinmux = <STM32F1_PINMUX('D', 10, GPIO_IN, ETH_REMAP1)>;
 			};
 
@@ -591,7 +591,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, ETH_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ eth_rxd2_pd11: eth_rxd2_pd11 {
+			/omit-if-no-ref/ eth_rxd2_remap1_pd11: eth_rxd2_remap1_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, ETH_REMAP1)>;
 			};
 
@@ -601,7 +601,7 @@
 				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, ETH_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ eth_rxd3_pd12: eth_rxd3_pd12 {
+			/omit-if-no-ref/ eth_rxd3_remap1_pd12: eth_rxd3_remap1_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, GPIO_IN, ETH_REMAP1)>;
 			};
 
@@ -617,7 +617,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, ETH_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ eth_rx_dv_pd8: eth_rx_dv_pd8 {
+			/omit-if-no-ref/ eth_rx_dv_remap1_pd8: eth_rx_dv_remap1_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, GPIO_IN, ETH_REMAP1)>;
 			};
 
@@ -675,7 +675,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -687,7 +687,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -702,7 +702,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, I2S3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ i2s3_ck_pc10: i2s3_ck_pc10 {
+			/omit-if-no-ref/ i2s3_ck_remap1_pc10: i2s3_ck_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, I2S3_REMAP1)>;
 			};
 
@@ -716,7 +716,7 @@
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, I2S3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ i2s3_sd_pc12: i2s3_sd_pc12 {
+			/omit-if-no-ref/ i2s3_sd_remap1_pc12: i2s3_sd_remap1_pc12 {
 				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, I2S3_REMAP1)>;
 			};
 
@@ -726,7 +726,7 @@
 				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ i2s3_ws_pa4: i2s3_ws_pa4 {
+			/omit-if-no-ref/ i2s3_ws_remap1_pa4: i2s3_ws_remap1_pa4 {
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, I2S3_REMAP1)>;
 			};
 
@@ -741,7 +741,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -756,7 +756,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi3_miso_master_pc11: spi3_miso_master_pc11 {
+			/omit-if-no-ref/ spi3_miso_remap1_master_pc11: spi3_miso_remap1_master_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, SPI3_REMAP1)>;
 				bias-pull-down;
 			};
@@ -767,7 +767,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -779,7 +779,7 @@
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi3_mosi_master_pc12: spi3_mosi_master_pc12 {
+			/omit-if-no-ref/ spi3_mosi_remap1_master_pc12: spi3_mosi_remap1_master_pc12 {
 				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, SPI3_REMAP1)>;
 			};
 
@@ -789,7 +789,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -797,7 +797,7 @@
 				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ spi3_nss_master_pa4: spi3_nss_master_pa4 {
+			/omit-if-no-ref/ spi3_nss_remap1_master_pa4: spi3_nss_remap1_master_pa4 {
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI3_REMAP1)>;
 			};
 
@@ -811,7 +811,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -823,7 +823,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi3_sck_master_pc10: spi3_sck_master_pc10 {
+			/omit-if-no-ref/ spi3_sck_remap1_master_pc10: spi3_sck_remap1_master_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, SPI3_REMAP1)>;
 			};
 
@@ -833,7 +833,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -845,7 +845,7 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi3_miso_slave_pc11: spi3_miso_slave_pc11 {
+			/omit-if-no-ref/ spi3_miso_remap1_slave_pc11: spi3_miso_remap1_slave_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, ALTERNATE, SPI3_REMAP1)>;
 			};
 
@@ -855,7 +855,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -867,7 +867,7 @@
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi3_mosi_slave_pc12: spi3_mosi_slave_pc12 {
+			/omit-if-no-ref/ spi3_mosi_remap1_slave_pc12: spi3_mosi_remap1_slave_pc12 {
 				pinmux = <STM32F1_PINMUX('C', 12, GPIO_IN, SPI3_REMAP1)>;
 			};
 
@@ -878,7 +878,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -888,7 +888,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi3_nss_slave_pa4: spi3_nss_slave_pa4 {
+			/omit-if-no-ref/ spi3_nss_remap1_slave_pa4: spi3_nss_remap1_slave_pa4 {
 				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI3_REMAP1)>;
 				bias-pull-up;
 			};
@@ -904,7 +904,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -916,13 +916,13 @@
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi3_sck_slave_pc10: spi3_sck_slave_pc10 {
+			/omit-if-no-ref/ spi3_sck_remap1_slave_pc10: spi3_sck_remap1_slave_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, GPIO_IN, SPI3_REMAP1)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -930,7 +930,7 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -938,7 +938,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -946,7 +946,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -954,15 +954,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -978,31 +978,31 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_pe8: tim1_ch1n_remap2_pwm_pe8 {
 				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_pe9: tim1_ch1_remap2_pwm_pe9 {
 				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_pe10: tim1_ch2n_remap2_pwm_pe10 {
 				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_pe11: tim1_ch2_remap2_pwm_pe11 {
 				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_pe12: tim1_ch3n_remap2_pwm_pe12 {
 				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_pe13: tim1_ch3_remap2_pwm_pe13 {
 				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_pe14: tim1_ch4_remap2_pwm_pe14 {
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
@@ -1010,7 +1010,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -1018,7 +1018,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -1026,7 +1026,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -1034,11 +1034,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -1046,7 +1046,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -1054,7 +1054,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -1062,7 +1062,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -1082,7 +1082,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -1090,31 +1090,31 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
@@ -1134,19 +1134,19 @@
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
@@ -1180,7 +1180,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
+			/omit-if-no-ref/ usart2_cts_remap1_pd3: usart2_cts_remap1_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -1192,13 +1192,13 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
+			/omit-if-no-ref/ usart3_cts_remap2_pd11: usart3_cts_remap2_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -1214,7 +1214,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
+			/omit-if-no-ref/ usart2_rts_remap1_pd4: usart2_rts_remap1_pd4 {
 				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -1222,11 +1222,11 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
+			/omit-if-no-ref/ usart3_rts_remap2_pd12: usart3_rts_remap2_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
@@ -1236,7 +1236,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -1244,7 +1244,7 @@
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rx_pd6: usart2_rx_pd6 {
+			/omit-if-no-ref/ usart2_rx_remap1_pd6: usart2_rx_remap1_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
@@ -1252,11 +1252,11 @@
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pc11: usart3_rx_pc11 {
+			/omit-if-no-ref/ usart3_rx_remap1_pc11: usart3_rx_remap1_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pd9: usart3_rx_pd9 {
+			/omit-if-no-ref/ usart3_rx_remap2_pd9: usart3_rx_remap2_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
@@ -1274,7 +1274,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
@@ -1282,7 +1282,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_tx_pd5: usart2_tx_pd5 {
+			/omit-if-no-ref/ usart2_tx_remap1_pd5: usart2_tx_remap1_pd5 {
 				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -1290,11 +1290,11 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pc10: usart3_tx_pc10 {
+			/omit-if-no-ref/ usart3_tx_remap1_pc10: usart3_tx_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
+			/omit-if-no-ref/ usart3_tx_remap2_pd8: usart3_tx_remap2_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 

--- a/dts/st/f1/stm32f107vchx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f107vchx-pinctrl.dtsi
@@ -468,15 +468,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, CAN1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can1_rx_pb8: can1_rx_pb8 {
+			/omit-if-no-ref/ can1_rx_remap1_pb8: can1_rx_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, CAN1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ can1_rx_pd0: can1_rx_pd0 {
+			/omit-if-no-ref/ can1_rx_remap2_pd0: can1_rx_remap2_pd0 {
 				pinmux = <STM32F1_PINMUX('D', 0, GPIO_IN, CAN1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ can2_rx_pb5: can2_rx_pb5 {
+			/omit-if-no-ref/ can2_rx_remap1_pb5: can2_rx_remap1_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, CAN2_REMAP1)>;
 			};
 
@@ -490,15 +490,15 @@
 				pinmux = <STM32F1_PINMUX('A', 12, ALTERNATE, CAN1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ can1_tx_pb9: can1_tx_pb9 {
+			/omit-if-no-ref/ can1_tx_remap1_pb9: can1_tx_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, CAN1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ can1_tx_pd1: can1_tx_pd1 {
+			/omit-if-no-ref/ can1_tx_remap2_pd1: can1_tx_remap2_pd1 {
 				pinmux = <STM32F1_PINMUX('D', 1, ALTERNATE, CAN1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ can2_tx_pb6: can2_tx_pb6 {
+			/omit-if-no-ref/ can2_tx_remap1_pb6: can2_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, CAN2_REMAP1)>;
 			};
 
@@ -534,7 +534,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, ETH_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ eth_crs_dv_pd8: eth_crs_dv_pd8 {
+			/omit-if-no-ref/ eth_crs_dv_remap1_pd8: eth_crs_dv_remap1_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, GPIO_IN, ETH_REMAP1)>;
 			};
 
@@ -571,7 +571,7 @@
 				pinmux = <STM32F1_PINMUX('C', 4, GPIO_IN, ETH_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ eth_rxd0_pd9: eth_rxd0_pd9 {
+			/omit-if-no-ref/ eth_rxd0_remap1_pd9: eth_rxd0_remap1_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, ETH_REMAP1)>;
 			};
 
@@ -581,7 +581,7 @@
 				pinmux = <STM32F1_PINMUX('C', 5, GPIO_IN, ETH_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ eth_rxd1_pd10: eth_rxd1_pd10 {
+			/omit-if-no-ref/ eth_rxd1_remap1_pd10: eth_rxd1_remap1_pd10 {
 				pinmux = <STM32F1_PINMUX('D', 10, GPIO_IN, ETH_REMAP1)>;
 			};
 
@@ -591,7 +591,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, ETH_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ eth_rxd2_pd11: eth_rxd2_pd11 {
+			/omit-if-no-ref/ eth_rxd2_remap1_pd11: eth_rxd2_remap1_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, ETH_REMAP1)>;
 			};
 
@@ -601,7 +601,7 @@
 				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, ETH_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ eth_rxd3_pd12: eth_rxd3_pd12 {
+			/omit-if-no-ref/ eth_rxd3_remap1_pd12: eth_rxd3_remap1_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, GPIO_IN, ETH_REMAP1)>;
 			};
 
@@ -617,7 +617,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, ETH_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ eth_rx_dv_pd8: eth_rx_dv_pd8 {
+			/omit-if-no-ref/ eth_rx_dv_remap1_pd8: eth_rx_dv_remap1_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, GPIO_IN, ETH_REMAP1)>;
 			};
 
@@ -675,7 +675,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pb8: i2c1_scl_pb8 {
+			/omit-if-no-ref/ i2c1_scl_remap1_pb8: i2c1_scl_remap1_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -687,7 +687,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pb9: i2c1_sda_pb9 {
+			/omit-if-no-ref/ i2c1_sda_remap1_pb9: i2c1_sda_remap1_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, I2C1_REMAP1)>;
 				drive-open-drain;
 			};
@@ -702,7 +702,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, I2S3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ i2s3_ck_pc10: i2s3_ck_pc10 {
+			/omit-if-no-ref/ i2s3_ck_remap1_pc10: i2s3_ck_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, I2S3_REMAP1)>;
 			};
 
@@ -716,7 +716,7 @@
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, I2S3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ i2s3_sd_pc12: i2s3_sd_pc12 {
+			/omit-if-no-ref/ i2s3_sd_remap1_pc12: i2s3_sd_remap1_pc12 {
 				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, I2S3_REMAP1)>;
 			};
 
@@ -726,7 +726,7 @@
 				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ i2s3_ws_pa4: i2s3_ws_pa4 {
+			/omit-if-no-ref/ i2s3_ws_remap1_pa4: i2s3_ws_remap1_pa4 {
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, I2S3_REMAP1)>;
 			};
 
@@ -741,7 +741,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi1_miso_master_pb4: spi1_miso_master_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_master_pb4: spi1_miso_remap1_master_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-down;
 			};
@@ -756,7 +756,7 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi3_miso_master_pc11: spi3_miso_master_pc11 {
+			/omit-if-no-ref/ spi3_miso_remap1_master_pc11: spi3_miso_remap1_master_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, SPI3_REMAP1)>;
 				bias-pull-down;
 			};
@@ -767,7 +767,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_master_pb5: spi1_mosi_master_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_master_pb5: spi1_mosi_remap1_master_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -779,7 +779,7 @@
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, SPI3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi3_mosi_master_pc12: spi3_mosi_master_pc12 {
+			/omit-if-no-ref/ spi3_mosi_remap1_master_pc12: spi3_mosi_remap1_master_pc12 {
 				pinmux = <STM32F1_PINMUX('C', 12, ALTERNATE, SPI3_REMAP1)>;
 			};
 
@@ -789,7 +789,7 @@
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_nss_master_pa15: spi1_nss_master_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_master_pa15: spi1_nss_remap1_master_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -797,7 +797,7 @@
 				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ spi3_nss_master_pa4: spi3_nss_master_pa4 {
+			/omit-if-no-ref/ spi3_nss_remap1_master_pa4: spi3_nss_remap1_master_pa4 {
 				pinmux = <STM32F1_PINMUX('A', 4, ALTERNATE, SPI3_REMAP1)>;
 			};
 
@@ -811,7 +811,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_master_pb3: spi1_sck_master_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_master_pb3: spi1_sck_remap1_master_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -823,7 +823,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, SPI3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi3_sck_master_pc10: spi3_sck_master_pc10 {
+			/omit-if-no-ref/ spi3_sck_remap1_master_pc10: spi3_sck_remap1_master_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, SPI3_REMAP1)>;
 			};
 
@@ -833,7 +833,7 @@
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_miso_slave_pb4: spi1_miso_slave_pb4 {
+			/omit-if-no-ref/ spi1_miso_remap1_slave_pb4: spi1_miso_remap1_slave_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI1_REMAP1)>;
 			};
 
@@ -845,7 +845,7 @@
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, SPI3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi3_miso_slave_pc11: spi3_miso_slave_pc11 {
+			/omit-if-no-ref/ spi3_miso_remap1_slave_pc11: spi3_miso_remap1_slave_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, ALTERNATE, SPI3_REMAP1)>;
 			};
 
@@ -855,7 +855,7 @@
 				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_mosi_slave_pb5: spi1_mosi_slave_pb5 {
+			/omit-if-no-ref/ spi1_mosi_remap1_slave_pb5: spi1_mosi_remap1_slave_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -867,7 +867,7 @@
 				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, SPI3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi3_mosi_slave_pc12: spi3_mosi_slave_pc12 {
+			/omit-if-no-ref/ spi3_mosi_remap1_slave_pc12: spi3_mosi_remap1_slave_pc12 {
 				pinmux = <STM32F1_PINMUX('C', 12, GPIO_IN, SPI3_REMAP1)>;
 			};
 
@@ -878,7 +878,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi1_nss_slave_pa15: spi1_nss_slave_pa15 {
+			/omit-if-no-ref/ spi1_nss_remap1_slave_pa15: spi1_nss_remap1_slave_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, SPI1_REMAP1)>;
 				bias-pull-up;
 			};
@@ -888,7 +888,7 @@
 				bias-pull-up;
 			};
 
-			/omit-if-no-ref/ spi3_nss_slave_pa4: spi3_nss_slave_pa4 {
+			/omit-if-no-ref/ spi3_nss_remap1_slave_pa4: spi3_nss_remap1_slave_pa4 {
 				pinmux = <STM32F1_PINMUX('A', 4, GPIO_IN, SPI3_REMAP1)>;
 				bias-pull-up;
 			};
@@ -904,7 +904,7 @@
 				pinmux = <STM32F1_PINMUX('A', 5, GPIO_IN, SPI1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi1_sck_slave_pb3: spi1_sck_slave_pb3 {
+			/omit-if-no-ref/ spi1_sck_remap1_slave_pb3: spi1_sck_remap1_slave_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
@@ -916,13 +916,13 @@
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ spi3_sck_slave_pc10: spi3_sck_slave_pc10 {
+			/omit-if-no-ref/ spi3_sck_remap1_slave_pc10: spi3_sck_remap1_slave_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, GPIO_IN, SPI3_REMAP1)>;
 			};
 
 			/* TIM_CH_PWM / TIM_CHN_PWM */
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pa7: tim1_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -930,7 +930,7 @@
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -938,7 +938,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -946,7 +946,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -954,15 +954,15 @@
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb0: tim1_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb1: tim1_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
@@ -978,31 +978,31 @@
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pe8: tim1_ch1n_pwm_pe8 {
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_pe8: tim1_ch1n_remap2_pwm_pe8 {
 				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pe9: tim1_ch1_pwm_pe9 {
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_pe9: tim1_ch1_remap2_pwm_pe9 {
 				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pe10: tim1_ch2n_pwm_pe10 {
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_pe10: tim1_ch2n_remap2_pwm_pe10 {
 				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pe11: tim1_ch2_pwm_pe11 {
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_pe11: tim1_ch2_remap2_pwm_pe11 {
 				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pe12: tim1_ch3n_pwm_pe12 {
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_pe12: tim1_ch3n_remap2_pwm_pe12 {
 				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pe13: tim1_ch3_pwm_pe13 {
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_pe13: tim1_ch3_remap2_pwm_pe13 {
 				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pe14: tim1_ch4_pwm_pe14 {
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_pe14: tim1_ch4_remap2_pwm_pe14 {
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
@@ -1010,7 +1010,7 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -1018,7 +1018,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -1026,7 +1026,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -1034,11 +1034,11 @@
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -1046,7 +1046,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
@@ -1054,7 +1054,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -1062,7 +1062,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
@@ -1082,7 +1082,7 @@
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
@@ -1090,31 +1090,31 @@
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pb4: tim3_ch1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pb5: tim3_ch2_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pc6: tim3_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pc7: tim3_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pc8: tim3_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pc9: tim3_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
@@ -1134,19 +1134,19 @@
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pd12: tim4_ch1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pd13: tim4_ch2_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pd14: tim4_ch3_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pd15: tim4_ch4_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
@@ -1180,7 +1180,7 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
+			/omit-if-no-ref/ usart2_cts_remap1_pd3: usart2_cts_remap1_pd3 {
 				pinmux = <STM32F1_PINMUX('D', 3, GPIO_IN, USART2_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -1192,13 +1192,13 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pb13: usart3_cts_pb13 {
+			/omit-if-no-ref/ usart3_cts_remap1_pb13: usart3_cts_remap1_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, USART3_REMAP1)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart3_cts_pd11: usart3_cts_pd11 {
+			/omit-if-no-ref/ usart3_cts_remap2_pd11: usart3_cts_remap2_pd11 {
 				pinmux = <STM32F1_PINMUX('D', 11, GPIO_IN, USART3_REMAP2)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -1214,7 +1214,7 @@
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rts_pd4: usart2_rts_pd4 {
+			/omit-if-no-ref/ usart2_rts_remap1_pd4: usart2_rts_remap1_pd4 {
 				pinmux = <STM32F1_PINMUX('D', 4, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -1222,11 +1222,11 @@
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pb14: usart3_rts_pb14 {
+			/omit-if-no-ref/ usart3_rts_remap1_pb14: usart3_rts_remap1_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rts_pd12: usart3_rts_pd12 {
+			/omit-if-no-ref/ usart3_rts_remap2_pd12: usart3_rts_remap2_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, USART3_REMAP2)>;
 			};
 
@@ -1236,7 +1236,7 @@
 				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
+			/omit-if-no-ref/ usart1_rx_remap1_pb7: usart1_rx_remap1_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, USART1_REMAP1)>;
 			};
 
@@ -1244,7 +1244,7 @@
 				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_rx_pd6: usart2_rx_pd6 {
+			/omit-if-no-ref/ usart2_rx_remap1_pd6: usart2_rx_remap1_pd6 {
 				pinmux = <STM32F1_PINMUX('D', 6, GPIO_IN, USART2_REMAP1)>;
 			};
 
@@ -1252,11 +1252,11 @@
 				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pc11: usart3_rx_pc11 {
+			/omit-if-no-ref/ usart3_rx_remap1_pc11: usart3_rx_remap1_pc11 {
 				pinmux = <STM32F1_PINMUX('C', 11, GPIO_IN, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_rx_pd9: usart3_rx_pd9 {
+			/omit-if-no-ref/ usart3_rx_remap2_pd9: usart3_rx_remap2_pd9 {
 				pinmux = <STM32F1_PINMUX('D', 9, GPIO_IN, USART3_REMAP2)>;
 			};
 
@@ -1274,7 +1274,7 @@
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, USART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart1_tx_pb6: usart1_tx_pb6 {
+			/omit-if-no-ref/ usart1_tx_remap1_pb6: usart1_tx_remap1_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, USART1_REMAP1)>;
 			};
 
@@ -1282,7 +1282,7 @@
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, USART2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart2_tx_pd5: usart2_tx_pd5 {
+			/omit-if-no-ref/ usart2_tx_remap1_pd5: usart2_tx_remap1_pd5 {
 				pinmux = <STM32F1_PINMUX('D', 5, ALTERNATE, USART2_REMAP1)>;
 			};
 
@@ -1290,11 +1290,11 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, USART3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pc10: usart3_tx_pc10 {
+			/omit-if-no-ref/ usart3_tx_remap1_pc10: usart3_tx_remap1_pc10 {
 				pinmux = <STM32F1_PINMUX('C', 10, ALTERNATE, USART3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
+			/omit-if-no-ref/ usart3_tx_remap2_pd8: usart3_tx_remap2_pd8 {
 				pinmux = <STM32F1_PINMUX('D', 8, ALTERNATE, USART3_REMAP2)>;
 			};
 

--- a/scripts/genpinctrl/genpinctrl.py
+++ b/scripts/genpinctrl/genpinctrl.py
@@ -191,6 +191,30 @@ def format_remap(remap):
         return remap
 
 
+def format_remap_name(remap):
+    """Format remap value for DT node name
+
+    Args:
+        remap: Remap definition.
+
+    Returns:
+        DT remap definition in lower caps
+    """
+
+    if remap == 0 or remap is None:
+        return ""
+    elif "REMAP0" in remap:
+        return ""
+    elif "REMAP1" in remap:
+        return "_remap1"
+    elif "REMAP2" in remap:
+        return "_remap2"
+    elif "REMAP3" in remap:
+        return "_remap3"
+    else:
+        return ""
+
+
 def get_gpio_ip_afs(data_path):
     """Obtain all GPIO IP alternate functions.
 
@@ -458,6 +482,7 @@ def main(data_path, output):
     env.filters["format_mode"] = format_mode
     env.filters["format_mode_f1"] = format_mode_f1
     env.filters["format_remap"] = format_remap
+    env.filters["format_remap_name"] = format_remap_name
     pinctrl_template = env.get_template(PINCTRL_TEMPLATE)
     readme_template = env.get_template(README_TEMPLATE)
 

--- a/scripts/genpinctrl/pinctrl-template.j2
+++ b/scripts/genpinctrl/pinctrl-template.j2
@@ -19,7 +19,8 @@
 {{ newline }}
 			{% for entry in group_entries %}
 			{% set variant = "_" + entry["variant"] if entry["variant"] else "" %}
-			{% set name = "%s%s_p%s%d" | format(entry["signal"], variant, entry["port"], entry["pin"]) %}
+			{% set remap = (entry["af"] | format_remap_name) if family == "STM32F1" else "" %}
+			{% set name = "%s%s%s_p%s%d" | format(entry["signal"], remap, variant, entry["port"], entry["pin"]) %}
 			/omit-if-no-ref/ {{ name }}: {{ name }} {
 				{% if family == "STM32F1" %}
 				pinmux = <STM32F1_PINMUX('{{ entry["port"] | upper }}', {{ entry["pin"] }}, {{ entry["mode"] | format_mode_f1 }}, {{ entry["af"] | format_remap }})>;

--- a/scripts/tests/genpinctrl/data/stm32f1testdie-pinctrl.dtsi
+++ b/scripts/tests/genpinctrl/data/stm32f1testdie-pinctrl.dtsi
@@ -25,7 +25,7 @@
 
 			/* UART_RX / USART_RX */
 
-			/omit-if-no-ref/ uart1_rx_pa0: uart1_rx_pa0 {
+			/omit-if-no-ref/ uart1_rx_remap1_pa0: uart1_rx_remap1_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, UART1_REMAP1)>;
 			};
 
@@ -35,15 +35,15 @@
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, UART1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ uart1_tx_pa0: uart1_tx_pa0 {
+			/omit-if-no-ref/ uart1_tx_remap1_pa0: uart1_tx_remap1_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, UART1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ uart1_tx_pa0: uart1_tx_pa0 {
+			/omit-if-no-ref/ uart1_tx_remap2_pa0: uart1_tx_remap2_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, UART1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ uart1_tx_pa0: uart1_tx_pa0 {
+			/omit-if-no-ref/ uart1_tx_remap3_pa0: uart1_tx_remap3_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, UART1_REMAP3)>;
 			};
 

--- a/scripts/tests/genpinctrl/test_genpinctrl.py
+++ b/scripts/tests/genpinctrl/test_genpinctrl.py
@@ -7,6 +7,7 @@ from genpinctrl import (
     format_mode,
     format_mode_f1,
     format_remap,
+    format_remap_name,
     get_gpio_ip_afs,
     get_mcu_signals,
     main,
@@ -147,6 +148,16 @@ def test_format_remap():
     assert format_remap("UART1_REMAP1") == "UART1_REMAP1"
     assert format_remap(0) == "NO_REMAP"
     assert format_remap(None) == "NO_REMAP"
+
+
+def test_format_remap_name():
+    """Test that format_remap_name works."""
+
+    assert format_remap_name("UART1_REMAP3") == "_remap3"
+    assert format_remap_name("UART1_REMAP2") == "_remap2"
+    assert format_remap_name("UART1_REMAP1") == "_remap1"
+    assert format_remap_name("UART1_REMAP0") == ""
+    assert format_remap_name(None) == ""
 
 
 def test_get_gpio_ip_afs(pindata):


### PR DESCRIPTION
Pin remap configurations may take two different values
For instance:
USART3_CTS PA13 matches both remap values 00 and 01.
    
In a peripheral pin remapping configuration, all pins associated to the
device must share the same remap value.
For instance, on USART3
-remap0 cfg uses PB10, PB11, PB12, PB13, PB14, all configured with remap0
-remap1 cfg uses PC10, PC11, PC12, PB13, PB14, all configured with remap1
    
If pinctrl driver detects one of the pins has a remap value different
from the whole set, it will generate an error.

Note:
I've chosen to include the remap information between signal an variant, as this is the most logical place