### PR TITLE
[DNM] dts: remove duplicate pinctrl nodes

### DIFF
--- a/dts/st/g0/stm32g031k(4-6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031k(4-6-8)tx-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -214,12 +206,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -239,12 +225,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -346,11 +326,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -385,11 +360,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -474,14 +444,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -688,10 +650,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -708,11 +666,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g071r(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071r(6-8-b)tx-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -344,12 +336,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -381,12 +367,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -518,11 +498,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -577,11 +552,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -725,14 +695,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -1174,10 +1136,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -1242,11 +1200,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g081rbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081rbtx-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -344,12 +336,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -381,12 +367,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -518,11 +498,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -577,11 +552,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -725,14 +695,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -1174,10 +1136,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -1242,11 +1200,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g0b1r(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1r(b-c-e)tx-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -412,12 +404,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -432,12 +418,6 @@
 
 			/omit-if-no-ref/ i2c2_scl_pa7: i2c2_scl_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_scl_pa9: i2c2_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -498,12 +478,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -518,12 +492,6 @@
 
 			/omit-if-no-ref/ i2c2_sda_pa6: i2c2_sda_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_sda_pa10: i2c2_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -653,10 +621,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
-			};
-
 			/omit-if-no-ref/ i2s2_sd_pb7: i2s2_sd_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
@@ -743,11 +707,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -812,11 +771,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -992,14 +946,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -1570,10 +1516,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -1678,11 +1620,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h735igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735igkx-pinctrl.dtsi
@@ -354,14 +354,6 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa0: analog_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa1: analog_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -496,14 +488,6 @@
 
 			/omit-if-no-ref/ analog_pc2: analog_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
@@ -907,11 +891,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_crs_pa0: eth_crs_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -957,11 +936,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_ref_clk_pa1: eth_ref_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -1001,11 +975,6 @@
 			};
 
 			/* ETH_RX_CLK */
-
-			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
@@ -1058,11 +1027,6 @@
 			/* ETH_TXD2 */
 
 			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -1080,11 +1044,6 @@
 			};
 
 			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
@@ -1187,12 +1146,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ fmc_a19_pa0: fmc_a19_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ fmc_d8_pa4: fmc_d8_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF12)>;
 				bias-pull-up;
@@ -1260,19 +1213,7 @@
 			};
 
 			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2067,10 +2008,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 			};
 
-			/omit-if-no-ref/ i2s6_ws_pa0: i2s6_ws_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF5)>;
-			};
-
 			/omit-if-no-ref/ i2s6_ws_pa4: i2s6_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF8)>;
 			};
@@ -2084,10 +2021,6 @@
 			};
 
 			/* LTDC */
-
-			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF14)>;
-			};
 
 			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
@@ -2421,16 +2354,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF12)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
 				slew-rate = "very-high-speed";
@@ -2507,32 +2430,12 @@
 			};
 
 			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 
 			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -2854,12 +2757,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF9)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2991,11 +2888,6 @@
 			};
 
 			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF5)>;
 				bias-pull-down;
 			};
@@ -3069,11 +2961,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 				bias-pull-down;
 			};
 
@@ -3201,11 +3088,6 @@
 
 			/omit-if-no-ref/ spi5_nss_ph5: spi5_nss_ph5 {
 				pinmux = <STM32_PINMUX('H', 5, AF5)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ spi6_nss_pa0: spi6_nss_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 				bias-pull-up;
 			};
 
@@ -3413,14 +3295,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pa0: tim2_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF1)>;
-			};
-
-			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-			};
-
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -3621,18 +3495,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF2)>;
-			};
-
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
@@ -3795,12 +3657,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3895,11 +3751,6 @@
 				drive-push-pull;
 			};
 
-			/omit-if-no-ref/ usart2_de_pa1: usart2_de_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				drive-push-pull;
-			};
-
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3976,12 +3827,6 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -4118,10 +3963,6 @@
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
-			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF8)>;
-			};
-
 			/omit-if-no-ref/ uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
@@ -4249,11 +4090,6 @@
 
 			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -4412,15 +4248,7 @@
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {

--- a/dts/st/h7/stm32h747xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xihx-pinctrl.dtsi
@@ -354,14 +354,6 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa0: analog_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa1: analog_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -496,14 +488,6 @@
 
 			/omit-if-no-ref/ analog_pc2: analog_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
@@ -1067,11 +1051,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_crs_pa0: eth_crs_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -1117,11 +1096,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_ref_clk_pa1: eth_ref_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -1161,11 +1135,6 @@
 			};
 
 			/* ETH_RX_CLK */
-
-			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
@@ -1227,11 +1196,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1245,11 +1209,6 @@
 			};
 
 			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
@@ -1358,18 +1317,6 @@
 
 			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2155,10 +2102,6 @@
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF14)>;
-			};
-
 			/omit-if-no-ref/ ltdc_r1_pa2: ltdc_r1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
@@ -2578,11 +2521,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -2795,12 +2733,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF9)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2900,11 +2832,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2984,11 +2911,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3368,14 +3290,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pa0: tim2_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF1)>;
-			};
-
-			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-			};
-
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -3514,18 +3428,6 @@
 
 			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
@@ -3732,12 +3634,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3821,11 +3717,6 @@
 				drive-push-pull;
 			};
 
-			/omit-if-no-ref/ usart2_de_pa1: usart2_de_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				drive-push-pull;
-			};
-
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3891,12 +3782,6 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -4013,10 +3898,6 @@
 
 			/omit-if-no-ref/ usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
-			};
-
-			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
 			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
@@ -4140,11 +4021,6 @@
 
 			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -4321,14 +4197,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {

--- a/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
@@ -226,14 +226,6 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa0: analog_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa1: analog_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
@@ -368,14 +360,6 @@
 
 			/omit-if-no-ref/ analog_pc2: analog_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
@@ -1020,18 +1004,6 @@
 
 			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1841,10 +1813,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 			};
 
-			/omit-if-no-ref/ i2s6_ws_pa0: i2s6_ws_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF5)>;
-			};
-
 			/omit-if-no-ref/ i2s6_ws_pa4: i2s6_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF8)>;
 			};
@@ -1858,10 +1826,6 @@
 			};
 
 			/* LTDC */
-
-			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF14)>;
-			};
 
 			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
@@ -2363,16 +2327,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 				slew-rate = "very-high-speed";
@@ -2435,26 +2389,6 @@
 
 			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -2836,12 +2770,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF9)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2971,11 +2899,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -3055,11 +2978,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3207,11 +3125,6 @@
 
 			/omit-if-no-ref/ spi5_nss_pk1: spi5_nss_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF5)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ spi6_nss_pa0: spi6_nss_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 				bias-pull-up;
 			};
 
@@ -3455,14 +3368,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pa0: tim2_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF1)>;
-			};
-
-			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-			};
-
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -3601,18 +3506,6 @@
 
 			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
@@ -3829,12 +3722,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3935,11 +3822,6 @@
 				drive-push-pull;
 			};
 
-			/omit-if-no-ref/ usart2_de_pa1: usart2_de_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				drive-push-pull;
-			};
-
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -4021,12 +3903,6 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -4169,10 +4045,6 @@
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
-			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF8)>;
-			};
-
 			/omit-if-no-ref/ uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
@@ -4308,11 +4180,6 @@
 
 			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -4477,14 +4344,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {


### PR DESCRIPTION
This patch cannot be merged as-is; I'm just using it for now to get cleaner CI in https://github.com/zephyrproject-rtos/zephyr/pull/50287.

The STM32 G0 and H7 family pinctrl DTSI files have a lot of duplicate nodes. In most cases, they are simply redundant, but not always, and I suspect there may be bugs in the genpinctrl script or the open pin database.

For example, look at the usb_otg_hs_ulpi_dir_pc2 nodes in stm32h735igkx-pinctrl.dtsi:

```
  /omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
          pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
  };

  /omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
          pinmux = <STM32_PINMUX('C', 2, AF10)>;
  };
```

Note the different alternate function -- ANALOG vs. AF10.

With current dtlib, AF10 wins, but this will be an error once zephyr PR 50287 is merged, and it looks suspicious.

The generation of these files should be investigated and fixed to not generate duplicate or conflicting definitions by someone who knows the hardware better; this is just a demo of what sort of thing needs to happen.
