### PR TITLE
pinctrl: fix duplicate entries

### DIFF
--- a/dts/st/f1/stm32f100c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100c(4-6)tx-pinctrl.dtsi
@@ -414,7 +414,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -422,7 +422,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -430,7 +430,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -438,7 +438,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f100c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100c(8-b)tx-pinctrl.dtsi
@@ -458,7 +458,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -466,7 +466,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -474,7 +474,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -482,7 +482,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f100r(4-6)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(4-6)hx-pinctrl.dtsi
@@ -486,7 +486,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -494,7 +494,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -502,7 +502,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -510,7 +510,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f100r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(4-6)tx-pinctrl.dtsi
@@ -494,7 +494,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -502,7 +502,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -510,7 +510,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -518,7 +518,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f100r(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(8-b)hx-pinctrl.dtsi
@@ -530,7 +530,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -538,7 +538,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -546,7 +546,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -554,7 +554,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f100r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(8-b)tx-pinctrl.dtsi
@@ -538,7 +538,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -546,7 +546,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -554,7 +554,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -562,7 +562,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f100r(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(c-d-e)tx-pinctrl.dtsi
@@ -572,7 +572,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -580,7 +580,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -588,7 +588,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -596,7 +596,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f100v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100v(8-b)tx-pinctrl.dtsi
@@ -682,7 +682,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -690,7 +690,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -698,7 +698,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -706,7 +706,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f100v(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100v(c-d-e)tx-pinctrl.dtsi
@@ -716,7 +716,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -724,7 +724,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -732,7 +732,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -740,7 +740,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f100z(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100z(c-d-e)tx-pinctrl.dtsi
@@ -844,7 +844,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -852,7 +852,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -860,7 +860,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -868,7 +868,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f101c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101c(4-6)tx-pinctrl.dtsi
@@ -348,7 +348,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -356,7 +356,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -364,7 +364,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -372,7 +372,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f101c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101c(8-b)tx-pinctrl.dtsi
@@ -392,7 +392,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -400,7 +400,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -408,7 +408,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -416,7 +416,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f101c(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101c(8-b)ux-pinctrl.dtsi
@@ -392,7 +392,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -400,7 +400,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -408,7 +408,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -416,7 +416,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f101r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101r(4-6)tx-pinctrl.dtsi
@@ -428,7 +428,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -436,7 +436,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -444,7 +444,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -452,7 +452,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f101r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101r(8-b)tx-pinctrl.dtsi
@@ -472,7 +472,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -480,7 +480,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -488,7 +488,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -496,7 +496,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f101r(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101r(c-d-e)tx-pinctrl.dtsi
@@ -516,7 +516,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -524,7 +524,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -532,7 +532,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -540,7 +540,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f101r(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101r(f-g)tx-pinctrl.dtsi
@@ -524,7 +524,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -532,7 +532,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -540,7 +540,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -548,7 +548,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f101rbhx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101rbhx-pinctrl.dtsi
@@ -464,7 +464,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -472,7 +472,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -480,7 +480,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -488,7 +488,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f101t(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101t(4-6)ux-pinctrl.dtsi
@@ -294,7 +294,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -302,7 +302,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f101t(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101t(8-b)ux-pinctrl.dtsi
@@ -294,7 +294,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -302,7 +302,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f101v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101v(8-b)tx-pinctrl.dtsi
@@ -588,7 +588,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -596,7 +596,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -604,7 +604,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -612,7 +612,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f101v(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101v(c-d-e)tx-pinctrl.dtsi
@@ -632,7 +632,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -640,7 +640,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -648,7 +648,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -656,7 +656,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f101v(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101v(f-g)tx-pinctrl.dtsi
@@ -640,7 +640,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -648,7 +648,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -656,7 +656,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -664,7 +664,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f101z(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101z(c-d-e)tx-pinctrl.dtsi
@@ -760,7 +760,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -768,7 +768,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -776,7 +776,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -784,7 +784,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f101z(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101z(f-g)tx-pinctrl.dtsi
@@ -776,7 +776,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -784,7 +784,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -792,7 +792,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -800,7 +800,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f102c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102c(4-6)tx-pinctrl.dtsi
@@ -348,7 +348,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -356,7 +356,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -364,7 +364,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -372,7 +372,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f102c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102c(8-b)tx-pinctrl.dtsi
@@ -392,7 +392,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -400,7 +400,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -408,7 +408,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -416,7 +416,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f102r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102r(4-6)tx-pinctrl.dtsi
@@ -428,7 +428,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -436,7 +436,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -444,7 +444,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -452,7 +452,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f102r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102r(8-b)tx-pinctrl.dtsi
@@ -472,7 +472,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -480,7 +480,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -488,7 +488,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -496,7 +496,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f103c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103c(4-6)tx-pinctrl.dtsi
@@ -464,7 +464,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -472,7 +472,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -480,7 +480,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -488,7 +488,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f103c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103c(8-b)tx-pinctrl.dtsi
@@ -508,7 +508,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -516,7 +516,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -524,7 +524,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -532,7 +532,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f103c6ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103c6ux-pinctrl.dtsi
@@ -464,7 +464,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -472,7 +472,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -480,7 +480,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -488,7 +488,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f103cbux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103cbux-pinctrl.dtsi
@@ -508,7 +508,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -516,7 +516,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -524,7 +524,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -532,7 +532,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f103r(4-6)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(4-6)hx-pinctrl.dtsi
@@ -556,7 +556,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -564,7 +564,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -572,7 +572,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -580,7 +580,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f103r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(4-6)tx-pinctrl.dtsi
@@ -568,7 +568,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -576,7 +576,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -584,7 +584,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -592,7 +592,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f103r(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(8-b)hx-pinctrl.dtsi
@@ -600,7 +600,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -608,7 +608,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -616,7 +616,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -624,7 +624,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f103r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(8-b)tx-pinctrl.dtsi
@@ -612,7 +612,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -620,7 +620,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -628,7 +628,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -636,7 +636,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f103r(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(c-d-e)tx-pinctrl.dtsi
@@ -718,7 +718,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -726,7 +726,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -734,7 +734,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -742,7 +742,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f103r(c-d-e)yx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(c-d-e)yx-pinctrl.dtsi
@@ -702,7 +702,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -710,7 +710,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -718,7 +718,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -726,7 +726,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f103r(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(f-g)tx-pinctrl.dtsi
@@ -726,7 +726,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -734,7 +734,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -742,7 +742,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -750,7 +750,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f103t(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103t(4-6)ux-pinctrl.dtsi
@@ -390,7 +390,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -398,7 +398,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f103t(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103t(8-b)ux-pinctrl.dtsi
@@ -390,7 +390,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -398,7 +398,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f103v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(8-b)hx-pinctrl.dtsi
@@ -764,7 +764,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -772,7 +772,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -780,7 +780,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -788,7 +788,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f103v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(8-b)tx-pinctrl.dtsi
@@ -764,7 +764,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -772,7 +772,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -780,7 +780,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -788,7 +788,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f103v(c-d-e)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(c-d-e)hx-pinctrl.dtsi
@@ -870,7 +870,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -878,7 +878,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -886,7 +886,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -894,7 +894,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f103v(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(c-d-e)tx-pinctrl.dtsi
@@ -870,7 +870,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -878,7 +878,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -886,7 +886,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -894,7 +894,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f103v(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(f-g)tx-pinctrl.dtsi
@@ -878,7 +878,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -886,7 +886,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -894,7 +894,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -902,7 +902,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f103vbix-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103vbix-pinctrl.dtsi
@@ -764,7 +764,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -772,7 +772,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -780,7 +780,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -788,7 +788,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f103z(c-d-e)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(c-d-e)hx-pinctrl.dtsi
@@ -1018,7 +1018,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -1026,7 +1026,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -1034,7 +1034,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -1042,7 +1042,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f103z(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(c-d-e)tx-pinctrl.dtsi
@@ -1018,7 +1018,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -1026,7 +1026,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -1034,7 +1034,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -1042,7 +1042,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f103z(f-g)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(f-g)hx-pinctrl.dtsi
@@ -1034,7 +1034,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -1042,7 +1042,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -1050,7 +1050,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -1058,7 +1058,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f103z(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(f-g)tx-pinctrl.dtsi
@@ -1034,7 +1034,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -1042,7 +1042,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -1050,7 +1050,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -1058,7 +1058,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f105r(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f105r(8-b-c)tx-pinctrl.dtsi
@@ -748,7 +748,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -756,7 +756,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -764,7 +764,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -772,7 +772,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f105v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f105v(8-b)hx-pinctrl.dtsi
@@ -900,7 +900,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -908,7 +908,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -916,7 +916,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -924,7 +924,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f105v(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f105v(8-b-c)tx-pinctrl.dtsi
@@ -900,7 +900,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -908,7 +908,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -916,7 +916,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -924,7 +924,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f107r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f107r(b-c)tx-pinctrl.dtsi
@@ -866,7 +866,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -874,7 +874,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -882,7 +882,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -890,7 +890,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f107v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f107v(b-c)tx-pinctrl.dtsi
@@ -1042,7 +1042,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -1050,7 +1050,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -1058,7 +1058,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -1066,7 +1066,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/f1/stm32f107vchx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f107vchx-pinctrl.dtsi
@@ -1042,7 +1042,7 @@
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa15: tim2_ch1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -1050,7 +1050,7 @@
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pb3: tim2_ch2_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -1058,7 +1058,7 @@
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pb10: tim2_ch3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
@@ -1066,7 +1066,7 @@
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pb11: tim2_ch4_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 

--- a/dts/st/g0/stm32g030c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g030c(6-8)tx-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -266,12 +258,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -303,12 +289,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -422,11 +402,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -471,11 +446,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -598,14 +568,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -801,10 +763,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -818,11 +776,6 @@
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
-			};
 
 			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;

--- a/dts/st/g0/stm32g030k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g030k(6-8)tx-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -210,12 +202,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -235,12 +221,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -342,11 +322,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -381,11 +356,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -470,14 +440,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -631,10 +593,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -648,11 +606,6 @@
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
-			};
 
 			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;

--- a/dts/st/g0/stm32g031c(4-6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031c(4-6-8)tx-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -270,12 +262,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -307,12 +293,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -426,11 +406,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -475,11 +450,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -602,14 +572,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -887,10 +849,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -911,11 +869,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g031c(4-6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031c(4-6-8)ux-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -270,12 +262,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -307,12 +293,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -426,11 +406,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -475,11 +450,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -602,14 +572,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -887,10 +849,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -911,11 +869,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g031k(4-6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031k(4-6-8)tx-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -214,12 +206,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -239,12 +225,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -346,11 +326,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -385,11 +360,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -474,14 +444,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -688,10 +650,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -708,11 +666,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g031k(4-6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031k(4-6-8)ux-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -214,12 +206,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -239,12 +225,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -346,11 +326,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -385,11 +360,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -474,14 +444,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -688,10 +650,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -708,11 +666,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g041c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041c(6-8)tx-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -270,12 +262,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -307,12 +293,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -426,11 +406,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -475,11 +450,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -602,14 +572,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -887,10 +849,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -911,11 +869,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g041c(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041c(6-8)ux-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -270,12 +262,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -307,12 +293,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -426,11 +406,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -475,11 +450,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -602,14 +572,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -887,10 +849,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -911,11 +869,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g041k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041k(6-8)tx-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -214,12 +206,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -239,12 +225,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -346,11 +326,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -385,11 +360,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -474,14 +444,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -688,10 +650,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -708,11 +666,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g041k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041k(6-8)ux-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -214,12 +206,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -239,12 +225,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -346,11 +326,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -385,11 +360,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -474,14 +444,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -688,10 +650,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -708,11 +666,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g050c6tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g050c6tx-pinctrl.dtsi
@@ -130,14 +130,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -277,12 +269,6 @@
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -319,12 +305,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -434,11 +414,6 @@
 			};
 
 			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
@@ -487,11 +462,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 				bias-pull-down;
 			};
 
@@ -613,15 +583,7 @@
 			};
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -846,10 +808,6 @@
 			/* UART_RX / USART_RX / LPUART_RX */
 
 			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
@@ -866,11 +824,6 @@
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-				bias-pull-up;
-			};
 
 			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;

--- a/dts/st/g0/stm32g050c8tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g050c8tx-pinctrl.dtsi
@@ -130,14 +130,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -277,12 +269,6 @@
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -319,12 +305,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -434,11 +414,6 @@
 			};
 
 			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
@@ -487,11 +462,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 				bias-pull-down;
 			};
 
@@ -613,15 +583,7 @@
 			};
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -846,10 +808,6 @@
 			/* UART_RX / USART_RX / LPUART_RX */
 
 			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
@@ -866,11 +824,6 @@
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-				bias-pull-up;
-			};
 
 			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;

--- a/dts/st/g0/stm32g050k6tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g050k6tx-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -209,12 +201,6 @@
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -239,12 +225,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -342,11 +322,6 @@
 			};
 
 			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
@@ -385,11 +360,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 				bias-pull-down;
 			};
 
@@ -473,15 +443,7 @@
 			};
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -644,10 +606,6 @@
 			/* UART_RX / USART_RX / LPUART_RX */
 
 			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
@@ -664,11 +622,6 @@
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-				bias-pull-up;
-			};
 
 			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;

--- a/dts/st/g0/stm32g050k8tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g050k8tx-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -209,12 +201,6 @@
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -239,12 +225,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -342,11 +322,6 @@
 			};
 
 			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
@@ -385,11 +360,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 				bias-pull-down;
 			};
 
@@ -473,15 +443,7 @@
 			};
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -644,10 +606,6 @@
 			/* UART_RX / USART_RX / LPUART_RX */
 
 			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
@@ -664,11 +622,6 @@
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-				bias-pull-up;
-			};
 
 			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;

--- a/dts/st/g0/stm32g051c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g051c(6-8)tx-pinctrl.dtsi
@@ -130,14 +130,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -287,12 +279,6 @@
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -329,12 +315,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -444,11 +424,6 @@
 			};
 
 			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
@@ -497,11 +472,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 				bias-pull-down;
 			};
 
@@ -623,15 +593,7 @@
 			};
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -938,10 +900,6 @@
 			};
 
 			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
@@ -965,11 +923,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g051c(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g051c(6-8)ux-pinctrl.dtsi
@@ -130,14 +130,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -287,12 +279,6 @@
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -329,12 +315,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -444,11 +424,6 @@
 			};
 
 			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
@@ -497,11 +472,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 				bias-pull-down;
 			};
 
@@ -623,15 +593,7 @@
 			};
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -938,10 +900,6 @@
 			};
 
 			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
@@ -965,11 +923,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g051k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g051k(6-8)tx-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -219,12 +211,6 @@
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -249,12 +235,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -352,11 +332,6 @@
 			};
 
 			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
@@ -395,11 +370,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 				bias-pull-down;
 			};
 
@@ -483,15 +453,7 @@
 			};
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -707,10 +669,6 @@
 			};
 
 			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
@@ -730,11 +688,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g051k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g051k(6-8)ux-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -219,12 +211,6 @@
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -249,12 +235,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -352,11 +332,6 @@
 			};
 
 			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
@@ -395,11 +370,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 				bias-pull-down;
 			};
 
@@ -483,15 +453,7 @@
 			};
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -707,10 +669,6 @@
 			};
 
 			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
@@ -730,11 +688,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g061c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g061c(6-8)tx-pinctrl.dtsi
@@ -130,14 +130,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -287,12 +279,6 @@
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -329,12 +315,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -444,11 +424,6 @@
 			};
 
 			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
@@ -497,11 +472,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 				bias-pull-down;
 			};
 
@@ -623,15 +593,7 @@
 			};
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -938,10 +900,6 @@
 			};
 
 			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
@@ -965,11 +923,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g061c(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g061c(6-8)ux-pinctrl.dtsi
@@ -130,14 +130,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -287,12 +279,6 @@
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -329,12 +315,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -444,11 +424,6 @@
 			};
 
 			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
@@ -497,11 +472,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 				bias-pull-down;
 			};
 
@@ -623,15 +593,7 @@
 			};
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -938,10 +900,6 @@
 			};
 
 			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
@@ -965,11 +923,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g061k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g061k(6-8)tx-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -219,12 +211,6 @@
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -249,12 +235,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -352,11 +332,6 @@
 			};
 
 			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
@@ -395,11 +370,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 				bias-pull-down;
 			};
 
@@ -483,15 +453,7 @@
 			};
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -707,10 +669,6 @@
 			};
 
 			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
@@ -730,11 +688,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g061k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g061k(6-8)ux-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -219,12 +211,6 @@
 			/* I2C_SCL */
 
 			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF6)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -249,12 +235,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -352,11 +332,6 @@
 			};
 
 			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF4)>;
 				bias-pull-down;
 			};
@@ -395,11 +370,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 				bias-pull-down;
 			};
 
@@ -483,15 +453,7 @@
 			};
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -707,10 +669,6 @@
 			};
 
 			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
@@ -730,11 +688,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g070cbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g070cbtx-pinctrl.dtsi
@@ -110,14 +110,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -258,12 +250,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -295,12 +281,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -414,11 +394,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -463,11 +438,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -590,14 +560,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -898,10 +860,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -931,11 +889,6 @@
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
-			};
 
 			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;

--- a/dts/st/g0/stm32g070kbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g070kbtx-pinctrl.dtsi
@@ -98,14 +98,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -190,12 +182,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -215,12 +201,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -322,11 +302,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -361,11 +336,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -450,14 +420,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -668,10 +630,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -697,11 +655,6 @@
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
-			};
 
 			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;

--- a/dts/st/g0/stm32g070rbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g070rbtx-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -330,12 +322,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -367,12 +353,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -504,11 +484,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -563,11 +538,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -711,14 +681,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -1070,10 +1032,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -1127,11 +1085,6 @@
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
-			};
 
 			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;

--- a/dts/st/g0/stm32g071c(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071c(6-8-b)tx-pinctrl.dtsi
@@ -110,14 +110,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -272,12 +264,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -309,12 +295,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -428,11 +408,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -477,11 +452,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -604,14 +574,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -994,10 +956,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -1034,11 +992,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g071c(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071c(6-8-b)ux-pinctrl.dtsi
@@ -110,14 +110,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -272,12 +264,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -309,12 +295,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -428,11 +408,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -477,11 +452,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -604,14 +574,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -994,10 +956,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -1034,11 +992,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g071k(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071k(6-8-b)tx-pinctrl.dtsi
@@ -98,14 +98,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -204,12 +196,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -229,12 +215,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -336,11 +316,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -375,11 +350,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -464,14 +434,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -735,10 +697,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -767,11 +725,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g071k(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071k(6-8-b)ux-pinctrl.dtsi
@@ -98,14 +98,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -204,12 +196,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -229,12 +215,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -336,11 +316,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -375,11 +350,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -464,14 +434,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -735,10 +697,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -767,11 +725,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g071k(8-b)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071k(8-b)txn-pinctrl.dtsi
@@ -94,14 +94,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -200,12 +192,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -225,12 +211,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -314,11 +294,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb6: spi2_miso_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF4)>;
 				bias-pull-down;
@@ -348,11 +323,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -442,14 +412,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -699,10 +661,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -727,11 +685,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g071k(8-b)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071k(8-b)uxn-pinctrl.dtsi
@@ -94,14 +94,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -200,12 +192,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -225,12 +211,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -314,11 +294,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb6: spi2_miso_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF4)>;
 				bias-pull-down;
@@ -348,11 +323,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -442,14 +412,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -699,10 +661,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -727,11 +685,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g071r(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071r(6-8-b)tx-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -344,12 +336,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -381,12 +367,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -518,11 +498,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -577,11 +552,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -725,14 +695,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -1174,10 +1136,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -1242,11 +1200,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g071rbix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071rbix-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -344,12 +336,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -381,12 +367,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -518,11 +498,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -577,11 +552,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -725,14 +695,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -1174,10 +1136,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -1242,11 +1200,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g081cbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081cbtx-pinctrl.dtsi
@@ -110,14 +110,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -272,12 +264,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -309,12 +295,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -428,11 +408,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -477,11 +452,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -604,14 +574,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -994,10 +956,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -1034,11 +992,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g081cbux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081cbux-pinctrl.dtsi
@@ -110,14 +110,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -272,12 +264,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -309,12 +295,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -428,11 +408,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -477,11 +452,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -604,14 +574,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -994,10 +956,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -1034,11 +992,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g081kbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081kbtx-pinctrl.dtsi
@@ -98,14 +98,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -204,12 +196,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -229,12 +215,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -336,11 +316,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -375,11 +350,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -464,14 +434,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -735,10 +697,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -767,11 +725,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g081kbtxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081kbtxn-pinctrl.dtsi
@@ -94,14 +94,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -200,12 +192,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -225,12 +211,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -314,11 +294,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb6: spi2_miso_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF4)>;
 				bias-pull-down;
@@ -348,11 +323,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -442,14 +412,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -699,10 +661,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -727,11 +685,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g081kbux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081kbux-pinctrl.dtsi
@@ -98,14 +98,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -204,12 +196,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -229,12 +215,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -336,11 +316,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -375,11 +350,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -464,14 +434,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -735,10 +697,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -767,11 +725,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g081kbuxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081kbuxn-pinctrl.dtsi
@@ -94,14 +94,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -200,12 +192,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -225,12 +211,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -314,11 +294,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb6: spi2_miso_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF4)>;
 				bias-pull-down;
@@ -348,11 +323,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -442,14 +412,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -699,10 +661,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -727,11 +685,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g081rbix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081rbix-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -344,12 +336,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -381,12 +367,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -518,11 +498,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -577,11 +552,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -725,14 +695,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -1174,10 +1136,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -1242,11 +1200,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g081rbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081rbtx-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -344,12 +336,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -381,12 +367,6 @@
 			};
 
 			/* I2C_SDA */
-
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
 
 			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, AF6)>;
@@ -518,11 +498,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -577,11 +552,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -725,14 +695,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -1174,10 +1136,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -1242,11 +1200,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g0b0cetx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b0cetx-pinctrl.dtsi
@@ -110,14 +110,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -262,12 +254,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -282,12 +268,6 @@
 
 			/omit-if-no-ref/ i2c2_scl_pa7: i2c2_scl_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_scl_pa9: i2c2_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -342,12 +322,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -362,12 +336,6 @@
 
 			/omit-if-no-ref/ i2c2_sda_pa6: i2c2_sda_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_sda_pa10: i2c2_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -482,10 +450,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
-			};
-
 			/omit-if-no-ref/ i2s2_sd_pb7: i2s2_sd_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
@@ -555,11 +519,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -609,11 +568,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -757,14 +711,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -1132,10 +1078,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -1185,11 +1127,6 @@
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
-			};
 
 			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;

--- a/dts/st/g0/stm32g0b0ketx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b0ketx-pinctrl.dtsi
@@ -98,14 +98,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -194,12 +186,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -214,12 +200,6 @@
 
 			/omit-if-no-ref/ i2c2_scl_pa7: i2c2_scl_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_scl_pa9: i2c2_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -262,12 +242,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -282,12 +256,6 @@
 
 			/omit-if-no-ref/ i2c2_sda_pa6: i2c2_sda_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_sda_pa10: i2c2_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -375,10 +343,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
-			};
-
 			/omit-if-no-ref/ i2s2_sd_pb7: i2s2_sd_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
@@ -432,11 +396,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -476,11 +435,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -586,14 +540,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -854,10 +800,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -899,11 +841,6 @@
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
-			};
 
 			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;

--- a/dts/st/g0/stm32g0b0retx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b0retx-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -334,12 +326,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -354,12 +340,6 @@
 
 			/omit-if-no-ref/ i2c2_scl_pa7: i2c2_scl_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_scl_pa9: i2c2_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -420,12 +400,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -440,12 +414,6 @@
 
 			/omit-if-no-ref/ i2c2_sda_pa6: i2c2_sda_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_sda_pa10: i2c2_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -575,10 +543,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
-			};
-
 			/omit-if-no-ref/ i2s2_sd_pb7: i2s2_sd_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
@@ -665,11 +629,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -734,11 +693,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -914,14 +868,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -1357,10 +1303,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -1438,11 +1380,6 @@
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
-			};
 
 			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;

--- a/dts/st/g0/stm32g0b0vetx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b0vetx-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -470,12 +462,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -490,12 +476,6 @@
 
 			/omit-if-no-ref/ i2c2_scl_pa7: i2c2_scl_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_scl_pa9: i2c2_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -556,12 +536,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -576,12 +550,6 @@
 
 			/omit-if-no-ref/ i2c2_sda_pa6: i2c2_sda_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_sda_pa10: i2c2_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -720,10 +688,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
-			};
-
 			/omit-if-no-ref/ i2s2_sd_pb7: i2s2_sd_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
@@ -819,11 +783,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -893,11 +852,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -1084,14 +1038,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -1665,10 +1611,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -1758,11 +1700,6 @@
 			};
 
 			/* UART_TX / USART_TX / LPUART_TX */
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
-				bias-pull-up;
-			};
 
 			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF1)>;

--- a/dts/st/g0/stm32g0b1c(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1c(b-c-e)tx-pinctrl.dtsi
@@ -110,14 +110,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -324,12 +316,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -344,12 +330,6 @@
 
 			/omit-if-no-ref/ i2c2_scl_pa7: i2c2_scl_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_scl_pa9: i2c2_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -404,12 +384,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -424,12 +398,6 @@
 
 			/omit-if-no-ref/ i2c2_sda_pa6: i2c2_sda_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_sda_pa10: i2c2_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -544,10 +512,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
-			};
-
 			/omit-if-no-ref/ i2s2_sd_pb7: i2s2_sd_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
@@ -617,11 +581,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -671,11 +630,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -819,14 +773,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -1304,10 +1250,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -1376,11 +1318,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g0b1c(b-c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1c(b-c-e)txn-pinctrl.dtsi
@@ -110,14 +110,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -316,12 +308,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -336,12 +322,6 @@
 
 			/omit-if-no-ref/ i2c2_scl_pa7: i2c2_scl_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_scl_pa9: i2c2_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -396,12 +376,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -416,12 +390,6 @@
 
 			/omit-if-no-ref/ i2c2_sda_pa6: i2c2_sda_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_sda_pa10: i2c2_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -536,10 +504,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
-			};
-
 			/omit-if-no-ref/ i2s2_sd_pb7: i2s2_sd_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
@@ -609,11 +573,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -663,11 +622,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -811,14 +765,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -1280,10 +1226,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -1348,11 +1290,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g0b1c(b-c-e)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1c(b-c-e)ux-pinctrl.dtsi
@@ -110,14 +110,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -324,12 +316,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -344,12 +330,6 @@
 
 			/omit-if-no-ref/ i2c2_scl_pa7: i2c2_scl_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_scl_pa9: i2c2_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -404,12 +384,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -424,12 +398,6 @@
 
 			/omit-if-no-ref/ i2c2_sda_pa6: i2c2_sda_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_sda_pa10: i2c2_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -544,10 +512,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
-			};
-
 			/omit-if-no-ref/ i2s2_sd_pb7: i2s2_sd_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
@@ -617,11 +581,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -671,11 +630,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -819,14 +773,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -1304,10 +1250,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -1376,11 +1318,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g0b1c(b-c-e)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1c(b-c-e)uxn-pinctrl.dtsi
@@ -110,14 +110,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -316,12 +308,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -336,12 +322,6 @@
 
 			/omit-if-no-ref/ i2c2_scl_pa7: i2c2_scl_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_scl_pa9: i2c2_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -396,12 +376,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -416,12 +390,6 @@
 
 			/omit-if-no-ref/ i2c2_sda_pa6: i2c2_sda_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_sda_pa10: i2c2_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -536,10 +504,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
-			};
-
 			/omit-if-no-ref/ i2s2_sd_pb7: i2s2_sd_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
@@ -609,11 +573,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -663,11 +622,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -811,14 +765,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -1280,10 +1226,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -1348,11 +1290,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g0b1k(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1k(b-c-e)tx-pinctrl.dtsi
@@ -98,14 +98,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -240,12 +232,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -260,12 +246,6 @@
 
 			/omit-if-no-ref/ i2c2_scl_pa7: i2c2_scl_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_scl_pa9: i2c2_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -308,12 +288,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -328,12 +302,6 @@
 
 			/omit-if-no-ref/ i2c2_sda_pa6: i2c2_sda_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_sda_pa10: i2c2_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -421,10 +389,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
-			};
-
 			/omit-if-no-ref/ i2s2_sd_pb7: i2s2_sd_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
@@ -478,11 +442,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -522,11 +481,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -632,14 +586,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -981,10 +927,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -1037,11 +979,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g0b1k(b-c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1k(b-c-e)txn-pinctrl.dtsi
@@ -94,14 +94,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -236,12 +228,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -256,12 +242,6 @@
 
 			/omit-if-no-ref/ i2c2_scl_pa7: i2c2_scl_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_scl_pa9: i2c2_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -292,12 +272,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -312,12 +286,6 @@
 
 			/omit-if-no-ref/ i2c2_sda_pa6: i2c2_sda_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_sda_pa10: i2c2_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -389,10 +357,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
-			};
-
 			/omit-if-no-ref/ i2s2_sd_pb7: i2s2_sd_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
@@ -445,11 +409,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb6: spi2_miso_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF4)>;
 				bias-pull-down;
@@ -479,11 +438,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -573,14 +527,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -895,10 +841,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -947,11 +889,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g0b1k(b-c-e)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1k(b-c-e)ux-pinctrl.dtsi
@@ -98,14 +98,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -240,12 +232,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -260,12 +246,6 @@
 
 			/omit-if-no-ref/ i2c2_scl_pa7: i2c2_scl_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_scl_pa9: i2c2_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -308,12 +288,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -328,12 +302,6 @@
 
 			/omit-if-no-ref/ i2c2_sda_pa6: i2c2_sda_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_sda_pa10: i2c2_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -421,10 +389,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
-			};
-
 			/omit-if-no-ref/ i2s2_sd_pb7: i2s2_sd_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
@@ -478,11 +442,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -522,11 +481,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -632,14 +586,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -981,10 +927,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -1037,11 +979,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g0b1k(b-c-e)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1k(b-c-e)uxn-pinctrl.dtsi
@@ -94,14 +94,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -236,12 +228,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -256,12 +242,6 @@
 
 			/omit-if-no-ref/ i2c2_scl_pa7: i2c2_scl_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_scl_pa9: i2c2_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -292,12 +272,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -312,12 +286,6 @@
 
 			/omit-if-no-ref/ i2c2_sda_pa6: i2c2_sda_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_sda_pa10: i2c2_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -389,10 +357,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
-			};
-
 			/omit-if-no-ref/ i2s2_sd_pb7: i2s2_sd_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
@@ -445,11 +409,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb6: spi2_miso_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF4)>;
 				bias-pull-down;
@@ -479,11 +438,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -573,14 +527,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -895,10 +841,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -947,11 +889,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g0b1m(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1m(b-c-e)tx-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -484,12 +476,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -504,12 +490,6 @@
 
 			/omit-if-no-ref/ i2c2_scl_pa7: i2c2_scl_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_scl_pa9: i2c2_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -570,12 +550,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -590,12 +564,6 @@
 
 			/omit-if-no-ref/ i2c2_sda_pa6: i2c2_sda_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_sda_pa10: i2c2_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -725,10 +693,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
-			};
-
 			/omit-if-no-ref/ i2s2_sd_pb7: i2s2_sd_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
@@ -815,11 +779,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -884,11 +843,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -1064,14 +1018,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -1727,10 +1673,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -1839,11 +1781,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g0b1neyx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1neyx-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -348,12 +340,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -368,12 +354,6 @@
 
 			/omit-if-no-ref/ i2c2_scl_pa7: i2c2_scl_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_scl_pa9: i2c2_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -428,12 +408,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -448,12 +422,6 @@
 
 			/omit-if-no-ref/ i2c2_sda_pa6: i2c2_sda_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_sda_pa10: i2c2_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -568,10 +536,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
-			};
-
 			/omit-if-no-ref/ i2s2_sd_pb7: i2s2_sd_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
@@ -641,11 +605,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -695,11 +654,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -843,14 +797,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -1336,10 +1282,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -1416,11 +1358,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g0b1r(b-c-e)ixn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1r(b-c-e)ixn-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -404,12 +396,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -424,12 +410,6 @@
 
 			/omit-if-no-ref/ i2c2_scl_pa7: i2c2_scl_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_scl_pa9: i2c2_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -490,12 +470,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -510,12 +484,6 @@
 
 			/omit-if-no-ref/ i2c2_sda_pa6: i2c2_sda_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_sda_pa10: i2c2_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -640,10 +608,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
-			};
-
 			/omit-if-no-ref/ i2s2_sd_pb7: i2s2_sd_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
@@ -726,11 +690,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -795,11 +754,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -964,14 +918,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -1542,10 +1488,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -1646,11 +1588,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g0b1r(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1r(b-c-e)tx-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -412,12 +404,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -432,12 +418,6 @@
 
 			/omit-if-no-ref/ i2c2_scl_pa7: i2c2_scl_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_scl_pa9: i2c2_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -498,12 +478,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -518,12 +492,6 @@
 
 			/omit-if-no-ref/ i2c2_sda_pa6: i2c2_sda_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_sda_pa10: i2c2_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -653,10 +621,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
-			};
-
 			/omit-if-no-ref/ i2s2_sd_pb7: i2s2_sd_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
@@ -743,11 +707,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -812,11 +771,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -992,14 +946,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -1570,10 +1516,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -1678,11 +1620,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g0b1r(b-c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1r(b-c-e)txn-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -404,12 +396,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -424,12 +410,6 @@
 
 			/omit-if-no-ref/ i2c2_scl_pa7: i2c2_scl_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_scl_pa9: i2c2_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -490,12 +470,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -510,12 +484,6 @@
 
 			/omit-if-no-ref/ i2c2_sda_pa6: i2c2_sda_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_sda_pa10: i2c2_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -640,10 +608,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
-			};
-
 			/omit-if-no-ref/ i2s2_sd_pb7: i2s2_sd_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
@@ -726,11 +690,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -795,11 +754,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -964,14 +918,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -1542,10 +1488,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -1646,11 +1588,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g0b1v(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1v(b-c-e)ix-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -564,12 +556,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -584,12 +570,6 @@
 
 			/omit-if-no-ref/ i2c2_scl_pa7: i2c2_scl_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_scl_pa9: i2c2_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -650,12 +630,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -670,12 +644,6 @@
 
 			/omit-if-no-ref/ i2c2_sda_pa6: i2c2_sda_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_sda_pa10: i2c2_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -814,10 +782,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
-			};
-
 			/omit-if-no-ref/ i2s2_sd_pb7: i2s2_sd_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
@@ -913,11 +877,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -987,11 +946,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -1178,14 +1132,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -1928,10 +1874,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -2056,11 +1998,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g0b1v(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1v(b-c-e)tx-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -564,12 +556,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -584,12 +570,6 @@
 
 			/omit-if-no-ref/ i2c2_scl_pa7: i2c2_scl_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_scl_pa9: i2c2_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -650,12 +630,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -670,12 +644,6 @@
 
 			/omit-if-no-ref/ i2c2_sda_pa6: i2c2_sda_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_sda_pa10: i2c2_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -814,10 +782,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
-			};
-
 			/omit-if-no-ref/ i2s2_sd_pb7: i2s2_sd_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
@@ -913,11 +877,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -987,11 +946,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -1178,14 +1132,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -1928,10 +1874,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -2056,11 +1998,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g0c1c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1c(c-e)tx-pinctrl.dtsi
@@ -110,14 +110,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -324,12 +316,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -344,12 +330,6 @@
 
 			/omit-if-no-ref/ i2c2_scl_pa7: i2c2_scl_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_scl_pa9: i2c2_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -404,12 +384,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -424,12 +398,6 @@
 
 			/omit-if-no-ref/ i2c2_sda_pa6: i2c2_sda_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_sda_pa10: i2c2_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -544,10 +512,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
-			};
-
 			/omit-if-no-ref/ i2s2_sd_pb7: i2s2_sd_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
@@ -617,11 +581,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -671,11 +630,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -819,14 +773,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -1304,10 +1250,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -1376,11 +1318,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g0c1c(c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1c(c-e)txn-pinctrl.dtsi
@@ -110,14 +110,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -316,12 +308,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -336,12 +322,6 @@
 
 			/omit-if-no-ref/ i2c2_scl_pa7: i2c2_scl_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_scl_pa9: i2c2_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -396,12 +376,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -416,12 +390,6 @@
 
 			/omit-if-no-ref/ i2c2_sda_pa6: i2c2_sda_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_sda_pa10: i2c2_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -536,10 +504,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
-			};
-
 			/omit-if-no-ref/ i2s2_sd_pb7: i2s2_sd_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
@@ -609,11 +573,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -663,11 +622,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -811,14 +765,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -1280,10 +1226,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -1348,11 +1290,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g0c1c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1c(c-e)ux-pinctrl.dtsi
@@ -110,14 +110,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -324,12 +316,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -344,12 +330,6 @@
 
 			/omit-if-no-ref/ i2c2_scl_pa7: i2c2_scl_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_scl_pa9: i2c2_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -404,12 +384,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -424,12 +398,6 @@
 
 			/omit-if-no-ref/ i2c2_sda_pa6: i2c2_sda_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_sda_pa10: i2c2_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -544,10 +512,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
-			};
-
 			/omit-if-no-ref/ i2s2_sd_pb7: i2s2_sd_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
@@ -617,11 +581,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -671,11 +630,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -819,14 +773,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -1304,10 +1250,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -1376,11 +1318,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g0c1c(c-e)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1c(c-e)uxn-pinctrl.dtsi
@@ -110,14 +110,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -316,12 +308,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -336,12 +322,6 @@
 
 			/omit-if-no-ref/ i2c2_scl_pa7: i2c2_scl_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_scl_pa9: i2c2_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -396,12 +376,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -416,12 +390,6 @@
 
 			/omit-if-no-ref/ i2c2_sda_pa6: i2c2_sda_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_sda_pa10: i2c2_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -536,10 +504,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
-			};
-
 			/omit-if-no-ref/ i2s2_sd_pb7: i2s2_sd_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
@@ -609,11 +573,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -663,11 +622,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -811,14 +765,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -1280,10 +1226,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -1348,11 +1290,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g0c1k(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1k(c-e)tx-pinctrl.dtsi
@@ -98,14 +98,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -240,12 +232,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -260,12 +246,6 @@
 
 			/omit-if-no-ref/ i2c2_scl_pa7: i2c2_scl_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_scl_pa9: i2c2_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -308,12 +288,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -328,12 +302,6 @@
 
 			/omit-if-no-ref/ i2c2_sda_pa6: i2c2_sda_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_sda_pa10: i2c2_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -421,10 +389,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
-			};
-
 			/omit-if-no-ref/ i2s2_sd_pb7: i2s2_sd_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
@@ -478,11 +442,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -522,11 +481,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -632,14 +586,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -981,10 +927,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -1037,11 +979,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g0c1k(c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1k(c-e)txn-pinctrl.dtsi
@@ -94,14 +94,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -236,12 +228,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -256,12 +242,6 @@
 
 			/omit-if-no-ref/ i2c2_scl_pa7: i2c2_scl_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_scl_pa9: i2c2_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -292,12 +272,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -312,12 +286,6 @@
 
 			/omit-if-no-ref/ i2c2_sda_pa6: i2c2_sda_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_sda_pa10: i2c2_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -389,10 +357,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
-			};
-
 			/omit-if-no-ref/ i2s2_sd_pb7: i2s2_sd_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
@@ -445,11 +409,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb6: spi2_miso_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF4)>;
 				bias-pull-down;
@@ -479,11 +438,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -573,14 +527,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -895,10 +841,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -947,11 +889,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g0c1k(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1k(c-e)ux-pinctrl.dtsi
@@ -98,14 +98,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -240,12 +232,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -260,12 +246,6 @@
 
 			/omit-if-no-ref/ i2c2_scl_pa7: i2c2_scl_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_scl_pa9: i2c2_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -308,12 +288,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -328,12 +302,6 @@
 
 			/omit-if-no-ref/ i2c2_sda_pa6: i2c2_sda_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_sda_pa10: i2c2_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -421,10 +389,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
-			};
-
 			/omit-if-no-ref/ i2s2_sd_pb7: i2s2_sd_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
@@ -478,11 +442,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -522,11 +481,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -632,14 +586,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -981,10 +927,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -1037,11 +979,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g0c1k(c-e)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1k(c-e)uxn-pinctrl.dtsi
@@ -94,14 +94,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -236,12 +228,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -256,12 +242,6 @@
 
 			/omit-if-no-ref/ i2c2_scl_pa7: i2c2_scl_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_scl_pa9: i2c2_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -292,12 +272,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -312,12 +286,6 @@
 
 			/omit-if-no-ref/ i2c2_sda_pa6: i2c2_sda_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_sda_pa10: i2c2_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -389,10 +357,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
-			};
-
 			/omit-if-no-ref/ i2s2_sd_pb7: i2s2_sd_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
@@ -445,11 +409,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb6: spi2_miso_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF4)>;
 				bias-pull-down;
@@ -479,11 +438,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -573,14 +527,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -895,10 +841,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -947,11 +889,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g0c1m(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1m(c-e)tx-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -484,12 +476,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -504,12 +490,6 @@
 
 			/omit-if-no-ref/ i2c2_scl_pa7: i2c2_scl_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_scl_pa9: i2c2_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -570,12 +550,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -590,12 +564,6 @@
 
 			/omit-if-no-ref/ i2c2_sda_pa6: i2c2_sda_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_sda_pa10: i2c2_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -725,10 +693,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
-			};
-
 			/omit-if-no-ref/ i2s2_sd_pb7: i2s2_sd_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
@@ -815,11 +779,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -884,11 +843,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -1064,14 +1018,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -1727,10 +1673,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -1839,11 +1781,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g0c1neyx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1neyx-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -348,12 +340,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -368,12 +354,6 @@
 
 			/omit-if-no-ref/ i2c2_scl_pa7: i2c2_scl_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_scl_pa9: i2c2_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -428,12 +408,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -448,12 +422,6 @@
 
 			/omit-if-no-ref/ i2c2_sda_pa6: i2c2_sda_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_sda_pa10: i2c2_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -568,10 +536,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
-			};
-
 			/omit-if-no-ref/ i2s2_sd_pb7: i2s2_sd_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
@@ -641,11 +605,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -695,11 +654,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -843,14 +797,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -1336,10 +1282,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -1416,11 +1358,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g0c1r(c-e)ixn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1r(c-e)ixn-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -404,12 +396,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -424,12 +410,6 @@
 
 			/omit-if-no-ref/ i2c2_scl_pa7: i2c2_scl_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_scl_pa9: i2c2_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -490,12 +470,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -510,12 +484,6 @@
 
 			/omit-if-no-ref/ i2c2_sda_pa6: i2c2_sda_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_sda_pa10: i2c2_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -640,10 +608,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
-			};
-
 			/omit-if-no-ref/ i2s2_sd_pb7: i2s2_sd_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
@@ -726,11 +690,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -795,11 +754,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -964,14 +918,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -1542,10 +1488,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -1646,11 +1588,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g0c1r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1r(c-e)tx-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -412,12 +404,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -432,12 +418,6 @@
 
 			/omit-if-no-ref/ i2c2_scl_pa7: i2c2_scl_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_scl_pa9: i2c2_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -498,12 +478,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -518,12 +492,6 @@
 
 			/omit-if-no-ref/ i2c2_sda_pa6: i2c2_sda_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_sda_pa10: i2c2_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -653,10 +621,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
-			};
-
 			/omit-if-no-ref/ i2s2_sd_pb7: i2s2_sd_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
@@ -743,11 +707,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -812,11 +771,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -992,14 +946,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -1570,10 +1516,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -1678,11 +1620,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g0c1r(c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1r(c-e)txn-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -404,12 +396,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -424,12 +410,6 @@
 
 			/omit-if-no-ref/ i2c2_scl_pa7: i2c2_scl_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_scl_pa9: i2c2_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -490,12 +470,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -510,12 +484,6 @@
 
 			/omit-if-no-ref/ i2c2_sda_pa6: i2c2_sda_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_sda_pa10: i2c2_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -640,10 +608,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
-			};
-
 			/omit-if-no-ref/ i2s2_sd_pb7: i2s2_sd_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
@@ -726,11 +690,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -795,11 +754,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -964,14 +918,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -1542,10 +1488,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -1646,11 +1588,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g0c1v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1v(c-e)ix-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -564,12 +556,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -584,12 +570,6 @@
 
 			/omit-if-no-ref/ i2c2_scl_pa7: i2c2_scl_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_scl_pa9: i2c2_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -650,12 +630,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -670,12 +644,6 @@
 
 			/omit-if-no-ref/ i2c2_sda_pa6: i2c2_sda_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_sda_pa10: i2c2_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -814,10 +782,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
-			};
-
 			/omit-if-no-ref/ i2s2_sd_pb7: i2s2_sd_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
@@ -913,11 +877,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -987,11 +946,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -1178,14 +1132,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -1928,10 +1874,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -2056,11 +1998,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/g0/stm32g0c1v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1v(c-e)tx-pinctrl.dtsi
@@ -118,14 +118,6 @@
 				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ analog_pa9: analog_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa10: analog_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ analog_pa10: analog_pa10 {
 				pinmux = <STM32_PINMUX('A', 10, ANALOG)>;
 			};
@@ -564,12 +556,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_scl_pa9: i2c1_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_scl_pb6: i2c1_scl_pb6 {
 				pinmux = <STM32_PINMUX('B', 6, AF6)>;
 				bias-pull-up;
@@ -584,12 +570,6 @@
 
 			/omit-if-no-ref/ i2c2_scl_pa7: i2c2_scl_pa7 {
 				pinmux = <STM32_PINMUX('A', 7, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_scl_pa9: i2c2_scl_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -650,12 +630,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ i2c1_sda_pa10: i2c1_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF6)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ i2c1_sda_pb7: i2c1_sda_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF6)>;
 				bias-pull-up;
@@ -670,12 +644,6 @@
 
 			/omit-if-no-ref/ i2c2_sda_pa6: i2c2_sda_pa6 {
 				pinmux = <STM32_PINMUX('A', 6, AF8)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ i2c2_sda_pa10: i2c2_sda_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF8)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -814,10 +782,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 			};
 
-			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
-			};
-
 			/omit-if-no-ref/ i2s2_sd_pb7: i2s2_sd_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF1)>;
 			};
@@ -913,11 +877,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pa9: spi2_miso_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF4)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pb2: spi2_miso_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF1)>;
 				bias-pull-down;
@@ -987,11 +946,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pa4: spi2_mosi_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF1)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pa10: spi2_mosi_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF0)>;
 				bias-pull-down;
 			};
 
@@ -1178,14 +1132,6 @@
 
 			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
 				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch2_pa9: tim1_ch2_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim1_ch3_pa10: tim1_ch3_pa10 {
@@ -1928,10 +1874,6 @@
 				pinmux = <STM32_PINMUX('A', 10, AF1)>;
 			};
 
-			/omit-if-no-ref/ usart1_rx_pa10: usart1_rx_pa10 {
-				pinmux = <STM32_PINMUX('A', 10, AF1)>;
-			};
-
 			/omit-if-no-ref/ usart1_rx_pb7: usart1_rx_pb7 {
 				pinmux = <STM32_PINMUX('B', 7, AF0)>;
 			};
@@ -2056,11 +1998,6 @@
 
 			/omit-if-no-ref/ lpuart1_tx_pa2: lpuart1_tx_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ usart1_tx_pa9: usart1_tx_pa9 {
-				pinmux = <STM32_PINMUX('A', 9, AF1)>;
 				bias-pull-up;
 			};
 

--- a/dts/st/h7/stm32h723vehx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vehx-pinctrl.dtsi
@@ -172,18 +172,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -320,14 +308,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -636,13 +616,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -652,13 +625,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -791,18 +757,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1590,26 +1544,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1882,11 +1816,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1941,11 +1870,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2937,14 +2861,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h723vetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vetx-pinctrl.dtsi
@@ -172,18 +172,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -320,14 +308,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -636,13 +616,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -652,13 +625,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -791,18 +757,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1590,26 +1544,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1882,11 +1816,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1941,11 +1870,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2937,14 +2861,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h723vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vghx-pinctrl.dtsi
@@ -172,18 +172,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -320,14 +308,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -636,13 +616,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -652,13 +625,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -791,18 +757,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1590,26 +1544,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1882,11 +1816,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1941,11 +1870,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2937,14 +2861,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h723vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vgtx-pinctrl.dtsi
@@ -172,18 +172,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -320,14 +308,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -636,13 +616,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -652,13 +625,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -791,18 +757,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1590,26 +1544,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1882,11 +1816,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1941,11 +1870,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2937,14 +2861,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h723zetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zetx-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -392,14 +380,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -856,13 +836,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -872,13 +845,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1032,18 +998,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2091,26 +2045,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2539,11 +2473,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2608,11 +2537,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3840,14 +3764,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h723zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zgtx-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -392,14 +380,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -856,13 +836,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -872,13 +845,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1032,18 +998,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2091,26 +2045,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2539,11 +2473,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2608,11 +2537,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3840,14 +3764,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h725aeix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725aeix-pinctrl.dtsi
@@ -16,23 +16,11 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc1_inn1_pa0: adc1_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp0_pa0: adc1_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -130,18 +118,6 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inn1_pa0: adc2_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pa0: adc2_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pa1: adc2_inp1_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -260,18 +236,6 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -336,14 +300,6 @@
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa0: analog_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa1: analog_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
@@ -480,14 +436,6 @@
 
 			/omit-if-no-ref/ analog_pc2: analog_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
@@ -863,11 +811,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_crs_pa0: eth_crs_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -913,11 +856,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_ref_clk_pa1: eth_ref_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -947,11 +885,6 @@
 			};
 
 			/* ETH_RX_CLK */
-
-			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
@@ -1008,11 +941,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1029,11 +957,6 @@
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1133,12 +1056,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ fmc_a19_pa0: fmc_a19_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ fmc_d8_pa4: fmc_d8_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF12)>;
 				bias-pull-up;
@@ -1211,20 +1128,8 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1953,10 +1858,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 			};
 
-			/omit-if-no-ref/ i2s6_ws_pa0: i2s6_ws_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF5)>;
-			};
-
 			/omit-if-no-ref/ i2s6_ws_pa4: i2s6_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF8)>;
 			};
@@ -1970,10 +1871,6 @@
 			};
 
 			/* LTDC */
-
-			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF14)>;
-			};
 
 			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
@@ -2287,16 +2184,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF12)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
 				slew-rate = "very-high-speed";
@@ -2382,16 +2269,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 				slew-rate = "very-high-speed";
@@ -2399,16 +2276,6 @@
 
 			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF4)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -2720,12 +2587,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF9)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2861,11 +2722,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2935,11 +2791,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3057,11 +2908,6 @@
 
 			/omit-if-no-ref/ spi5_nss_pf6: spi5_nss_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF5)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ spi6_nss_pa0: spi6_nss_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 				bias-pull-up;
 			};
 
@@ -3263,14 +3109,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pa0: tim2_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF1)>;
-			};
-
-			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-			};
-
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -3463,18 +3301,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF2)>;
-			};
-
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
@@ -3633,12 +3459,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3733,11 +3553,6 @@
 				drive-push-pull;
 			};
 
-			/omit-if-no-ref/ usart2_de_pa1: usart2_de_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				drive-push-pull;
-			};
-
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3814,12 +3629,6 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -3956,10 +3765,6 @@
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
-			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF8)>;
-			};
-
 			/omit-if-no-ref/ uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
@@ -4087,11 +3892,6 @@
 
 			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -4253,16 +4053,8 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h725agix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725agix-pinctrl.dtsi
@@ -16,23 +16,11 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc1_inn1_pa0: adc1_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp0_pa0: adc1_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -130,18 +118,6 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inn1_pa0: adc2_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pa0: adc2_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pa1: adc2_inp1_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -260,18 +236,6 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -336,14 +300,6 @@
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa0: analog_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa1: analog_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
@@ -480,14 +436,6 @@
 
 			/omit-if-no-ref/ analog_pc2: analog_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
@@ -863,11 +811,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_crs_pa0: eth_crs_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -913,11 +856,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_ref_clk_pa1: eth_ref_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -947,11 +885,6 @@
 			};
 
 			/* ETH_RX_CLK */
-
-			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
@@ -1008,11 +941,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1029,11 +957,6 @@
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1133,12 +1056,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ fmc_a19_pa0: fmc_a19_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ fmc_d8_pa4: fmc_d8_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF12)>;
 				bias-pull-up;
@@ -1211,20 +1128,8 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1953,10 +1858,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 			};
 
-			/omit-if-no-ref/ i2s6_ws_pa0: i2s6_ws_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF5)>;
-			};
-
 			/omit-if-no-ref/ i2s6_ws_pa4: i2s6_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF8)>;
 			};
@@ -1970,10 +1871,6 @@
 			};
 
 			/* LTDC */
-
-			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF14)>;
-			};
 
 			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
@@ -2287,16 +2184,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF12)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
 				slew-rate = "very-high-speed";
@@ -2382,16 +2269,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 				slew-rate = "very-high-speed";
@@ -2399,16 +2276,6 @@
 
 			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF4)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -2720,12 +2587,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF9)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2861,11 +2722,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2935,11 +2791,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3057,11 +2908,6 @@
 
 			/omit-if-no-ref/ spi5_nss_pf6: spi5_nss_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF5)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ spi6_nss_pa0: spi6_nss_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 				bias-pull-up;
 			};
 
@@ -3263,14 +3109,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pa0: tim2_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF1)>;
-			};
-
-			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-			};
-
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -3463,18 +3301,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF2)>;
-			};
-
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
@@ -3633,12 +3459,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3733,11 +3553,6 @@
 				drive-push-pull;
 			};
 
-			/omit-if-no-ref/ usart2_de_pa1: usart2_de_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				drive-push-pull;
-			};
-
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3814,12 +3629,6 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -3956,10 +3765,6 @@
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
-			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF8)>;
-			};
-
 			/omit-if-no-ref/ uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
@@ -4087,11 +3892,6 @@
 
 			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -4253,16 +4053,8 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h725iekx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725iekx-pinctrl.dtsi
@@ -16,23 +16,11 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc1_inn1_pa0: adc1_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp0_pa0: adc1_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -130,18 +118,6 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inn1_pa0: adc2_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pa0: adc2_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pa1: adc2_inp1_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -260,18 +236,6 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -352,14 +316,6 @@
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa0: analog_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa1: analog_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
@@ -496,14 +452,6 @@
 
 			/omit-if-no-ref/ analog_pc2: analog_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
@@ -907,11 +855,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_crs_pa0: eth_crs_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -957,11 +900,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_ref_clk_pa1: eth_ref_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -1001,11 +939,6 @@
 			};
 
 			/* ETH_RX_CLK */
-
-			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
@@ -1062,11 +995,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1083,11 +1011,6 @@
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1187,12 +1110,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ fmc_a19_pa0: fmc_a19_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ fmc_d8_pa4: fmc_d8_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF12)>;
 				bias-pull-up;
@@ -1265,20 +1182,8 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2067,10 +1972,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 			};
 
-			/omit-if-no-ref/ i2s6_ws_pa0: i2s6_ws_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF5)>;
-			};
-
 			/omit-if-no-ref/ i2s6_ws_pa4: i2s6_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF8)>;
 			};
@@ -2084,10 +1985,6 @@
 			};
 
 			/* LTDC */
-
-			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF14)>;
-			};
 
 			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
@@ -2421,16 +2318,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF12)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
 				slew-rate = "very-high-speed";
@@ -2516,16 +2403,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 				slew-rate = "very-high-speed";
@@ -2533,16 +2410,6 @@
 
 			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF4)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -2854,12 +2721,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF9)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2995,11 +2856,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -3074,11 +2930,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3201,11 +3052,6 @@
 
 			/omit-if-no-ref/ spi5_nss_ph5: spi5_nss_ph5 {
 				pinmux = <STM32_PINMUX('H', 5, AF5)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ spi6_nss_pa0: spi6_nss_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 				bias-pull-up;
 			};
 
@@ -3413,14 +3259,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pa0: tim2_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF1)>;
-			};
-
-			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-			};
-
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -3621,18 +3459,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF2)>;
-			};
-
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
@@ -3795,12 +3621,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3895,11 +3715,6 @@
 				drive-push-pull;
 			};
 
-			/omit-if-no-ref/ usart2_de_pa1: usart2_de_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				drive-push-pull;
-			};
-
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3976,12 +3791,6 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -4118,10 +3927,6 @@
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
-			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF8)>;
-			};
-
 			/omit-if-no-ref/ uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
@@ -4249,11 +4054,6 @@
 
 			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -4415,16 +4215,8 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h725ietx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725ietx-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -392,14 +380,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -884,13 +864,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -900,13 +873,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1060,18 +1026,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2147,26 +2101,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2595,11 +2529,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2669,11 +2598,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3974,14 +3898,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h725igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725igkx-pinctrl.dtsi
@@ -16,23 +16,11 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc1_inn1_pa0: adc1_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp0_pa0: adc1_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -130,18 +118,6 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inn1_pa0: adc2_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pa0: adc2_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pa1: adc2_inp1_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -260,18 +236,6 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -352,14 +316,6 @@
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa0: analog_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa1: analog_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
@@ -496,14 +452,6 @@
 
 			/omit-if-no-ref/ analog_pc2: analog_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
@@ -907,11 +855,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_crs_pa0: eth_crs_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -957,11 +900,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_ref_clk_pa1: eth_ref_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -1001,11 +939,6 @@
 			};
 
 			/* ETH_RX_CLK */
-
-			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
@@ -1062,11 +995,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1083,11 +1011,6 @@
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1187,12 +1110,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ fmc_a19_pa0: fmc_a19_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ fmc_d8_pa4: fmc_d8_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF12)>;
 				bias-pull-up;
@@ -1265,20 +1182,8 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2067,10 +1972,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 			};
 
-			/omit-if-no-ref/ i2s6_ws_pa0: i2s6_ws_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF5)>;
-			};
-
 			/omit-if-no-ref/ i2s6_ws_pa4: i2s6_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF8)>;
 			};
@@ -2084,10 +1985,6 @@
 			};
 
 			/* LTDC */
-
-			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF14)>;
-			};
 
 			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
@@ -2421,16 +2318,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF12)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
 				slew-rate = "very-high-speed";
@@ -2516,16 +2403,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 				slew-rate = "very-high-speed";
@@ -2533,16 +2410,6 @@
 
 			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF4)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -2854,12 +2721,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF9)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2995,11 +2856,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -3074,11 +2930,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3201,11 +3052,6 @@
 
 			/omit-if-no-ref/ spi5_nss_ph5: spi5_nss_ph5 {
 				pinmux = <STM32_PINMUX('H', 5, AF5)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ spi6_nss_pa0: spi6_nss_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 				bias-pull-up;
 			};
 
@@ -3413,14 +3259,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pa0: tim2_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF1)>;
-			};
-
-			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-			};
-
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -3621,18 +3459,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF2)>;
-			};
-
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
@@ -3795,12 +3621,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3895,11 +3715,6 @@
 				drive-push-pull;
 			};
 
-			/omit-if-no-ref/ usart2_de_pa1: usart2_de_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				drive-push-pull;
-			};
-
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3976,12 +3791,6 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -4118,10 +3927,6 @@
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
-			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF8)>;
-			};
-
 			/omit-if-no-ref/ uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
@@ -4249,11 +4054,6 @@
 
 			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -4415,16 +4215,8 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h725igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725igtx-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -392,14 +380,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -884,13 +864,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -900,13 +873,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1060,18 +1026,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2147,26 +2101,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2595,11 +2529,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2669,11 +2598,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3974,14 +3898,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h725vehx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vehx-pinctrl.dtsi
@@ -172,18 +172,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -320,14 +308,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -616,13 +596,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -632,13 +605,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -771,18 +737,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1520,26 +1474,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1807,11 +1741,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1861,11 +1790,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2825,14 +2749,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h725vetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vetx-pinctrl.dtsi
@@ -172,18 +172,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -320,14 +308,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -584,13 +564,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -600,13 +573,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -739,18 +705,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1424,26 +1378,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1679,11 +1613,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1728,11 +1657,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2614,14 +2538,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h725vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vghx-pinctrl.dtsi
@@ -172,18 +172,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -320,14 +308,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -616,13 +596,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -632,13 +605,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -771,18 +737,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1520,26 +1474,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1807,11 +1741,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1861,11 +1790,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2825,14 +2749,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h725vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vgtx-pinctrl.dtsi
@@ -172,18 +172,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -320,14 +308,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -584,13 +564,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -600,13 +573,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -739,18 +705,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1424,26 +1378,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1679,11 +1613,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1728,11 +1657,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2614,14 +2538,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h725zetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725zetx-pinctrl.dtsi
@@ -184,18 +184,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inn4_pf6: adc3_inn4_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
 			};
@@ -364,14 +352,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -768,13 +748,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -784,13 +757,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -944,18 +910,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1889,26 +1843,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2287,11 +2221,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2356,11 +2285,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3549,14 +3473,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h725zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725zgtx-pinctrl.dtsi
@@ -184,18 +184,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inn4_pf6: adc3_inn4_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
 			};
@@ -364,14 +352,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -768,13 +748,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -784,13 +757,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -944,18 +910,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1889,26 +1843,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2287,11 +2221,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2356,11 +2285,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3549,14 +3473,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h730abixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730abixq-pinctrl.dtsi
@@ -16,23 +16,11 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc1_inn1_pa0: adc1_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp0_pa0: adc1_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -130,18 +118,6 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inn1_pa0: adc2_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pa0: adc2_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pa1: adc2_inp1_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -260,18 +236,6 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -336,14 +300,6 @@
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa0: analog_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa1: analog_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
@@ -480,14 +436,6 @@
 
 			/omit-if-no-ref/ analog_pc2: analog_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
@@ -863,11 +811,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_crs_pa0: eth_crs_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -913,11 +856,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_ref_clk_pa1: eth_ref_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -947,11 +885,6 @@
 			};
 
 			/* ETH_RX_CLK */
-
-			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
@@ -1008,11 +941,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1029,11 +957,6 @@
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1133,12 +1056,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ fmc_a19_pa0: fmc_a19_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ fmc_d8_pa4: fmc_d8_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF12)>;
 				bias-pull-up;
@@ -1211,20 +1128,8 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1953,10 +1858,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 			};
 
-			/omit-if-no-ref/ i2s6_ws_pa0: i2s6_ws_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF5)>;
-			};
-
 			/omit-if-no-ref/ i2s6_ws_pa4: i2s6_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF8)>;
 			};
@@ -1970,10 +1871,6 @@
 			};
 
 			/* LTDC */
-
-			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF14)>;
-			};
 
 			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
@@ -2287,16 +2184,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF12)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
 				slew-rate = "very-high-speed";
@@ -2382,16 +2269,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 				slew-rate = "very-high-speed";
@@ -2399,16 +2276,6 @@
 
 			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF4)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -2720,12 +2587,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF9)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2861,11 +2722,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2935,11 +2791,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3057,11 +2908,6 @@
 
 			/omit-if-no-ref/ spi5_nss_pf6: spi5_nss_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF5)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ spi6_nss_pa0: spi6_nss_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 				bias-pull-up;
 			};
 
@@ -3263,14 +3109,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pa0: tim2_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF1)>;
-			};
-
-			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-			};
-
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -3463,18 +3301,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF2)>;
-			};
-
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
@@ -3633,12 +3459,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3733,11 +3553,6 @@
 				drive-push-pull;
 			};
 
-			/omit-if-no-ref/ usart2_de_pa1: usart2_de_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				drive-push-pull;
-			};
-
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3814,12 +3629,6 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -3956,10 +3765,6 @@
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
-			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF8)>;
-			};
-
 			/omit-if-no-ref/ uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
@@ -4087,11 +3892,6 @@
 
 			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -4253,16 +4053,8 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h730ibkxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730ibkxq-pinctrl.dtsi
@@ -16,23 +16,11 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc1_inn1_pa0: adc1_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp0_pa0: adc1_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -130,18 +118,6 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inn1_pa0: adc2_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pa0: adc2_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pa1: adc2_inp1_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -260,18 +236,6 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -352,14 +316,6 @@
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa0: analog_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa1: analog_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
@@ -496,14 +452,6 @@
 
 			/omit-if-no-ref/ analog_pc2: analog_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
@@ -907,11 +855,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_crs_pa0: eth_crs_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -957,11 +900,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_ref_clk_pa1: eth_ref_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -1001,11 +939,6 @@
 			};
 
 			/* ETH_RX_CLK */
-
-			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
@@ -1062,11 +995,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1083,11 +1011,6 @@
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1187,12 +1110,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ fmc_a19_pa0: fmc_a19_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ fmc_d8_pa4: fmc_d8_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF12)>;
 				bias-pull-up;
@@ -1265,20 +1182,8 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2067,10 +1972,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 			};
 
-			/omit-if-no-ref/ i2s6_ws_pa0: i2s6_ws_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF5)>;
-			};
-
 			/omit-if-no-ref/ i2s6_ws_pa4: i2s6_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF8)>;
 			};
@@ -2084,10 +1985,6 @@
 			};
 
 			/* LTDC */
-
-			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF14)>;
-			};
 
 			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
@@ -2421,16 +2318,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF12)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
 				slew-rate = "very-high-speed";
@@ -2516,16 +2403,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 				slew-rate = "very-high-speed";
@@ -2533,16 +2410,6 @@
 
 			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF4)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -2854,12 +2721,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF9)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2995,11 +2856,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -3074,11 +2930,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3201,11 +3052,6 @@
 
 			/omit-if-no-ref/ spi5_nss_ph5: spi5_nss_ph5 {
 				pinmux = <STM32_PINMUX('H', 5, AF5)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ spi6_nss_pa0: spi6_nss_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 				bias-pull-up;
 			};
 
@@ -3413,14 +3259,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pa0: tim2_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF1)>;
-			};
-
-			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-			};
-
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -3621,18 +3459,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF2)>;
-			};
-
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
@@ -3795,12 +3621,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3895,11 +3715,6 @@
 				drive-push-pull;
 			};
 
-			/omit-if-no-ref/ usart2_de_pa1: usart2_de_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				drive-push-pull;
-			};
-
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3976,12 +3791,6 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -4118,10 +3927,6 @@
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
-			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF8)>;
-			};
-
 			/omit-if-no-ref/ uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
@@ -4249,11 +4054,6 @@
 
 			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -4415,16 +4215,8 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h730ibtxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730ibtxq-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -392,14 +380,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -884,13 +864,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -900,13 +873,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1060,18 +1026,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2147,26 +2101,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2595,11 +2529,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2669,11 +2598,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3974,14 +3898,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h730vbhx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730vbhx-pinctrl.dtsi
@@ -172,18 +172,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -320,14 +308,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -636,13 +616,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -652,13 +625,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -791,18 +757,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1590,26 +1544,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1882,11 +1816,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1941,11 +1870,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2937,14 +2861,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h730vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730vbtx-pinctrl.dtsi
@@ -172,18 +172,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -320,14 +308,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -636,13 +616,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -652,13 +625,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -791,18 +757,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1590,26 +1544,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1882,11 +1816,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1941,11 +1870,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2937,14 +2861,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h730zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730zbtx-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -392,14 +380,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -856,13 +836,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -872,13 +845,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1032,18 +998,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2091,26 +2045,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2539,11 +2473,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2608,11 +2537,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3840,14 +3764,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h733vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733vghx-pinctrl.dtsi
@@ -172,18 +172,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -320,14 +308,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -636,13 +616,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -652,13 +625,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -791,18 +757,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1590,26 +1544,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1882,11 +1816,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1941,11 +1870,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2937,14 +2861,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h733vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733vgtx-pinctrl.dtsi
@@ -172,18 +172,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -320,14 +308,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -636,13 +616,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -652,13 +625,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -791,18 +757,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1590,26 +1544,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1882,11 +1816,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1941,11 +1870,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2937,14 +2861,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h733zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733zgtx-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -392,14 +380,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -856,13 +836,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -872,13 +845,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1032,18 +998,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2091,26 +2045,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2539,11 +2473,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2608,11 +2537,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3840,14 +3764,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h735agix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735agix-pinctrl.dtsi
@@ -16,23 +16,11 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc1_inn1_pa0: adc1_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp0_pa0: adc1_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -130,18 +118,6 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inn1_pa0: adc2_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pa0: adc2_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pa1: adc2_inp1_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -260,18 +236,6 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -336,14 +300,6 @@
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa0: analog_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa1: analog_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
@@ -480,14 +436,6 @@
 
 			/omit-if-no-ref/ analog_pc2: analog_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
@@ -863,11 +811,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_crs_pa0: eth_crs_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -913,11 +856,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_ref_clk_pa1: eth_ref_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -947,11 +885,6 @@
 			};
 
 			/* ETH_RX_CLK */
-
-			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
@@ -1008,11 +941,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1029,11 +957,6 @@
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1133,12 +1056,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ fmc_a19_pa0: fmc_a19_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ fmc_d8_pa4: fmc_d8_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF12)>;
 				bias-pull-up;
@@ -1211,20 +1128,8 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1953,10 +1858,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 			};
 
-			/omit-if-no-ref/ i2s6_ws_pa0: i2s6_ws_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF5)>;
-			};
-
 			/omit-if-no-ref/ i2s6_ws_pa4: i2s6_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF8)>;
 			};
@@ -1970,10 +1871,6 @@
 			};
 
 			/* LTDC */
-
-			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF14)>;
-			};
 
 			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
@@ -2287,16 +2184,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF12)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
 				slew-rate = "very-high-speed";
@@ -2382,16 +2269,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 				slew-rate = "very-high-speed";
@@ -2399,16 +2276,6 @@
 
 			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF4)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -2720,12 +2587,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF9)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2861,11 +2722,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2935,11 +2791,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3057,11 +2908,6 @@
 
 			/omit-if-no-ref/ spi5_nss_pf6: spi5_nss_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF5)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ spi6_nss_pa0: spi6_nss_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 				bias-pull-up;
 			};
 
@@ -3263,14 +3109,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pa0: tim2_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF1)>;
-			};
-
-			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-			};
-
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -3463,18 +3301,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF2)>;
-			};
-
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
@@ -3633,12 +3459,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3733,11 +3553,6 @@
 				drive-push-pull;
 			};
 
-			/omit-if-no-ref/ usart2_de_pa1: usart2_de_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				drive-push-pull;
-			};
-
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3814,12 +3629,6 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -3956,10 +3765,6 @@
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
-			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF8)>;
-			};
-
 			/omit-if-no-ref/ uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
@@ -4087,11 +3892,6 @@
 
 			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -4253,16 +4053,8 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h735igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735igkx-pinctrl.dtsi
@@ -16,23 +16,11 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc1_inn1_pa0: adc1_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp0_pa0: adc1_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -130,18 +118,6 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inn1_pa0: adc2_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pa0: adc2_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pa1: adc2_inp1_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -260,18 +236,6 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -352,14 +316,6 @@
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa0: analog_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa1: analog_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
@@ -496,14 +452,6 @@
 
 			/omit-if-no-ref/ analog_pc2: analog_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
@@ -907,11 +855,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_crs_pa0: eth_crs_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -957,11 +900,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_ref_clk_pa1: eth_ref_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -1001,11 +939,6 @@
 			};
 
 			/* ETH_RX_CLK */
-
-			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
@@ -1062,11 +995,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1083,11 +1011,6 @@
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1187,12 +1110,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ fmc_a19_pa0: fmc_a19_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ fmc_d8_pa4: fmc_d8_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF12)>;
 				bias-pull-up;
@@ -1265,20 +1182,8 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2067,10 +1972,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 			};
 
-			/omit-if-no-ref/ i2s6_ws_pa0: i2s6_ws_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF5)>;
-			};
-
 			/omit-if-no-ref/ i2s6_ws_pa4: i2s6_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF8)>;
 			};
@@ -2084,10 +1985,6 @@
 			};
 
 			/* LTDC */
-
-			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF14)>;
-			};
 
 			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
@@ -2421,16 +2318,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF12)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
 				slew-rate = "very-high-speed";
@@ -2516,16 +2403,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 				slew-rate = "very-high-speed";
@@ -2533,16 +2410,6 @@
 
 			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF4)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -2854,12 +2721,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF9)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2995,11 +2856,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -3074,11 +2930,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3201,11 +3052,6 @@
 
 			/omit-if-no-ref/ spi5_nss_ph5: spi5_nss_ph5 {
 				pinmux = <STM32_PINMUX('H', 5, AF5)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ spi6_nss_pa0: spi6_nss_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 				bias-pull-up;
 			};
 
@@ -3413,14 +3259,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pa0: tim2_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF1)>;
-			};
-
-			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-			};
-
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -3621,18 +3459,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF2)>;
-			};
-
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
@@ -3795,12 +3621,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3895,11 +3715,6 @@
 				drive-push-pull;
 			};
 
-			/omit-if-no-ref/ usart2_de_pa1: usart2_de_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				drive-push-pull;
-			};
-
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3976,12 +3791,6 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -4118,10 +3927,6 @@
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
-			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF8)>;
-			};
-
 			/omit-if-no-ref/ uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
@@ -4249,11 +4054,6 @@
 
 			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -4415,16 +4215,8 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h735igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735igtx-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -392,14 +380,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -884,13 +864,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -900,13 +873,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1060,18 +1026,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2147,26 +2101,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2595,11 +2529,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2669,11 +2598,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3974,14 +3898,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h735vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vghx-pinctrl.dtsi
@@ -172,18 +172,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -320,14 +308,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -616,13 +596,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -632,13 +605,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -771,18 +737,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1520,26 +1474,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1807,11 +1741,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1861,11 +1790,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2825,14 +2749,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h735vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vgtx-pinctrl.dtsi
@@ -172,18 +172,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -320,14 +308,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -584,13 +564,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -600,13 +573,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -739,18 +705,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1424,26 +1378,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1679,11 +1613,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1728,11 +1657,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2614,14 +2538,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h735zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735zgtx-pinctrl.dtsi
@@ -184,18 +184,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inn4_pf6: adc3_inn4_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
 			};
@@ -364,14 +352,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -768,13 +748,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -784,13 +757,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -944,18 +910,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1889,26 +1843,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF4)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2287,11 +2221,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2356,11 +2285,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3549,14 +3473,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -420,14 +408,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -966,13 +946,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -982,13 +955,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1076,18 +1042,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2096,11 +2050,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2170,11 +2119,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3328,14 +3272,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -420,14 +408,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -1125,13 +1105,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1141,13 +1114,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1247,18 +1213,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2345,11 +2299,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2429,11 +2378,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3711,14 +3655,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -420,14 +408,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -1013,13 +993,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1029,13 +1002,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1135,18 +1101,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2233,11 +2187,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2312,11 +2261,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3513,14 +3457,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -420,14 +408,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -1013,13 +993,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1029,13 +1002,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1135,18 +1101,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2233,11 +2187,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2312,11 +2261,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3513,14 +3457,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
@@ -172,18 +172,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -320,14 +308,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -636,13 +616,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -652,13 +625,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -741,18 +707,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1400,11 +1354,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1459,11 +1408,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2427,14 +2371,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
@@ -172,18 +172,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -320,14 +308,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -636,13 +616,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -652,13 +625,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -741,18 +707,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1400,11 +1354,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1459,11 +1408,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2427,14 +2371,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
@@ -16,23 +16,11 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc1_inn1_pa0: adc1_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp0_pa0: adc1_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -130,18 +118,6 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inn1_pa0: adc2_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pa0: adc2_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pa1: adc2_inp1_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -260,18 +236,6 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -352,14 +316,6 @@
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa0: analog_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa1: analog_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
@@ -496,14 +452,6 @@
 
 			/omit-if-no-ref/ analog_pc2: analog_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
@@ -1067,11 +1015,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_crs_pa0: eth_crs_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -1117,11 +1060,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_ref_clk_pa1: eth_ref_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -1161,11 +1099,6 @@
 			};
 
 			/* ETH_RX_CLK */
-
-			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
@@ -1227,11 +1160,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1245,11 +1173,6 @@
 			};
 
 			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
@@ -1358,18 +1281,6 @@
 
 			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2149,18 +2060,7 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
-			/* LTDC */
-
-			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF14)>;
-			};
-
 			/* QUADSPI */
-
-			/omit-if-no-ref/ quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF9)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
@@ -2379,12 +2279,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF9)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2484,11 +2378,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2568,11 +2457,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2952,14 +2836,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pa0: tim2_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF1)>;
-			};
-
-			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-			};
-
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -3098,18 +2974,6 @@
 
 			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
@@ -3316,12 +3180,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3405,11 +3263,6 @@
 				drive-push-pull;
 			};
 
-			/omit-if-no-ref/ usart2_de_pa1: usart2_de_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				drive-push-pull;
-			};
-
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3475,12 +3328,6 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -3597,10 +3444,6 @@
 
 			/omit-if-no-ref/ usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
-			};
-
-			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
 			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
@@ -3724,11 +3567,6 @@
 
 			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -3905,14 +3743,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {

--- a/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -392,14 +380,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -856,13 +836,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -872,13 +845,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -966,18 +932,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1871,11 +1825,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1940,11 +1889,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3049,14 +2993,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -420,14 +408,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -966,13 +946,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -982,13 +955,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1076,18 +1042,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2370,11 +2324,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2444,11 +2393,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3602,14 +3546,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -420,14 +408,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -1125,13 +1105,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1141,13 +1114,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1247,18 +1213,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2763,11 +2717,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2847,11 +2796,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -4129,14 +4073,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h743bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bitx-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -420,14 +408,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -1125,13 +1105,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1141,13 +1114,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1247,18 +1213,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2763,11 +2717,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2847,11 +2796,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -4129,14 +4073,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h743igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igkx-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -420,14 +408,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -1013,13 +993,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1029,13 +1002,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1135,18 +1101,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2523,11 +2477,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2602,11 +2551,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3803,14 +3747,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h743igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igtx-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -420,14 +408,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -1013,13 +993,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1029,13 +1002,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1135,18 +1101,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2523,11 +2477,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2602,11 +2551,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3803,14 +3747,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h743iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iikx-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -420,14 +408,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -1013,13 +993,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1029,13 +1002,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1135,18 +1101,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2523,11 +2477,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2602,11 +2551,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3803,14 +3747,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h743iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iitx-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -420,14 +408,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -1013,13 +993,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1029,13 +1002,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1135,18 +1101,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2523,11 +2477,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2602,11 +2551,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3803,14 +3747,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
@@ -172,18 +172,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -320,14 +308,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -636,13 +616,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -652,13 +625,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -741,18 +707,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1558,11 +1512,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1617,11 +1566,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2585,14 +2529,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
@@ -172,18 +172,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -320,14 +308,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -636,13 +616,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -652,13 +625,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -741,18 +707,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1558,11 +1512,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1617,11 +1566,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2585,14 +2529,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h743vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vitx-pinctrl.dtsi
@@ -172,18 +172,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -320,14 +308,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -636,13 +616,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -652,13 +625,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -741,18 +707,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1558,11 +1512,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1617,11 +1566,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2585,14 +2529,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h743xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xghx-pinctrl.dtsi
@@ -16,23 +16,11 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc1_inn1_pa0: adc1_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp0_pa0: adc1_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -130,18 +118,6 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inn1_pa0: adc2_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pa0: adc2_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pa1: adc2_inp1_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -260,18 +236,6 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -352,14 +316,6 @@
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa0: analog_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa1: analog_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
@@ -496,14 +452,6 @@
 
 			/omit-if-no-ref/ analog_pc2: analog_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
@@ -1067,11 +1015,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_crs_pa0: eth_crs_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -1117,11 +1060,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_ref_clk_pa1: eth_ref_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -1161,11 +1099,6 @@
 			};
 
 			/* ETH_RX_CLK */
-
-			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
@@ -1227,11 +1160,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1245,11 +1173,6 @@
 			};
 
 			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
@@ -1358,18 +1281,6 @@
 
 			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2155,10 +2066,6 @@
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF14)>;
-			};
-
 			/omit-if-no-ref/ ltdc_r1_pa2: ltdc_r1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
@@ -2578,11 +2485,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -2795,12 +2697,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF9)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2900,11 +2796,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2984,11 +2875,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3368,14 +3254,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pa0: tim2_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF1)>;
-			};
-
-			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-			};
-
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -3514,18 +3392,6 @@
 
 			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
@@ -3732,12 +3598,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3821,11 +3681,6 @@
 				drive-push-pull;
 			};
 
-			/omit-if-no-ref/ usart2_de_pa1: usart2_de_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				drive-push-pull;
-			};
-
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3891,12 +3746,6 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -4013,10 +3862,6 @@
 
 			/omit-if-no-ref/ usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
-			};
-
-			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
 			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
@@ -4140,11 +3985,6 @@
 
 			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -4321,14 +4161,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {

--- a/dts/st/h7/stm32h743xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xihx-pinctrl.dtsi
@@ -16,23 +16,11 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc1_inn1_pa0: adc1_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp0_pa0: adc1_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -130,18 +118,6 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inn1_pa0: adc2_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pa0: adc2_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pa1: adc2_inp1_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -260,18 +236,6 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -352,14 +316,6 @@
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa0: analog_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa1: analog_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
@@ -496,14 +452,6 @@
 
 			/omit-if-no-ref/ analog_pc2: analog_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
@@ -1067,11 +1015,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_crs_pa0: eth_crs_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -1117,11 +1060,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_ref_clk_pa1: eth_ref_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -1161,11 +1099,6 @@
 			};
 
 			/* ETH_RX_CLK */
-
-			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
@@ -1227,11 +1160,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1245,11 +1173,6 @@
 			};
 
 			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
@@ -1358,18 +1281,6 @@
 
 			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2155,10 +2066,6 @@
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF14)>;
-			};
-
 			/omit-if-no-ref/ ltdc_r1_pa2: ltdc_r1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
@@ -2578,11 +2485,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -2795,12 +2697,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF9)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2900,11 +2796,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2984,11 +2875,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3368,14 +3254,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pa0: tim2_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF1)>;
-			};
-
-			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-			};
-
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -3514,18 +3392,6 @@
 
 			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
@@ -3732,12 +3598,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3821,11 +3681,6 @@
 				drive-push-pull;
 			};
 
-			/omit-if-no-ref/ usart2_de_pa1: usart2_de_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				drive-push-pull;
-			};
-
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3891,12 +3746,6 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -4013,10 +3862,6 @@
 
 			/omit-if-no-ref/ usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
-			};
-
-			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
 			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
@@ -4140,11 +3985,6 @@
 
 			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -4321,14 +4161,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {

--- a/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -392,14 +380,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -856,13 +836,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -872,13 +845,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -966,18 +932,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2073,11 +2027,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2142,11 +2091,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3251,14 +3195,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h743zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zitx-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -392,14 +380,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -856,13 +836,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -872,13 +845,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -966,18 +932,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2073,11 +2027,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2142,11 +2091,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3251,14 +3195,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -420,14 +408,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -1053,13 +1033,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1069,13 +1042,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1175,18 +1141,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2607,11 +2561,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2691,11 +2640,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3973,14 +3917,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h745bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bitx-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -420,14 +408,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -1053,13 +1033,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1069,13 +1042,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1175,18 +1141,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2607,11 +2561,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2691,11 +2640,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3973,14 +3917,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h745igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igkx-pinctrl.dtsi
@@ -16,23 +16,11 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc1_inn1_pa0: adc1_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp0_pa0: adc1_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -130,18 +118,6 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inn1_pa0: adc2_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pa0: adc2_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pa1: adc2_inp1_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -260,18 +236,6 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -352,14 +316,6 @@
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa0: analog_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa1: analog_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
@@ -496,14 +452,6 @@
 
 			/omit-if-no-ref/ analog_pc2: analog_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
@@ -907,11 +855,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_crs_pa0: eth_crs_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -957,11 +900,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_ref_clk_pa1: eth_ref_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -1001,11 +939,6 @@
 			};
 
 			/* ETH_RX_CLK */
-
-			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
@@ -1062,11 +995,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1080,11 +1008,6 @@
 			};
 
 			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
@@ -1189,18 +1112,6 @@
 
 			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1917,10 +1828,6 @@
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF14)>;
-			};
-
 			/omit-if-no-ref/ ltdc_r1_pa2: ltdc_r1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
@@ -2172,11 +2079,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -2389,12 +2291,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF9)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2494,11 +2390,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2568,11 +2459,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2896,14 +2782,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pa0: tim2_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF1)>;
-			};
-
-			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-			};
-
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -3042,18 +2920,6 @@
 
 			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
@@ -3208,12 +3074,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3297,11 +3157,6 @@
 				drive-push-pull;
 			};
 
-			/omit-if-no-ref/ usart2_de_pa1: usart2_de_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				drive-push-pull;
-			};
-
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3367,12 +3222,6 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -3495,10 +3344,6 @@
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
-			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF8)>;
-			};
-
 			/omit-if-no-ref/ uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
@@ -3608,11 +3453,6 @@
 
 			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -3784,14 +3624,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {

--- a/dts/st/h7/stm32h745igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igtx-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -392,14 +380,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -884,13 +864,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -900,13 +873,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -994,18 +960,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2129,11 +2083,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2203,11 +2152,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3385,14 +3329,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h745iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iikx-pinctrl.dtsi
@@ -16,23 +16,11 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc1_inn1_pa0: adc1_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp0_pa0: adc1_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -130,18 +118,6 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inn1_pa0: adc2_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pa0: adc2_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pa1: adc2_inp1_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -260,18 +236,6 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -352,14 +316,6 @@
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa0: analog_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa1: analog_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
@@ -496,14 +452,6 @@
 
 			/omit-if-no-ref/ analog_pc2: analog_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
@@ -907,11 +855,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_crs_pa0: eth_crs_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -957,11 +900,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_ref_clk_pa1: eth_ref_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -1001,11 +939,6 @@
 			};
 
 			/* ETH_RX_CLK */
-
-			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
@@ -1062,11 +995,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1080,11 +1008,6 @@
 			};
 
 			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
@@ -1189,18 +1112,6 @@
 
 			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1917,10 +1828,6 @@
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF14)>;
-			};
-
 			/omit-if-no-ref/ ltdc_r1_pa2: ltdc_r1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
@@ -2172,11 +2079,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -2389,12 +2291,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF9)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2494,11 +2390,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2568,11 +2459,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2896,14 +2782,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pa0: tim2_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF1)>;
-			};
-
-			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-			};
-
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -3042,18 +2920,6 @@
 
 			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
@@ -3208,12 +3074,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3297,11 +3157,6 @@
 				drive-push-pull;
 			};
 
-			/omit-if-no-ref/ usart2_de_pa1: usart2_de_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				drive-push-pull;
-			};
-
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3367,12 +3222,6 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -3495,10 +3344,6 @@
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
-			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF8)>;
-			};
-
 			/omit-if-no-ref/ uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
@@ -3608,11 +3453,6 @@
 
 			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -3784,14 +3624,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {

--- a/dts/st/h7/stm32h745iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iitx-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -392,14 +380,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -884,13 +864,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -900,13 +873,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -994,18 +960,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2129,11 +2083,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2203,11 +2152,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3385,14 +3329,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h745xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xghx-pinctrl.dtsi
@@ -16,23 +16,11 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc1_inn1_pa0: adc1_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp0_pa0: adc1_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -130,18 +118,6 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inn1_pa0: adc2_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pa0: adc2_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pa1: adc2_inp1_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -260,18 +236,6 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -352,14 +316,6 @@
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa0: analog_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa1: analog_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
@@ -496,14 +452,6 @@
 
 			/omit-if-no-ref/ analog_pc2: analog_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
@@ -1067,11 +1015,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_crs_pa0: eth_crs_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -1117,11 +1060,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_ref_clk_pa1: eth_ref_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -1161,11 +1099,6 @@
 			};
 
 			/* ETH_RX_CLK */
-
-			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
@@ -1227,11 +1160,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1245,11 +1173,6 @@
 			};
 
 			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
@@ -1358,18 +1281,6 @@
 
 			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2155,10 +2066,6 @@
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF14)>;
-			};
-
 			/omit-if-no-ref/ ltdc_r1_pa2: ltdc_r1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
@@ -2578,11 +2485,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -2795,12 +2697,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF9)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2900,11 +2796,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2984,11 +2875,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3368,14 +3254,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pa0: tim2_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF1)>;
-			};
-
-			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-			};
-
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -3514,18 +3392,6 @@
 
 			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
@@ -3732,12 +3598,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3821,11 +3681,6 @@
 				drive-push-pull;
 			};
 
-			/omit-if-no-ref/ usart2_de_pa1: usart2_de_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				drive-push-pull;
-			};
-
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3891,12 +3746,6 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -4013,10 +3862,6 @@
 
 			/omit-if-no-ref/ usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
-			};
-
-			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
 			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
@@ -4140,11 +3985,6 @@
 
 			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -4321,14 +4161,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {

--- a/dts/st/h7/stm32h745xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xihx-pinctrl.dtsi
@@ -16,23 +16,11 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc1_inn1_pa0: adc1_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp0_pa0: adc1_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -130,18 +118,6 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inn1_pa0: adc2_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pa0: adc2_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pa1: adc2_inp1_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -260,18 +236,6 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -352,14 +316,6 @@
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa0: analog_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa1: analog_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
@@ -496,14 +452,6 @@
 
 			/omit-if-no-ref/ analog_pc2: analog_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
@@ -1067,11 +1015,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_crs_pa0: eth_crs_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -1117,11 +1060,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_ref_clk_pa1: eth_ref_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -1161,11 +1099,6 @@
 			};
 
 			/* ETH_RX_CLK */
-
-			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
@@ -1227,11 +1160,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1245,11 +1173,6 @@
 			};
 
 			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
@@ -1358,18 +1281,6 @@
 
 			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2155,10 +2066,6 @@
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF14)>;
-			};
-
 			/omit-if-no-ref/ ltdc_r1_pa2: ltdc_r1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
@@ -2578,11 +2485,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -2795,12 +2697,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF9)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2900,11 +2796,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2984,11 +2875,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3368,14 +3254,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pa0: tim2_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF1)>;
-			};
-
-			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-			};
-
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -3514,18 +3392,6 @@
 
 			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
@@ -3732,12 +3598,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3821,11 +3681,6 @@
 				drive-push-pull;
 			};
 
-			/omit-if-no-ref/ usart2_de_pa1: usart2_de_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				drive-push-pull;
-			};
-
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3891,12 +3746,6 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -4013,10 +3862,6 @@
 
 			/omit-if-no-ref/ usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
-			};
-
-			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
 			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
@@ -4140,11 +3985,6 @@
 
 			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -4321,14 +4161,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {

--- a/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
@@ -184,18 +184,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp8_pf6: adc3_inp8_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
 			};
@@ -360,14 +348,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -764,13 +744,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -780,13 +753,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -874,18 +840,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1879,11 +1833,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1948,11 +1897,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3051,14 +2995,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h745zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zitx-pinctrl.dtsi
@@ -184,18 +184,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp8_pf6: adc3_inp8_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
 			};
@@ -360,14 +348,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -764,13 +744,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -780,13 +753,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -874,18 +840,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1879,11 +1833,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1948,11 +1897,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3051,14 +2995,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -392,14 +380,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -856,13 +836,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -872,13 +845,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -966,18 +932,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2073,11 +2027,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2142,11 +2091,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3251,14 +3195,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -420,14 +408,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -1017,13 +997,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1033,13 +1006,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1139,18 +1105,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2535,11 +2489,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2614,11 +2563,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3815,14 +3759,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h747bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bitx-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -420,14 +408,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -1017,13 +997,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1033,13 +1006,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1139,18 +1105,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2535,11 +2489,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2614,11 +2563,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3815,14 +3759,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h747igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747igtx-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -392,14 +380,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -856,13 +836,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -872,13 +845,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -966,18 +932,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2073,11 +2027,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2142,11 +2091,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3251,14 +3195,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h747iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747iitx-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -392,14 +380,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -856,13 +836,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -872,13 +845,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -966,18 +932,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2073,11 +2027,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2142,11 +2091,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3251,14 +3195,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h747xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xghx-pinctrl.dtsi
@@ -16,23 +16,11 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc1_inn1_pa0: adc1_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp0_pa0: adc1_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -130,18 +118,6 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inn1_pa0: adc2_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pa0: adc2_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pa1: adc2_inp1_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -260,18 +236,6 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -352,14 +316,6 @@
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa0: analog_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa1: analog_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
@@ -496,14 +452,6 @@
 
 			/omit-if-no-ref/ analog_pc2: analog_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
@@ -1067,11 +1015,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_crs_pa0: eth_crs_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -1117,11 +1060,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_ref_clk_pa1: eth_ref_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -1161,11 +1099,6 @@
 			};
 
 			/* ETH_RX_CLK */
-
-			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
@@ -1227,11 +1160,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1245,11 +1173,6 @@
 			};
 
 			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
@@ -1358,18 +1281,6 @@
 
 			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2155,10 +2066,6 @@
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF14)>;
-			};
-
 			/omit-if-no-ref/ ltdc_r1_pa2: ltdc_r1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
@@ -2578,11 +2485,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -2795,12 +2697,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF9)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2900,11 +2796,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2984,11 +2875,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3368,14 +3254,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pa0: tim2_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF1)>;
-			};
-
-			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-			};
-
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -3514,18 +3392,6 @@
 
 			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
@@ -3732,12 +3598,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3821,11 +3681,6 @@
 				drive-push-pull;
 			};
 
-			/omit-if-no-ref/ usart2_de_pa1: usart2_de_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				drive-push-pull;
-			};
-
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3891,12 +3746,6 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -4013,10 +3862,6 @@
 
 			/omit-if-no-ref/ usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
-			};
-
-			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
 			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
@@ -4140,11 +3985,6 @@
 
 			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -4321,14 +4161,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {

--- a/dts/st/h7/stm32h747xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xihx-pinctrl.dtsi
@@ -16,23 +16,11 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc1_inn1_pa0: adc1_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp0_pa0: adc1_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -130,18 +118,6 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inn1_pa0: adc2_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pa0: adc2_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pa1: adc2_inp1_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -260,18 +236,6 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -352,14 +316,6 @@
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa0: analog_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa1: analog_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
@@ -496,14 +452,6 @@
 
 			/omit-if-no-ref/ analog_pc2: analog_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
@@ -1067,11 +1015,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_crs_pa0: eth_crs_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -1117,11 +1060,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_ref_clk_pa1: eth_ref_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -1161,11 +1099,6 @@
 			};
 
 			/* ETH_RX_CLK */
-
-			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
@@ -1227,11 +1160,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1245,11 +1173,6 @@
 			};
 
 			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
@@ -1358,18 +1281,6 @@
 
 			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2155,10 +2066,6 @@
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF14)>;
-			};
-
 			/omit-if-no-ref/ ltdc_r1_pa2: ltdc_r1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
@@ -2578,11 +2485,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -2795,12 +2697,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF9)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2900,11 +2796,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2984,11 +2875,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3368,14 +3254,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pa0: tim2_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF1)>;
-			};
-
-			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-			};
-
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -3514,18 +3392,6 @@
 
 			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
@@ -3732,12 +3598,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3821,11 +3681,6 @@
 				drive-push-pull;
 			};
 
-			/omit-if-no-ref/ usart2_de_pa1: usart2_de_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				drive-push-pull;
-			};
-
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3891,12 +3746,6 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -4013,10 +3862,6 @@
 
 			/omit-if-no-ref/ usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
-			};
-
-			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
 			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
@@ -4140,11 +3985,6 @@
 
 			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -4321,14 +4161,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {

--- a/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -360,14 +348,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -757,13 +737,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -773,13 +746,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -862,18 +828,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1821,11 +1775,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1880,11 +1829,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2870,14 +2814,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -420,14 +408,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -1013,13 +993,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1029,13 +1002,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1135,18 +1101,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2523,11 +2477,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2602,11 +2551,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3803,14 +3747,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -420,14 +408,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -1013,13 +993,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1029,13 +1002,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1135,18 +1101,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2523,11 +2477,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2602,11 +2551,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3803,14 +3747,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
@@ -172,18 +172,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -320,14 +308,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -636,13 +616,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -652,13 +625,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -741,18 +707,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1558,11 +1512,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1617,11 +1566,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2585,14 +2529,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
@@ -16,23 +16,11 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc1_inn1_pa0: adc1_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp0_pa0: adc1_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -130,18 +118,6 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inn1_pa0: adc2_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pa0: adc2_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pa1: adc2_inp1_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -260,18 +236,6 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -352,14 +316,6 @@
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa0: analog_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa1: analog_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
@@ -496,14 +452,6 @@
 
 			/omit-if-no-ref/ analog_pc2: analog_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
@@ -1067,11 +1015,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_crs_pa0: eth_crs_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -1117,11 +1060,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_ref_clk_pa1: eth_ref_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -1161,11 +1099,6 @@
 			};
 
 			/* ETH_RX_CLK */
-
-			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
@@ -1227,11 +1160,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1245,11 +1173,6 @@
 			};
 
 			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
@@ -1358,18 +1281,6 @@
 
 			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2155,10 +2066,6 @@
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF14)>;
-			};
-
 			/omit-if-no-ref/ ltdc_r1_pa2: ltdc_r1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
@@ -2578,11 +2485,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -2795,12 +2697,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF9)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2900,11 +2796,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2984,11 +2875,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3368,14 +3254,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pa0: tim2_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF1)>;
-			};
-
-			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-			};
-
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -3514,18 +3392,6 @@
 
 			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
@@ -3732,12 +3598,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3821,11 +3681,6 @@
 				drive-push-pull;
 			};
 
-			/omit-if-no-ref/ usart2_de_pa1: usart2_de_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				drive-push-pull;
-			};
-
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3891,12 +3746,6 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -4013,10 +3862,6 @@
 
 			/omit-if-no-ref/ usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
-			};
-
-			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
 			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
@@ -4140,11 +3985,6 @@
 
 			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -4321,14 +4161,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {

--- a/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -392,14 +380,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -856,13 +836,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -872,13 +845,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -966,18 +932,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2073,11 +2027,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2142,11 +2091,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3251,14 +3195,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h753aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753aiix-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -420,14 +408,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -966,13 +946,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -982,13 +955,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1076,18 +1042,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2370,11 +2324,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2444,11 +2393,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3602,14 +3546,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h753bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753bitx-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -420,14 +408,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -1125,13 +1105,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1141,13 +1114,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1247,18 +1213,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2763,11 +2717,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2847,11 +2796,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -4129,14 +4073,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h753iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iikx-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -420,14 +408,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -1013,13 +993,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1029,13 +1002,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1135,18 +1101,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2523,11 +2477,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2602,11 +2551,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3803,14 +3747,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h753iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iitx-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -420,14 +408,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -1013,13 +993,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1029,13 +1002,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1135,18 +1101,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2523,11 +2477,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2602,11 +2551,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3803,14 +3747,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h753vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vihx-pinctrl.dtsi
@@ -172,18 +172,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -320,14 +308,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -636,13 +616,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -652,13 +625,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -741,18 +707,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1558,11 +1512,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1617,11 +1566,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2585,14 +2529,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h753vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vitx-pinctrl.dtsi
@@ -172,18 +172,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -320,14 +308,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -636,13 +616,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -652,13 +625,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -741,18 +707,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1558,11 +1512,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1617,11 +1566,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2585,14 +2529,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h753xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753xihx-pinctrl.dtsi
@@ -16,23 +16,11 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc1_inn1_pa0: adc1_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp0_pa0: adc1_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -130,18 +118,6 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inn1_pa0: adc2_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pa0: adc2_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pa1: adc2_inp1_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -260,18 +236,6 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -352,14 +316,6 @@
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa0: analog_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa1: analog_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
@@ -496,14 +452,6 @@
 
 			/omit-if-no-ref/ analog_pc2: analog_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
@@ -1067,11 +1015,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_crs_pa0: eth_crs_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -1117,11 +1060,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_ref_clk_pa1: eth_ref_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -1161,11 +1099,6 @@
 			};
 
 			/* ETH_RX_CLK */
-
-			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
@@ -1227,11 +1160,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1245,11 +1173,6 @@
 			};
 
 			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
@@ -1358,18 +1281,6 @@
 
 			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2155,10 +2066,6 @@
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF14)>;
-			};
-
 			/omit-if-no-ref/ ltdc_r1_pa2: ltdc_r1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
@@ -2578,11 +2485,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -2795,12 +2697,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF9)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2900,11 +2796,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2984,11 +2875,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3368,14 +3254,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pa0: tim2_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF1)>;
-			};
-
-			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-			};
-
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -3514,18 +3392,6 @@
 
 			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
@@ -3732,12 +3598,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3821,11 +3681,6 @@
 				drive-push-pull;
 			};
 
-			/omit-if-no-ref/ usart2_de_pa1: usart2_de_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				drive-push-pull;
-			};
-
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3891,12 +3746,6 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -4013,10 +3862,6 @@
 
 			/omit-if-no-ref/ usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
-			};
-
-			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
 			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
@@ -4140,11 +3985,6 @@
 
 			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -4321,14 +4161,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {

--- a/dts/st/h7/stm32h753zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753zitx-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -392,14 +380,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -856,13 +836,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -872,13 +845,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -966,18 +932,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2073,11 +2027,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2142,11 +2091,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3251,14 +3195,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h755bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755bitx-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -420,14 +408,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -1053,13 +1033,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1069,13 +1042,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1175,18 +1141,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2607,11 +2561,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2691,11 +2640,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3973,14 +3917,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h755iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iikx-pinctrl.dtsi
@@ -16,23 +16,11 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc1_inn1_pa0: adc1_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp0_pa0: adc1_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -130,18 +118,6 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inn1_pa0: adc2_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pa0: adc2_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pa1: adc2_inp1_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -260,18 +236,6 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -352,14 +316,6 @@
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa0: analog_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa1: analog_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
@@ -496,14 +452,6 @@
 
 			/omit-if-no-ref/ analog_pc2: analog_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
@@ -907,11 +855,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_crs_pa0: eth_crs_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -957,11 +900,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_ref_clk_pa1: eth_ref_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -1001,11 +939,6 @@
 			};
 
 			/* ETH_RX_CLK */
-
-			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
@@ -1062,11 +995,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1080,11 +1008,6 @@
 			};
 
 			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
@@ -1189,18 +1112,6 @@
 
 			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1917,10 +1828,6 @@
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF14)>;
-			};
-
 			/omit-if-no-ref/ ltdc_r1_pa2: ltdc_r1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
@@ -2172,11 +2079,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -2389,12 +2291,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF9)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2494,11 +2390,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2568,11 +2459,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2896,14 +2782,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pa0: tim2_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF1)>;
-			};
-
-			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-			};
-
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -3042,18 +2920,6 @@
 
 			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
@@ -3208,12 +3074,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3297,11 +3157,6 @@
 				drive-push-pull;
 			};
 
-			/omit-if-no-ref/ usart2_de_pa1: usart2_de_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				drive-push-pull;
-			};
-
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3367,12 +3222,6 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -3495,10 +3344,6 @@
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
-			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF8)>;
-			};
-
 			/omit-if-no-ref/ uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
@@ -3608,11 +3453,6 @@
 
 			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -3784,14 +3624,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {

--- a/dts/st/h7/stm32h755iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iitx-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -392,14 +380,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -884,13 +864,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -900,13 +873,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -994,18 +960,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2129,11 +2083,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2203,11 +2152,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3385,14 +3329,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h755xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755xihx-pinctrl.dtsi
@@ -16,23 +16,11 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc1_inn1_pa0: adc1_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp0_pa0: adc1_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -130,18 +118,6 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inn1_pa0: adc2_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pa0: adc2_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pa1: adc2_inp1_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -260,18 +236,6 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -352,14 +316,6 @@
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa0: analog_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa1: analog_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
@@ -496,14 +452,6 @@
 
 			/omit-if-no-ref/ analog_pc2: analog_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
@@ -1067,11 +1015,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_crs_pa0: eth_crs_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -1117,11 +1060,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_ref_clk_pa1: eth_ref_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -1161,11 +1099,6 @@
 			};
 
 			/* ETH_RX_CLK */
-
-			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
@@ -1227,11 +1160,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1245,11 +1173,6 @@
 			};
 
 			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
@@ -1358,18 +1281,6 @@
 
 			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2155,10 +2066,6 @@
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF14)>;
-			};
-
 			/omit-if-no-ref/ ltdc_r1_pa2: ltdc_r1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
@@ -2578,11 +2485,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -2795,12 +2697,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF9)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2900,11 +2796,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2984,11 +2875,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3368,14 +3254,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pa0: tim2_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF1)>;
-			};
-
-			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-			};
-
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -3514,18 +3392,6 @@
 
 			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
@@ -3732,12 +3598,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3821,11 +3681,6 @@
 				drive-push-pull;
 			};
 
-			/omit-if-no-ref/ usart2_de_pa1: usart2_de_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				drive-push-pull;
-			};
-
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3891,12 +3746,6 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -4013,10 +3862,6 @@
 
 			/omit-if-no-ref/ usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
-			};
-
-			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
 			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
@@ -4140,11 +3985,6 @@
 
 			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -4321,14 +4161,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {

--- a/dts/st/h7/stm32h755zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755zitx-pinctrl.dtsi
@@ -184,18 +184,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp8_pf6: adc3_inp8_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
 			};
@@ -360,14 +348,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -764,13 +744,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -780,13 +753,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -874,18 +840,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1879,11 +1833,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1948,11 +1897,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3051,14 +2995,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h757aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757aiix-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -392,14 +380,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -856,13 +836,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -872,13 +845,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -966,18 +932,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2073,11 +2027,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2142,11 +2091,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3251,14 +3195,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h757bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757bitx-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -420,14 +408,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -1017,13 +997,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1033,13 +1006,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1139,18 +1105,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2535,11 +2489,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2614,11 +2563,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3815,14 +3759,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h757iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757iitx-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -392,14 +380,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -856,13 +836,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -872,13 +845,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -966,18 +932,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2073,11 +2027,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2142,11 +2091,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3251,14 +3195,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h757xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757xihx-pinctrl.dtsi
@@ -16,23 +16,11 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc1_inn1_pa0: adc1_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp0_pa0: adc1_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -130,18 +118,6 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inn1_pa0: adc2_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pa0: adc2_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pa1: adc2_inp1_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -260,18 +236,6 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -352,14 +316,6 @@
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa0: analog_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa1: analog_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
@@ -496,14 +452,6 @@
 
 			/omit-if-no-ref/ analog_pc2: analog_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
@@ -1067,11 +1015,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_crs_pa0: eth_crs_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -1117,11 +1060,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_ref_clk_pa1: eth_ref_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -1161,11 +1099,6 @@
 			};
 
 			/* ETH_RX_CLK */
-
-			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
@@ -1227,11 +1160,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1245,11 +1173,6 @@
 			};
 
 			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
-				slew-rate = "very-high-speed";
-			};
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
@@ -1358,18 +1281,6 @@
 
 			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2155,10 +2066,6 @@
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
-			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF14)>;
-			};
-
 			/omit-if-no-ref/ ltdc_r1_pa2: ltdc_r1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
@@ -2578,11 +2485,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -2795,12 +2697,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF9)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2900,11 +2796,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2984,11 +2875,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3368,14 +3254,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pa0: tim2_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF1)>;
-			};
-
-			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-			};
-
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -3514,18 +3392,6 @@
 
 			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
@@ -3732,12 +3598,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3821,11 +3681,6 @@
 				drive-push-pull;
 			};
 
-			/omit-if-no-ref/ usart2_de_pa1: usart2_de_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				drive-push-pull;
-			};
-
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3891,12 +3746,6 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -4013,10 +3862,6 @@
 
 			/omit-if-no-ref/ usart3_rx_pd9: usart3_rx_pd9 {
 				pinmux = <STM32_PINMUX('D', 9, AF7)>;
-			};
-
-			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
 			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
@@ -4140,11 +3985,6 @@
 
 			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -4321,14 +4161,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {

--- a/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
@@ -196,18 +196,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc3_inn1_pc2: adc3_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp0_pc2: adc3_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc3_inp1_pc3: adc3_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -360,14 +348,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -757,13 +737,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/* ETH_TXD2 */
-
-			/omit-if-no-ref/ eth_txd2_pc2: eth_txd2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -773,13 +746,6 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/* ETH_TX_CLK */
-
-			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -862,18 +828,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1821,11 +1775,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1880,11 +1829,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2870,14 +2814,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
@@ -16,23 +16,11 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc1_inn1_pa0: adc1_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp0_pa0: adc1_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -176,23 +164,11 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc2_inn1_pc2: adc2_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pc2: adc2_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc2_inn12_pc3: adc2_inn12_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp13_pc3: adc2_inp13_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pc3: adc2_inp1_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
@@ -224,14 +200,6 @@
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa0: analog_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa1: analog_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
@@ -368,14 +336,6 @@
 
 			/omit-if-no-ref/ analog_pc2: analog_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
@@ -828,18 +788,6 @@
 
 			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1520,10 +1468,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 			};
 
-			/omit-if-no-ref/ i2s6_ws_pa0: i2s6_ws_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF5)>;
-			};
-
 			/omit-if-no-ref/ i2s6_ws_pa4: i2s6_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF8)>;
 			};
@@ -1537,10 +1481,6 @@
 			};
 
 			/* LTDC */
-
-			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF14)>;
-			};
 
 			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
@@ -1854,16 +1794,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 				slew-rate = "very-high-speed";
@@ -1926,26 +1856,6 @@
 
 			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -2267,12 +2177,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF9)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2402,11 +2306,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2471,11 +2370,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2598,11 +2492,6 @@
 
 			/omit-if-no-ref/ spi5_nss_pf6: spi5_nss_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF5)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ spi6_nss_pa0: spi6_nss_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 				bias-pull-up;
 			};
 
@@ -2804,14 +2693,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pa0: tim2_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF1)>;
-			};
-
-			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-			};
-
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -2942,18 +2823,6 @@
 
 			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
@@ -3114,12 +2983,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3214,11 +3077,6 @@
 				drive-push-pull;
 			};
 
-			/omit-if-no-ref/ usart2_de_pa1: usart2_de_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				drive-push-pull;
-			};
-
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3295,12 +3153,6 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -3437,10 +3289,6 @@
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
-			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF8)>;
-			};
-
 			/omit-if-no-ref/ uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
@@ -3568,11 +3416,6 @@
 
 			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -3732,14 +3575,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {

--- a/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
@@ -140,18 +140,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc2_inn1_pc2: adc2_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pc2: adc2_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pc3: adc2_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -312,14 +300,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -842,18 +822,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2098,26 +2066,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2565,11 +2513,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2644,11 +2587,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3908,14 +3846,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
@@ -16,23 +16,11 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc1_inn1_pa0: adc1_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp0_pa0: adc1_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -176,23 +164,11 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc2_inn1_pc2: adc2_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pc2: adc2_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc2_inn12_pc3: adc2_inn12_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp13_pc3: adc2_inp13_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pc3: adc2_inp1_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
@@ -224,14 +200,6 @@
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa0: analog_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa1: analog_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
@@ -368,14 +336,6 @@
 
 			/omit-if-no-ref/ analog_pc2: analog_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
@@ -856,18 +816,6 @@
 
 			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1608,10 +1556,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 			};
 
-			/omit-if-no-ref/ i2s6_ws_pa0: i2s6_ws_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF5)>;
-			};
-
 			/omit-if-no-ref/ i2s6_ws_pa4: i2s6_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF8)>;
 			};
@@ -1625,10 +1569,6 @@
 			};
 
 			/* LTDC */
-
-			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF14)>;
-			};
 
 			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
@@ -1962,16 +1902,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 				slew-rate = "very-high-speed";
@@ -2034,26 +1964,6 @@
 
 			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -2375,12 +2285,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF9)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2510,11 +2414,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2584,11 +2483,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2716,11 +2610,6 @@
 
 			/omit-if-no-ref/ spi5_nss_ph5: spi5_nss_ph5 {
 				pinmux = <STM32_PINMUX('H', 5, AF5)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ spi6_nss_pa0: spi6_nss_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 				bias-pull-up;
 			};
 
@@ -2928,14 +2817,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pa0: tim2_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF1)>;
-			};
-
-			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-			};
-
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -3074,18 +2955,6 @@
 
 			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
@@ -3250,12 +3119,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3350,11 +3213,6 @@
 				drive-push-pull;
 			};
 
-			/omit-if-no-ref/ usart2_de_pa1: usart2_de_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				drive-push-pull;
-			};
-
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3431,12 +3289,6 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -3573,10 +3425,6 @@
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
-			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF8)>;
-			};
-
 			/omit-if-no-ref/ uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
@@ -3704,11 +3552,6 @@
 
 			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -3868,14 +3711,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {

--- a/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
@@ -140,18 +140,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc2_inn1_pc2: adc2_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pc2: adc2_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pc3: adc2_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -312,14 +300,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -842,18 +822,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2098,26 +2066,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2565,11 +2513,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2644,11 +2587,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3908,14 +3846,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
@@ -140,18 +140,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc2_inn1_pc2: adc2_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pc2: adc2_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pc3: adc2_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -312,14 +300,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -754,18 +734,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1767,26 +1735,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2209,11 +2157,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2283,11 +2226,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3528,14 +3466,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
@@ -16,23 +16,11 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc1_inn1_pa0: adc1_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp0_pa0: adc1_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -176,18 +164,6 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc2_inn1_pc2: adc2_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pc2: adc2_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pc3: adc2_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc2_inn12_pc3: adc2_inn12_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
@@ -224,14 +200,6 @@
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa0: analog_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa1: analog_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
@@ -368,14 +336,6 @@
 
 			/omit-if-no-ref/ analog_pc2: analog_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
@@ -1020,18 +980,6 @@
 
 			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1841,10 +1789,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 			};
 
-			/omit-if-no-ref/ i2s6_ws_pa0: i2s6_ws_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF5)>;
-			};
-
 			/omit-if-no-ref/ i2s6_ws_pa4: i2s6_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF8)>;
 			};
@@ -1858,10 +1802,6 @@
 			};
 
 			/* LTDC */
-
-			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF14)>;
-			};
 
 			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
@@ -2363,16 +2303,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 				slew-rate = "very-high-speed";
@@ -2435,26 +2365,6 @@
 
 			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -2836,12 +2746,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF9)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2971,11 +2875,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -3055,11 +2954,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3207,11 +3101,6 @@
 
 			/omit-if-no-ref/ spi5_nss_pk1: spi5_nss_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF5)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ spi6_nss_pa0: spi6_nss_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 				bias-pull-up;
 			};
 
@@ -3455,14 +3344,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pa0: tim2_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF1)>;
-			};
-
-			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-			};
-
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -3601,18 +3482,6 @@
 
 			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
@@ -3829,12 +3698,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3935,11 +3798,6 @@
 				drive-push-pull;
 			};
 
-			/omit-if-no-ref/ usart2_de_pa1: usart2_de_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				drive-push-pull;
-			};
-
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -4021,12 +3879,6 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -4169,10 +4021,6 @@
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
-			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF8)>;
-			};
-
 			/omit-if-no-ref/ uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
@@ -4308,11 +4156,6 @@
 
 			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -4477,14 +4320,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {

--- a/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
@@ -140,18 +140,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc2_inn1_pc2: adc2_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pc2: adc2_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pc3: adc2_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -312,14 +300,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -954,18 +934,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2338,26 +2306,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2850,11 +2798,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2934,11 +2877,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -4296,14 +4234,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h7a3v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)hx-pinctrl.dtsi
@@ -128,18 +128,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc2_inn1_pc2: adc2_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pc2: adc2_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pc3: adc2_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -288,14 +276,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -574,18 +554,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1311,26 +1279,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1597,11 +1545,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1656,11 +1599,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2652,14 +2590,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h7a3v(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)hxq-pinctrl.dtsi
@@ -128,18 +128,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc2_inn1_pc2: adc2_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pc2: adc2_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pc3: adc2_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -288,14 +276,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -554,18 +534,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1241,26 +1209,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1522,11 +1470,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1576,11 +1519,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2540,14 +2478,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h7a3v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)tx-pinctrl.dtsi
@@ -128,18 +128,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc2_inn1_pc2: adc2_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pc2: adc2_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pc3: adc2_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -288,14 +276,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -574,18 +554,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1311,26 +1279,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1597,11 +1545,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1656,11 +1599,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2652,14 +2590,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h7a3v(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)txq-pinctrl.dtsi
@@ -128,18 +128,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc2_inn1_pc2: adc2_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pc2: adc2_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pc3: adc2_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -288,14 +276,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -526,18 +506,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1159,26 +1127,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1408,11 +1356,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1457,11 +1400,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2364,14 +2302,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
@@ -140,18 +140,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc2_inn1_pc2: adc2_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pc2: adc2_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pc3: adc2_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -312,14 +300,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -726,18 +706,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1711,26 +1679,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2153,11 +2101,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2222,11 +2165,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3394,14 +3332,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h7a3z(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)txq-pinctrl.dtsi
@@ -132,18 +132,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc2_inn1_pc2: adc2_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pc2: adc2_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pc3: adc2_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -300,14 +288,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -654,18 +634,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1537,26 +1505,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1929,11 +1877,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1998,11 +1941,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3155,14 +3093,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
@@ -16,23 +16,11 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc1_inn1_pa0: adc1_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp0_pa0: adc1_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -176,23 +164,11 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc2_inn1_pc2: adc2_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pc2: adc2_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc2_inn12_pc3: adc2_inn12_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp13_pc3: adc2_inp13_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pc3: adc2_inp1_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
@@ -224,14 +200,6 @@
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa0: analog_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa1: analog_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
@@ -368,14 +336,6 @@
 
 			/omit-if-no-ref/ analog_pc2: analog_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
@@ -828,18 +788,6 @@
 
 			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1520,10 +1468,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 			};
 
-			/omit-if-no-ref/ i2s6_ws_pa0: i2s6_ws_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF5)>;
-			};
-
 			/omit-if-no-ref/ i2s6_ws_pa4: i2s6_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF8)>;
 			};
@@ -1537,10 +1481,6 @@
 			};
 
 			/* LTDC */
-
-			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF14)>;
-			};
 
 			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
@@ -1854,16 +1794,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 				slew-rate = "very-high-speed";
@@ -1926,26 +1856,6 @@
 
 			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -2267,12 +2177,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF9)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2402,11 +2306,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2471,11 +2370,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2598,11 +2492,6 @@
 
 			/omit-if-no-ref/ spi5_nss_pf6: spi5_nss_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF5)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ spi6_nss_pa0: spi6_nss_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 				bias-pull-up;
 			};
 
@@ -2804,14 +2693,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pa0: tim2_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF1)>;
-			};
-
-			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-			};
-
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -2942,18 +2823,6 @@
 
 			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
@@ -3114,12 +2983,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3214,11 +3077,6 @@
 				drive-push-pull;
 			};
 
-			/omit-if-no-ref/ usart2_de_pa1: usart2_de_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				drive-push-pull;
-			};
-
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3295,12 +3153,6 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -3437,10 +3289,6 @@
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
-			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF8)>;
-			};
-
 			/omit-if-no-ref/ uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
@@ -3568,11 +3416,6 @@
 
 			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -3732,14 +3575,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {

--- a/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
@@ -16,23 +16,11 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc1_inn1_pa0: adc1_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp0_pa0: adc1_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -176,23 +164,11 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc2_inn1_pc2: adc2_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pc2: adc2_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc2_inn12_pc3: adc2_inn12_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp13_pc3: adc2_inp13_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pc3: adc2_inp1_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
@@ -224,14 +200,6 @@
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa0: analog_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa1: analog_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
@@ -368,14 +336,6 @@
 
 			/omit-if-no-ref/ analog_pc2: analog_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
@@ -856,18 +816,6 @@
 
 			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1608,10 +1556,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 			};
 
-			/omit-if-no-ref/ i2s6_ws_pa0: i2s6_ws_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF5)>;
-			};
-
 			/omit-if-no-ref/ i2s6_ws_pa4: i2s6_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF8)>;
 			};
@@ -1625,10 +1569,6 @@
 			};
 
 			/* LTDC */
-
-			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF14)>;
-			};
 
 			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
@@ -1962,16 +1902,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 				slew-rate = "very-high-speed";
@@ -2034,26 +1964,6 @@
 
 			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -2375,12 +2285,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF9)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2510,11 +2414,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2584,11 +2483,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2716,11 +2610,6 @@
 
 			/omit-if-no-ref/ spi5_nss_ph5: spi5_nss_ph5 {
 				pinmux = <STM32_PINMUX('H', 5, AF5)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ spi6_nss_pa0: spi6_nss_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 				bias-pull-up;
 			};
 
@@ -2928,14 +2817,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pa0: tim2_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF1)>;
-			};
-
-			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-			};
-
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -3074,18 +2955,6 @@
 
 			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
@@ -3250,12 +3119,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3350,11 +3213,6 @@
 				drive-push-pull;
 			};
 
-			/omit-if-no-ref/ usart2_de_pa1: usart2_de_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				drive-push-pull;
-			};
-
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3431,12 +3289,6 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -3573,10 +3425,6 @@
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
-			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF8)>;
-			};
-
 			/omit-if-no-ref/ uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
@@ -3704,11 +3552,6 @@
 
 			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -3868,14 +3711,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {

--- a/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
@@ -140,18 +140,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc2_inn1_pc2: adc2_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pc2: adc2_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pc3: adc2_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -312,14 +300,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -842,18 +822,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2098,26 +2066,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2565,11 +2513,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2644,11 +2587,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3908,14 +3846,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h7b0vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0vbtx-pinctrl.dtsi
@@ -128,18 +128,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc2_inn1_pc2: adc2_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pc2: adc2_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pc3: adc2_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -288,14 +276,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -574,18 +554,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1311,26 +1279,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1597,11 +1545,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1656,11 +1599,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2652,14 +2590,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
@@ -140,18 +140,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc2_inn1_pc2: adc2_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pc2: adc2_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pc3: adc2_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -312,14 +300,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -726,18 +706,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1711,26 +1679,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2153,11 +2101,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2222,11 +2165,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3394,14 +3332,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
@@ -16,23 +16,11 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc1_inn1_pa0: adc1_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp0_pa0: adc1_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -176,23 +164,11 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc2_inn1_pc2: adc2_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pc2: adc2_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc2_inn12_pc3: adc2_inn12_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp13_pc3: adc2_inp13_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pc3: adc2_inp1_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
@@ -224,14 +200,6 @@
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa0: analog_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa1: analog_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
@@ -368,14 +336,6 @@
 
 			/omit-if-no-ref/ analog_pc2: analog_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
@@ -828,18 +788,6 @@
 
 			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1520,10 +1468,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 			};
 
-			/omit-if-no-ref/ i2s6_ws_pa0: i2s6_ws_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF5)>;
-			};
-
 			/omit-if-no-ref/ i2s6_ws_pa4: i2s6_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF8)>;
 			};
@@ -1537,10 +1481,6 @@
 			};
 
 			/* LTDC */
-
-			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF14)>;
-			};
 
 			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
@@ -1854,16 +1794,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 				slew-rate = "very-high-speed";
@@ -1926,26 +1856,6 @@
 
 			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -2267,12 +2177,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF9)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2402,11 +2306,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2471,11 +2370,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2598,11 +2492,6 @@
 
 			/omit-if-no-ref/ spi5_nss_pf6: spi5_nss_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, AF5)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ spi6_nss_pa0: spi6_nss_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 				bias-pull-up;
 			};
 
@@ -2804,14 +2693,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pa0: tim2_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF1)>;
-			};
-
-			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-			};
-
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -2942,18 +2823,6 @@
 
 			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
@@ -3114,12 +2983,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3214,11 +3077,6 @@
 				drive-push-pull;
 			};
 
-			/omit-if-no-ref/ usart2_de_pa1: usart2_de_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				drive-push-pull;
-			};
-
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3295,12 +3153,6 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -3437,10 +3289,6 @@
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
-			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF8)>;
-			};
-
 			/omit-if-no-ref/ uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
@@ -3568,11 +3416,6 @@
 
 			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -3732,14 +3575,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {

--- a/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
@@ -140,18 +140,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc2_inn1_pc2: adc2_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pc2: adc2_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pc3: adc2_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -312,14 +300,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -842,18 +822,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2098,26 +2066,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2565,11 +2513,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2644,11 +2587,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3908,14 +3846,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
@@ -16,23 +16,11 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc1_inn1_pa0: adc1_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp0_pa0: adc1_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -176,23 +164,11 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc2_inn1_pc2: adc2_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pc2: adc2_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc2_inn12_pc3: adc2_inn12_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp13_pc3: adc2_inp13_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pc3: adc2_inp1_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
@@ -224,14 +200,6 @@
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa0: analog_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa1: analog_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
@@ -368,14 +336,6 @@
 
 			/omit-if-no-ref/ analog_pc2: analog_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
@@ -856,18 +816,6 @@
 
 			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1608,10 +1556,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 			};
 
-			/omit-if-no-ref/ i2s6_ws_pa0: i2s6_ws_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF5)>;
-			};
-
 			/omit-if-no-ref/ i2s6_ws_pa4: i2s6_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF8)>;
 			};
@@ -1625,10 +1569,6 @@
 			};
 
 			/* LTDC */
-
-			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF14)>;
-			};
 
 			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
@@ -1962,16 +1902,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 				slew-rate = "very-high-speed";
@@ -2034,26 +1964,6 @@
 
 			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -2375,12 +2285,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF9)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2510,11 +2414,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2584,11 +2483,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2716,11 +2610,6 @@
 
 			/omit-if-no-ref/ spi5_nss_ph5: spi5_nss_ph5 {
 				pinmux = <STM32_PINMUX('H', 5, AF5)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ spi6_nss_pa0: spi6_nss_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 				bias-pull-up;
 			};
 
@@ -2928,14 +2817,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pa0: tim2_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF1)>;
-			};
-
-			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-			};
-
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -3074,18 +2955,6 @@
 
 			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
@@ -3250,12 +3119,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3350,11 +3213,6 @@
 				drive-push-pull;
 			};
 
-			/omit-if-no-ref/ usart2_de_pa1: usart2_de_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				drive-push-pull;
-			};
-
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3431,12 +3289,6 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -3573,10 +3425,6 @@
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
-			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF8)>;
-			};
-
 			/omit-if-no-ref/ uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
@@ -3704,11 +3552,6 @@
 
 			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -3868,14 +3711,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {

--- a/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
@@ -140,18 +140,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc2_inn1_pc2: adc2_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pc2: adc2_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pc3: adc2_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -312,14 +300,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -842,18 +822,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2098,26 +2066,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2565,11 +2513,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2644,11 +2587,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3908,14 +3846,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
@@ -140,18 +140,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc2_inn1_pc2: adc2_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pc2: adc2_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pc3: adc2_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -312,14 +300,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -754,18 +734,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1767,26 +1735,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2209,11 +2157,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2283,11 +2226,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3528,14 +3466,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
@@ -16,23 +16,11 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc1_inn1_pa0: adc1_inn1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp0_pa0: adc1_inp0_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc1_inp1_pa1: adc1_inp1_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -176,18 +164,6 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc2_inn1_pc2: adc2_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pc2: adc2_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pc3: adc2_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc2_inn12_pc3: adc2_inn12_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
@@ -224,14 +200,6 @@
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa0: analog_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pa1: analog_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
@@ -368,14 +336,6 @@
 
 			/omit-if-no-ref/ analog_pc2: analog_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
@@ -1020,18 +980,6 @@
 
 			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1841,10 +1789,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 			};
 
-			/omit-if-no-ref/ i2s6_ws_pa0: i2s6_ws_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF5)>;
-			};
-
 			/omit-if-no-ref/ i2s6_ws_pa4: i2s6_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF8)>;
 			};
@@ -1858,10 +1802,6 @@
 			};
 
 			/* LTDC */
-
-			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF14)>;
-			};
 
 			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
@@ -2363,16 +2303,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_dqs_pa1: octospim_p1_dqs_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io3_pa1: octospim_p1_io3_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 				slew-rate = "very-high-speed";
@@ -2435,26 +2365,6 @@
 
 			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -2836,12 +2746,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ sdmmc2_cmd_pa0: sdmmc2_cmd_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF9)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2971,11 +2875,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -3055,11 +2954,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3207,11 +3101,6 @@
 
 			/omit-if-no-ref/ spi5_nss_pk1: spi5_nss_pk1 {
 				pinmux = <STM32_PINMUX('K', 1, AF5)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ spi6_nss_pa0: spi6_nss_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 				bias-pull-up;
 			};
 
@@ -3455,14 +3344,6 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pa0: tim2_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF1)>;
-			};
-
-			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF1)>;
-			};
-
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
@@ -3601,18 +3482,6 @@
 
 			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch1_pa0: tim5_ch1_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF2)>;
-			};
-
-			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF4)>;
-			};
-
-			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
@@ -3829,12 +3698,6 @@
 				drive-open-drain;
 			};
 
-			/omit-if-no-ref/ usart2_cts_pa0: usart2_cts_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3935,11 +3798,6 @@
 				drive-push-pull;
 			};
 
-			/omit-if-no-ref/ usart2_de_pa1: usart2_de_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
-				drive-push-pull;
-			};
-
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -4021,12 +3879,6 @@
 
 			/omit-if-no-ref/ usart1_rts_pa12: usart1_rts_pa12 {
 				pinmux = <STM32_PINMUX('A', 12, AF7)>;
-				bias-pull-up;
-				drive-open-drain;
-			};
-
-			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
 			};
@@ -4169,10 +4021,6 @@
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
-			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
-				pinmux = <STM32_PINMUX('A', 1, AF8)>;
-			};
-
 			/omit-if-no-ref/ uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
@@ -4308,11 +4156,6 @@
 
 			/omit-if-no-ref/ usart3_tx_pd8: usart3_tx_pd8 {
 				pinmux = <STM32_PINMUX('D', 8, AF7)>;
-				bias-pull-up;
-			};
-
-			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
-				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
 
@@ -4477,14 +4320,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {

--- a/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
@@ -140,18 +140,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc2_inn1_pc2: adc2_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pc2: adc2_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pc3: adc2_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -312,14 +300,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -954,18 +934,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2338,26 +2306,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2850,11 +2798,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2934,11 +2877,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -4296,14 +4234,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h7b3vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vihx-pinctrl.dtsi
@@ -128,18 +128,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc2_inn1_pc2: adc2_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pc2: adc2_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pc3: adc2_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -288,14 +276,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -574,18 +554,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1311,26 +1279,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1597,11 +1545,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1656,11 +1599,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2652,14 +2590,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h7b3vihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vihxq-pinctrl.dtsi
@@ -128,18 +128,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc2_inn1_pc2: adc2_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pc2: adc2_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pc3: adc2_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -288,14 +276,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -554,18 +534,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1241,26 +1209,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1522,11 +1470,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1576,11 +1519,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2540,14 +2478,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h7b3vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vitx-pinctrl.dtsi
@@ -128,18 +128,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc2_inn1_pc2: adc2_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pc2: adc2_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pc3: adc2_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -288,14 +276,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -574,18 +554,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1311,26 +1279,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1597,11 +1545,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1656,11 +1599,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2652,14 +2590,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h7b3vitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vitxq-pinctrl.dtsi
@@ -128,18 +128,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc2_inn1_pc2: adc2_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pc2: adc2_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pc3: adc2_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -288,14 +276,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -526,18 +506,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1159,26 +1127,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1408,11 +1356,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1457,11 +1400,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2364,14 +2302,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
@@ -140,18 +140,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc2_inn1_pc2: adc2_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pc2: adc2_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pc3: adc2_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -312,14 +300,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -726,18 +706,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1711,26 +1679,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2153,11 +2101,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2222,11 +2165,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3394,14 +3332,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h7b3zitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitxq-pinctrl.dtsi
@@ -132,18 +132,6 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
-			/omit-if-no-ref/ adc2_inn1_pc2: adc2_inn1_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp0_pc2: adc2_inp0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ adc2_inp1_pc3: adc2_inp1_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
-			};
-
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -300,14 +288,6 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc2: analog_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
-			};
-
-			/omit-if-no-ref/ analog_pc3: analog_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -654,18 +634,6 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF12)>;
-				bias-pull-up;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1537,26 +1505,6 @@
 				slew-rate = "very-high-speed";
 			};
 
-			/omit-if-no-ref/ octospim_p1_io2_pc2: octospim_p1_io2_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF9)>;
-				slew-rate = "very-high-speed";
-			};
-
-			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF11)>;
-				slew-rate = "very-high-speed";
-			};
-
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1929,11 +1877,6 @@
 				bias-pull-down;
 			};
 
-			/omit-if-no-ref/ spi2_miso_pc2: spi2_miso_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF5)>;
-				bias-pull-down;
-			};
-
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1998,11 +1941,6 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
-				bias-pull-down;
-			};
-
-			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3155,14 +3093,6 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
-				pinmux = <STM32_PINMUX('C', 2, AF10)>;
-			};
-
-			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
-				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/scripts/genpinctrl/genpinctrl.py
+++ b/scripts/genpinctrl/genpinctrl.py
@@ -416,6 +416,10 @@ def get_mcu_signals(data_path, gpio_ip_afs):
             if family == "STM32G0" and pin_name in ("PA9", "PA10"):
                 continue
 
+            # skip pins with analog switch (Pxy_C) (not supported)
+            if pin_name.endswith("_C"):
+                continue
+
             # obtain pin port (A, B, ...) and number (0, 1, ...)
             m = re.search(r"^P([A-Z])(\d+).*$", pin_name)
             if not m:

--- a/scripts/genpinctrl/genpinctrl.py
+++ b/scripts/genpinctrl/genpinctrl.py
@@ -410,8 +410,13 @@ def get_mcu_signals(data_path, gpio_ip_afs):
             if pin.get("Type") != "I/O":
                 continue
 
-            # obtain pin port (A, B, ...) and number (0, 1, ...)
             pin_name = pin.get("Name")
+
+            # skip duplicate remappable entries in some G0 files
+            if family == "STM32G0" and pin_name in ("PA9", "PA10"):
+                continue
+
+            # obtain pin port (A, B, ...) and number (0, 1, ...)
             m = re.search(r"^P([A-Z])(\d+).*$", pin_name)
             if not m:
                 continue


### PR DESCRIPTION
This PR fixes a couple of issues in the genpinctrl script that lead to duplicate nodes:

- Handling of duplicate remappable entries in some G0 files
- Skip pins with analog switch (Pxy_C) as they are not supported (H7)

Files have been regenerated, so we should no longer have duplicate entries.