### PR TITLE
stm32cube: u5: Rename LL_PWR_EnableVDDIO2 to LL_PWR_EnableVddIO2

### DIFF
--- a/stm32cube/stm32u5xx/README
+++ b/stm32cube/stm32u5xx/README
@@ -44,4 +44,9 @@ Patch List:
     -Added stm32cube/stm32u5xx/drivers/include/stm32_assert.h
     -Removed unused stm32cube/stm32u5xx/drivers/include/stm32_assert_template.h
 
+   *Fix LL_PWR_Enable/DisableVDD* functions:
+    -Align definition on other STM32 series
+   Impacted files: drivers/include/Legacy/stm32_hal_legacy.h
+   Internal reference: 134618
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32u5xx/drivers/include/Legacy/stm32_hal_legacy.h
+++ b/stm32cube/stm32u5xx/drivers/include/Legacy/stm32_hal_legacy.h
@@ -3974,10 +3974,15 @@ extern "C" {
   * @}
   */
 
+#if defined(STM32U5)
+#define LL_PWR_EnableVddUSB		LL_PWR_EnableVDDUSB
+#define LL_PWR_DisableVddUSB		LL_PWR_DisableVDDUSB
+#define LL_PWR_EnableVddIO2		LL_PWR_EnableVDDIO2
+#define LL_PWR_DisableVddIO2		LL_PWR_DisableVDDIO2
+#endif /* STM32U5 */
+
 #ifdef __cplusplus
 }
 #endif
 
 #endif /* STM32_HAL_LEGACY */
-
-


### PR DESCRIPTION
Align U5 LL_PWR_EnableVDDIO2 function name to name used on other STM32 series: LL_PWR_EnableVddIO2
Apply similar treatment to:
- LL_PWR_DisableVDDUSB
- LL_PWR_EnableVDDIO2
- LL_PWR_DisableVDDIO2

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>