### PR TITLE
Wrap define UNUSED with an ifndef

### DIFF
--- a/stm32cube/stm32f0xx/README
+++ b/stm32cube/stm32f0xx/README
@@ -47,4 +47,11 @@ Patch List:
     -Added stm32cube/stm32f0xx/drivers/include/stm32_assert.h
     -Removed unused stm32cube/stm32f0xx/drivers/include/stm32_assert_template.h
 
+   *Wrap define UNUSED with an ifndef
+     This will prevent a compiler warning for the case the UNUSED macro
+     is already defined elsewhere in the project
+     Impacted files:
+      drivers/include/stm32f0xx_hal_def.h
+     ST Internal Reference: 136825
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32f0xx/drivers/include/stm32f0xx_hal_def.h
+++ b/stm32cube/stm32f0xx/drivers/include/stm32f0xx_hal_def.h
@@ -55,7 +55,9 @@ typedef enum
 
 /* Exported macro ------------------------------------------------------------*/
 
-#define UNUSED(X) (void)X      /* To avoid gcc/g++ warnings */
+#ifndef UNUSED
+  #define UNUSED(X) (void)X      /* To avoid gcc/g++ warnings */
+#endif
 
 #define HAL_MAX_DELAY      0xFFFFFFFFU
 

--- a/stm32cube/stm32f1xx/README
+++ b/stm32cube/stm32f1xx/README
@@ -52,4 +52,11 @@ Patch List:
     -Added stm32cube/stm32f1xx/drivers/include/stm32_assert.h
     -Removed unused stm32cube/stm32f1xx/drivers/include/stm32_assert_template.h
 
+   *Wrap define UNUSED with an ifndef
+     This will prevent a compiler warning for the case the UNUSED macro
+     is already defined elsewhere in the project
+     Impacted files:
+      drivers/include/stm32f1xx_hal_def.h
+     ST Internal Reference: 136825
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32f1xx/drivers/include/stm32f1xx_hal_def.h
+++ b/stm32cube/stm32f1xx/drivers/include/stm32f1xx_hal_def.h
@@ -65,7 +65,9 @@ typedef enum
                               (__DMA_HANDLE__).Parent = (__HANDLE__);             \
                           } while(0U)
 
-#define UNUSED(X) (void)X      /* To avoid gcc/g++ warnings */
+#ifndef UNUSED
+  #define UNUSED(X) (void)X      /* To avoid gcc/g++ warnings */
+#endif
 
 /** @brief Reset the Handle's State field.
   * @param __HANDLE__ specifies the Peripheral Handle.

--- a/stm32cube/stm32f2xx/README
+++ b/stm32cube/stm32f2xx/README
@@ -52,4 +52,11 @@ Patch List:
     -Added stm32cube/stm32f2xx/drivers/include/stm32_assert.h
     -Removed unused stm32cube/stm32f2xx/drivers/include/stm32_assert_template.h
 
+   *Wrap define UNUSED with an ifndef
+     This will prevent a compiler warning for the case the UNUSED macro
+     is already defined elsewhere in the project
+     Impacted files:
+      drivers/include/stm32f2xx_hal_def.h
+     ST Internal Reference: 136825
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32f2xx/drivers/include/stm32f2xx_hal_def.h
+++ b/stm32cube/stm32f2xx/drivers/include/stm32f2xx_hal_def.h
@@ -55,7 +55,9 @@ typedef enum
 
 /* Exported macro ------------------------------------------------------------*/
 
-#define UNUSED(X) (void)X      /* To avoid gcc/g++ warnings */
+#ifndef UNUSED
+  #define UNUSED(X) (void)X      /* To avoid gcc/g++ warnings */
+#endif
 
 #define HAL_MAX_DELAY      0xFFFFFFFFU
 

--- a/stm32cube/stm32f3xx/README
+++ b/stm32cube/stm32f3xx/README
@@ -44,4 +44,11 @@ Patch List:
     -Added stm32cube/stm32f3xx/drivers/include/stm32_assert.h
     -Removed unused stm32cube/stm32f3xx/drivers/include/stm32_assert_template.h
 
+   *Wrap define UNUSED with an ifndef
+     This will prevent a compiler warning for the case the UNUSED macro
+     is already defined elsewhere in the project
+     Impacted files:
+      drivers/include/stm32f3xx_hal_def.h
+     ST Internal Reference: 136825
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32f3xx/drivers/include/stm32f3xx_hal_def.h
+++ b/stm32cube/stm32f3xx/drivers/include/stm32f3xx_hal_def.h
@@ -55,7 +55,9 @@ typedef enum
 
 /* Exported macro ------------------------------------------------------------*/
 
-#define UNUSED(X) (void)X      /* To avoid gcc/g++ warnings */
+#ifndef UNUSED
+  #define UNUSED(X) (void)X      /* To avoid gcc/g++ warnings */
+#endif
 
 #define HAL_MAX_DELAY      0xFFFFFFFFU
 

--- a/stm32cube/stm32f4xx/README
+++ b/stm32cube/stm32f4xx/README
@@ -62,4 +62,11 @@ Patch List:
     This will have to be removed once Zephyr driver is migrated ot the new
     Cube HAL ethernet API.
 
+   *Wrap define UNUSED with an ifndef
+     This will prevent a compiler warning for the case the UNUSED macro
+     is already defined elsewhere in the project
+     Impacted files:
+      drivers/include/stm32f4xx_hal_def.h
+     ST Internal Reference: 136825
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32f4xx/drivers/include/stm32f4xx_hal_def.h
+++ b/stm32cube/stm32f4xx/drivers/include/stm32f4xx_hal_def.h
@@ -54,7 +54,9 @@ typedef enum
 
 /* Exported macro ------------------------------------------------------------*/
 
-#define UNUSED(X) (void)X      /* To avoid gcc/g++ warnings */
+#ifndef UNUSED
+  #define UNUSED(X) (void)X      /* To avoid gcc/g++ warnings */
+#endif
 
 #define HAL_MAX_DELAY      0xFFFFFFFFU
 

--- a/stm32cube/stm32f7xx/README
+++ b/stm32cube/stm32f7xx/README
@@ -47,4 +47,12 @@ Patch List:
    *Enable legacy ethernet driver using HAL_ETH_LEGACY_MODULE_ENABLED
     This will have to be removed once Zephyr driver is migrated ot the new
     Cube HAL ethernet API.
+
+   *Wrap define UNUSED with an ifndef
+     This will prevent a compiler warning for the case the UNUSED macro
+     is already defined elsewhere in the project
+     Impacted files:
+      drivers/include/stm32f7xx_hal_def.h
+     ST Internal Reference: 136825
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32f7xx/drivers/include/stm32f7xx_hal_def.h
+++ b/stm32cube/stm32f7xx/drivers/include/stm32f7xx_hal_def.h
@@ -54,7 +54,9 @@ typedef enum
 
 /* Exported macro ------------------------------------------------------------*/
 
-#define UNUSED(X) (void)X      /* To avoid gcc/g++ warnings */
+#ifndef UNUSED
+  #define UNUSED(X) (void)X      /* To avoid gcc/g++ warnings */
+#endif
 
 #define HAL_MAX_DELAY      0xFFFFFFFFU
 

--- a/stm32cube/stm32g0xx/README
+++ b/stm32cube/stm32g0xx/README
@@ -44,4 +44,11 @@ Patch List:
     -Added stm32cube/stm32g0xx/drivers/include/stm32_assert.h
     -Removed unused stm32cube/stm32g0xx/drivers/include/stm32_assert_template.h
 
+   *Wrap define UNUSED with an ifndef
+     This will prevent a compiler warning for the case the UNUSED macro
+     is already defined elsewhere in the project
+     Impacted files:
+      drivers/include/stm32g0xx_hal_def.h
+     ST Internal Reference: 136825
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_def.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_def.h
@@ -54,7 +54,9 @@ typedef enum
 
 /* Exported macros -----------------------------------------------------------*/
 
-#define UNUSED(X) (void)X      /* To avoid gcc/g++ warnings */
+#ifndef UNUSED
+  #define UNUSED(X) (void)X      /* To avoid gcc/g++ warnings */
+#endif
 
 #define HAL_MAX_DELAY      0xFFFFFFFFU
 

--- a/stm32cube/stm32g4xx/README
+++ b/stm32cube/stm32g4xx/README
@@ -44,4 +44,11 @@ Patch List:
     -Added stm32cube/stm32g4xx/drivers/include/stm32_assert.h
     -Removed unused stm32cube/stm32g4xx/drivers/include/stm32_assert_template.h
 
+   *Wrap define UNUSED with an ifndef
+     This will prevent a compiler warning for the case the UNUSED macro
+     is already defined elsewhere in the project
+     Impacted files:
+      drivers/include/stm32g4xx_hal_def.h
+     ST Internal Reference: 136825
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32g4xx/drivers/include/stm32g4xx_hal_def.h
+++ b/stm32cube/stm32g4xx/drivers/include/stm32g4xx_hal_def.h
@@ -65,7 +65,9 @@ typedef enum
     (__DMA_HANDLE__).Parent = (__HANDLE__);                          \
   } while(0)
 
-#define UNUSED(X) (void)X
+#ifndef UNUSED
+  #define UNUSED(X) (void)X
+#endif
 
 /** @brief Reset the Handle's State field.
   * @param __HANDLE__: specifies the Peripheral Handle.

--- a/stm32cube/stm32h7xx/README
+++ b/stm32cube/stm32h7xx/README
@@ -57,4 +57,11 @@ Patch List:
     Impacted file: drivers/include/stm32h7xx_ll_spi.h
     Internal reference: 124484
 
+   *Wrap define UNUSED with an ifndef
+     This will prevent a compiler warning for the case the UNUSED macro
+     is already defined elsewhere in the project
+     Impacted files:
+      drivers/include/stm32h7xx_hal_def.h
+     ST Internal Reference: 136825
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32h7xx/drivers/include/stm32h7xx_hal_def.h
+++ b/stm32cube/stm32h7xx/drivers/include/stm32h7xx_hal_def.h
@@ -66,7 +66,9 @@ typedef enum
                               (__DMA_HANDLE__).Parent = (__HANDLE__);             \
                           } while(0)
 
-#define UNUSED(x) ((void)(x))
+#ifndef UNUSED
+  #define UNUSED(x) ((void)(x))
+#endif
 
 /** @brief Reset the Handle's State field.
   * @param __HANDLE__: specifies the Peripheral Handle.

--- a/stm32cube/stm32l0xx/README
+++ b/stm32cube/stm32l0xx/README
@@ -44,4 +44,11 @@ Patch List:
     -Added stm32cube/stm32l0xx/drivers/include/stm32_assert.h
     -Removed unused stm32cube/stm32l0xx/drivers/include/stm32_assert_template.h
 
+   *Wrap define UNUSED with an ifndef
+     This will prevent a compiler warning for the case the UNUSED macro
+     is already defined elsewhere in the project
+     Impacted files:
+      drivers/include/stm32l0xx_hal_def.h
+     ST Internal Reference: 136825
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32l0xx/drivers/include/stm32l0xx_hal_def.h
+++ b/stm32cube/stm32l0xx/drivers/include/stm32l0xx_hal_def.h
@@ -55,7 +55,9 @@ typedef enum
 
 /* Exported macro ------------------------------------------------------------*/
 
-#define UNUSED(X) (void)X      /* To avoid gcc/g++ warnings */
+#ifndef UNUSED
+  #define UNUSED(X) (void)X      /* To avoid gcc/g++ warnings */
+#endif
 
 #define HAL_MAX_DELAY      0xFFFFFFFFU
 

--- a/stm32cube/stm32l1xx/README
+++ b/stm32cube/stm32l1xx/README
@@ -107,4 +107,11 @@ Patch List:
       drivers/src/stm32l1xx_hal_rcc.c
      ST Bug tracker ID: 80902
 
+   *Wrap define UNUSED with an ifndef
+     This will prevent a compiler warning for the case the UNUSED macro
+     is already defined elsewhere in the project
+     Impacted files:
+      drivers/include/stm32l1xx_hal_def.h
+     ST Internal Reference: 136825
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32l1xx/drivers/include/stm32l1xx_hal_def.h
+++ b/stm32cube/stm32l1xx/drivers/include/stm32l1xx_hal_def.h
@@ -55,7 +55,9 @@ typedef enum
 
 /* Exported macro ------------------------------------------------------------*/
 
-#define UNUSED(X) (void)X      /* To avoid gcc/g++ warnings */
+#ifndef UNUSED
+  #define UNUSED(X) (void)X      /* To avoid gcc/g++ warnings */
+#endif
 
 #define HAL_MAX_DELAY      0xFFFFFFFFU
 

--- a/stm32cube/stm32l4xx/README
+++ b/stm32cube/stm32l4xx/README
@@ -44,4 +44,11 @@ Patch List:
     -Added stm32cube/stm32l4xx/drivers/include/stm32_assert.h
     -Removed unused stm32cube/stm32l4xx/drivers/include/stm32_assert_template.h
 
+   *Wrap define UNUSED with an ifndef
+     This will prevent a compiler warning for the case the UNUSED macro
+     is already defined elsewhere in the project
+     Impacted files:
+      drivers/include/stm32l4xx_hal_def.h
+     ST Internal Reference: 136825
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32l4xx/drivers/include/stm32l4xx_hal_def.h
+++ b/stm32cube/stm32l4xx/drivers/include/stm32l4xx_hal_def.h
@@ -54,7 +54,9 @@ typedef enum
 
 /* Exported macros -----------------------------------------------------------*/
 
-#define UNUSED(X) (void)X      /* To avoid gcc/g++ warnings */
+#ifndef UNUSED
+  #define UNUSED(X) (void)X      /* To avoid gcc/g++ warnings */
+#endif
 
 #define HAL_MAX_DELAY      0xFFFFFFFFU
 

--- a/stm32cube/stm32l5xx/README
+++ b/stm32cube/stm32l5xx/README
@@ -44,4 +44,11 @@ Patch List:
     -Added stm32cube/stm32l5xx/drivers/include/stm32_assert.h
     -Removed unused stm32cube/stm32l5xx/drivers/include/stm32_assert_template.h
 
+   *Wrap define UNUSED with an ifndef
+     This will prevent a compiler warning for the case the UNUSED macro
+     is already defined elsewhere in the project
+     Impacted files:
+      drivers/include/stm32l5xx_hal_def.h
+     ST Internal Reference: 136825
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32l5xx/drivers/include/stm32l5xx_hal_def.h
+++ b/stm32cube/stm32l5xx/drivers/include/stm32l5xx_hal_def.h
@@ -59,7 +59,9 @@ typedef enum
 
 /* Exported macros -----------------------------------------------------------*/
 
-#define UNUSED(X) (void)X      /* To avoid gcc/g++ warnings */
+#ifndef UNUSED
+  #define UNUSED(X) (void)X      /* To avoid gcc/g++ warnings */
+#endif
 
 #define HAL_MAX_DELAY      0xFFFFFFFFU
 

--- a/stm32cube/stm32mp1xx/README
+++ b/stm32cube/stm32mp1xx/README
@@ -43,4 +43,11 @@ Patch List:
    *Provision to enable hal & ll asserts added
     -Modified stm32cube/stm32mp1xx/drivers/include/stm32_assert.h
 
+   *Wrap define UNUSED with an ifndef
+     This will prevent a compiler warning for the case the UNUSED macro
+     is already defined elsewhere in the project
+     Impacted files:
+      drivers/include/stm32mp1xx_hal_def.h
+     ST Internal Reference: 136825
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32mp1xx/drivers/include/stm32mp1xx_hal_def.h
+++ b/stm32cube/stm32mp1xx/drivers/include/stm32mp1xx_hal_def.h
@@ -56,7 +56,9 @@ typedef enum
 
 /* Exported macros -----------------------------------------------------------*/
 
-#define UNUSED(X) (void)X      /* To avoid gcc/g++ warnings */
+#ifndef UNUSED
+  #define UNUSED(X) (void)X      /* To avoid gcc/g++ warnings */
+#endif
 
 #define HAL_MAX_DELAY      0xFFFFFFFFU
 

--- a/stm32cube/stm32u5xx/README
+++ b/stm32cube/stm32u5xx/README
@@ -49,4 +49,11 @@ Patch List:
    Impacted files: drivers/include/Legacy/stm32_hal_legacy.h
    Internal reference: 134618
 
+   *Wrap define UNUSED with an ifndef
+     This will prevent a compiler warning for the case the UNUSED macro
+     is already defined elsewhere in the project
+     Impacted files:
+      drivers/include/stm32u5xx_hal_def.h
+     ST Internal Reference: 136825
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32u5xx/drivers/include/stm32u5xx_hal_def.h
+++ b/stm32cube/stm32u5xx/drivers/include/stm32u5xx_hal_def.h
@@ -70,7 +70,9 @@ typedef enum
     (__DMA_HANDLE__).Parent = (__HANDLE__);                                       \
   } while(0)
 
-#define UNUSED(x) ((void)(x))
+#ifndef UNUSED
+  #define UNUSED(x) ((void)(x))
+#endif
 
 /** @brief Reset the Handle's State field.
   * @param __HANDLE__: specifies the Peripheral Handle.

--- a/stm32cube/stm32wlxx/README
+++ b/stm32cube/stm32wlxx/README
@@ -66,4 +66,11 @@ Patch List:
      stm32cube/stm32wlxx/drivers/src/stm32wlxx_ll_util.c
     ST Internal reference: 124139
 
+   *Wrap define UNUSED with an ifndef
+     This will prevent a compiler warning for the case the UNUSED macro
+     is already defined elsewhere in the project
+     Impacted files:
+      drivers/include/stm32wlxx_hal_def.h
+     ST Internal Reference: 136825
+
    See release_note.html from STM32Cube

--- a/stm32cube/stm32wlxx/drivers/include/stm32wlxx_hal_def.h
+++ b/stm32cube/stm32wlxx/drivers/include/stm32wlxx_hal_def.h
@@ -55,7 +55,9 @@ typedef enum
 
 /* Exported macros -----------------------------------------------------------*/
 
-#define UNUSED(X) (void)X      /* To avoid gcc/g++ warnings */
+#ifndef UNUSED
+  #define UNUSED(X) (void)X      /* To avoid gcc/g++ warnings */
+#endif
 
 #define HAL_MAX_DELAY      0xFFFFFFFFU
 


### PR DESCRIPTION
To prevent the error `... error: "UNUSED" redefined ...` we have to wrap the define with an `#ifndef`.
We can not remove our define and think that others also have this problem and so can benefit from this change.