### PR TITLE
scripts: genpinctrl: handle pins with analog switch

### DIFF
--- a/dts/st/h7/stm32h723vehx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vehx-pinctrl.dtsi
@@ -172,6 +172,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -308,6 +320,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -616,6 +636,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -625,6 +652,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -757,6 +791,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1544,6 +1590,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1816,6 +1882,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1870,6 +1941,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2861,6 +2937,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h723vetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vetx-pinctrl.dtsi
@@ -172,6 +172,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -308,6 +320,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -616,6 +636,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -625,6 +652,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -757,6 +791,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1544,6 +1590,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1816,6 +1882,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1870,6 +1941,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2861,6 +2937,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h723vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vghx-pinctrl.dtsi
@@ -172,6 +172,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -308,6 +320,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -616,6 +636,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -625,6 +652,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -757,6 +791,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1544,6 +1590,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1816,6 +1882,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1870,6 +1941,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2861,6 +2937,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h723vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vgtx-pinctrl.dtsi
@@ -172,6 +172,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -308,6 +320,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -616,6 +636,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -625,6 +652,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -757,6 +791,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1544,6 +1590,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1816,6 +1882,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1870,6 +1941,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2861,6 +2937,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h723zetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zetx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -380,6 +392,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -836,6 +856,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -845,6 +872,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -998,6 +1032,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2045,6 +2091,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2473,6 +2539,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2537,6 +2608,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3764,6 +3840,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h723zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zgtx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -380,6 +392,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -836,6 +856,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -845,6 +872,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -998,6 +1032,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2045,6 +2091,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2473,6 +2539,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2537,6 +2608,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3764,6 +3840,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h725aeix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725aeix-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc1_inn1_pa0_c: adc1_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp0_pa0_c: adc1_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp1_pa1_c: adc1_inp1_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -118,6 +130,18 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inn1_pa0_c: adc2_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pa0_c: adc2_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pa1_c: adc2_inp1_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -236,6 +260,18 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -302,7 +338,15 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pa0_c: analog_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pa1_c: analog_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -438,7 +482,15 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
@@ -811,6 +863,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_crs_pa0_c: eth_crs_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -856,6 +913,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_ref_clk_pa1_c: eth_ref_clk_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -887,6 +949,11 @@
 			/* ETH_RX_CLK */
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rx_clk_pa1_c: eth_rx_clk_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -941,6 +1008,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -957,6 +1029,11 @@
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1056,6 +1133,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_a19_pa0_c: fmc_a19_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_d8_pa4: fmc_d8_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF12)>;
 				bias-pull-up;
@@ -1128,8 +1211,20 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1858,6 +1953,10 @@
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 			};
 
+			/omit-if-no-ref/ i2s6_ws_pa0_c: i2s6_ws_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF5)>;
+			};
+
 			/omit-if-no-ref/ i2s6_ws_pa4: i2s6_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF8)>;
 			};
@@ -1873,6 +1972,10 @@
 			/* LTDC */
 
 			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			/omit-if-no-ref/ ltdc_r2_pa1_c: ltdc_r2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
@@ -2184,6 +2287,16 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_dqs_pa1_c: octospim_p1_dqs_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1_c: octospim_p1_io3_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
 				slew-rate = "very-high-speed";
@@ -2269,6 +2382,16 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 				slew-rate = "very-high-speed";
@@ -2276,6 +2399,16 @@
 
 			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -2587,6 +2720,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ sdmmc2_cmd_pa0_c: sdmmc2_cmd_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2722,6 +2861,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2791,6 +2935,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2912,6 +3061,11 @@
 			};
 
 			/omit-if-no-ref/ spi6_nss_pa0: spi6_nss_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF5)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ spi6_nss_pa0_c: spi6_nss_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 				bias-pull-up;
 			};
@@ -3109,7 +3263,15 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			/omit-if-no-ref/ tim2_ch1_pa0_c: tim2_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pa1_c: tim2_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
@@ -3301,11 +3463,23 @@
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
+			/omit-if-no-ref/ tim5_ch1_pa0_c: tim5_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
 			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1n_pa1_c: tim15_ch1n_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pa1_c: tim5_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
@@ -3459,6 +3633,12 @@
 				drive-open-drain;
 			};
 
+			/omit-if-no-ref/ usart2_cts_pa0_c: usart2_cts_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3553,6 +3733,11 @@
 				drive-push-pull;
 			};
 
+			/omit-if-no-ref/ usart2_de_pa1_c: usart2_de_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3634,6 +3819,12 @@
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			/omit-if-no-ref/ usart2_rts_pa1_c: usart2_rts_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -3762,6 +3953,10 @@
 			};
 
 			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ uart4_rx_pa1_c: uart4_rx_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
@@ -3896,6 +4091,11 @@
 			};
 
 			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ uart4_tx_pa0_c: uart4_tx_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
@@ -4053,8 +4253,16 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h725agix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725agix-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc1_inn1_pa0_c: adc1_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp0_pa0_c: adc1_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp1_pa1_c: adc1_inp1_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -118,6 +130,18 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inn1_pa0_c: adc2_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pa0_c: adc2_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pa1_c: adc2_inp1_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -236,6 +260,18 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -302,7 +338,15 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pa0_c: analog_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pa1_c: analog_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -438,7 +482,15 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
@@ -811,6 +863,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_crs_pa0_c: eth_crs_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -856,6 +913,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_ref_clk_pa1_c: eth_ref_clk_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -887,6 +949,11 @@
 			/* ETH_RX_CLK */
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rx_clk_pa1_c: eth_rx_clk_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -941,6 +1008,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -957,6 +1029,11 @@
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1056,6 +1133,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_a19_pa0_c: fmc_a19_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_d8_pa4: fmc_d8_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF12)>;
 				bias-pull-up;
@@ -1128,8 +1211,20 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1858,6 +1953,10 @@
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 			};
 
+			/omit-if-no-ref/ i2s6_ws_pa0_c: i2s6_ws_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF5)>;
+			};
+
 			/omit-if-no-ref/ i2s6_ws_pa4: i2s6_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF8)>;
 			};
@@ -1873,6 +1972,10 @@
 			/* LTDC */
 
 			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			/omit-if-no-ref/ ltdc_r2_pa1_c: ltdc_r2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
@@ -2184,6 +2287,16 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_dqs_pa1_c: octospim_p1_dqs_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1_c: octospim_p1_io3_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
 				slew-rate = "very-high-speed";
@@ -2269,6 +2382,16 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 				slew-rate = "very-high-speed";
@@ -2276,6 +2399,16 @@
 
 			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -2587,6 +2720,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ sdmmc2_cmd_pa0_c: sdmmc2_cmd_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2722,6 +2861,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2791,6 +2935,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2912,6 +3061,11 @@
 			};
 
 			/omit-if-no-ref/ spi6_nss_pa0: spi6_nss_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF5)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ spi6_nss_pa0_c: spi6_nss_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 				bias-pull-up;
 			};
@@ -3109,7 +3263,15 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			/omit-if-no-ref/ tim2_ch1_pa0_c: tim2_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pa1_c: tim2_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
@@ -3301,11 +3463,23 @@
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
+			/omit-if-no-ref/ tim5_ch1_pa0_c: tim5_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
 			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1n_pa1_c: tim15_ch1n_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pa1_c: tim5_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
@@ -3459,6 +3633,12 @@
 				drive-open-drain;
 			};
 
+			/omit-if-no-ref/ usart2_cts_pa0_c: usart2_cts_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3553,6 +3733,11 @@
 				drive-push-pull;
 			};
 
+			/omit-if-no-ref/ usart2_de_pa1_c: usart2_de_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3634,6 +3819,12 @@
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			/omit-if-no-ref/ usart2_rts_pa1_c: usart2_rts_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -3762,6 +3953,10 @@
 			};
 
 			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ uart4_rx_pa1_c: uart4_rx_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
@@ -3896,6 +4091,11 @@
 			};
 
 			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ uart4_tx_pa0_c: uart4_tx_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
@@ -4053,8 +4253,16 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h725iekx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725iekx-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc1_inn1_pa0_c: adc1_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp0_pa0_c: adc1_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp1_pa1_c: adc1_inp1_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -118,6 +130,18 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inn1_pa0_c: adc2_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pa0_c: adc2_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pa1_c: adc2_inp1_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -236,6 +260,18 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -318,7 +354,15 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pa0_c: analog_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pa1_c: analog_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -454,7 +498,15 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
@@ -855,6 +907,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_crs_pa0_c: eth_crs_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -900,6 +957,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_ref_clk_pa1_c: eth_ref_clk_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -941,6 +1003,11 @@
 			/* ETH_RX_CLK */
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rx_clk_pa1_c: eth_rx_clk_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -995,6 +1062,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1011,6 +1083,11 @@
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1110,6 +1187,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_a19_pa0_c: fmc_a19_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_d8_pa4: fmc_d8_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF12)>;
 				bias-pull-up;
@@ -1182,8 +1265,20 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1972,6 +2067,10 @@
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 			};
 
+			/omit-if-no-ref/ i2s6_ws_pa0_c: i2s6_ws_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF5)>;
+			};
+
 			/omit-if-no-ref/ i2s6_ws_pa4: i2s6_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF8)>;
 			};
@@ -1987,6 +2086,10 @@
 			/* LTDC */
 
 			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			/omit-if-no-ref/ ltdc_r2_pa1_c: ltdc_r2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
@@ -2318,6 +2421,16 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_dqs_pa1_c: octospim_p1_dqs_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1_c: octospim_p1_io3_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
 				slew-rate = "very-high-speed";
@@ -2403,6 +2516,16 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 				slew-rate = "very-high-speed";
@@ -2410,6 +2533,16 @@
 
 			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -2721,6 +2854,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ sdmmc2_cmd_pa0_c: sdmmc2_cmd_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2856,6 +2995,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2930,6 +3074,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3056,6 +3205,11 @@
 			};
 
 			/omit-if-no-ref/ spi6_nss_pa0: spi6_nss_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF5)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ spi6_nss_pa0_c: spi6_nss_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 				bias-pull-up;
 			};
@@ -3259,7 +3413,15 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			/omit-if-no-ref/ tim2_ch1_pa0_c: tim2_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pa1_c: tim2_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
@@ -3459,11 +3621,23 @@
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
+			/omit-if-no-ref/ tim5_ch1_pa0_c: tim5_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
 			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1n_pa1_c: tim15_ch1n_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pa1_c: tim5_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
@@ -3621,6 +3795,12 @@
 				drive-open-drain;
 			};
 
+			/omit-if-no-ref/ usart2_cts_pa0_c: usart2_cts_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3715,6 +3895,11 @@
 				drive-push-pull;
 			};
 
+			/omit-if-no-ref/ usart2_de_pa1_c: usart2_de_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3796,6 +3981,12 @@
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			/omit-if-no-ref/ usart2_rts_pa1_c: usart2_rts_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -3924,6 +4115,10 @@
 			};
 
 			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ uart4_rx_pa1_c: uart4_rx_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
@@ -4058,6 +4253,11 @@
 			};
 
 			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ uart4_tx_pa0_c: uart4_tx_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
@@ -4215,8 +4415,16 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h725ietx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725ietx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -380,6 +392,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -864,6 +884,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -873,6 +900,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1026,6 +1060,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2101,6 +2147,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2529,6 +2595,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2598,6 +2669,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3898,6 +3974,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h725igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725igkx-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc1_inn1_pa0_c: adc1_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp0_pa0_c: adc1_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp1_pa1_c: adc1_inp1_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -118,6 +130,18 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inn1_pa0_c: adc2_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pa0_c: adc2_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pa1_c: adc2_inp1_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -236,6 +260,18 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -318,7 +354,15 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pa0_c: analog_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pa1_c: analog_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -454,7 +498,15 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
@@ -855,6 +907,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_crs_pa0_c: eth_crs_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -900,6 +957,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_ref_clk_pa1_c: eth_ref_clk_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -941,6 +1003,11 @@
 			/* ETH_RX_CLK */
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rx_clk_pa1_c: eth_rx_clk_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -995,6 +1062,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1011,6 +1083,11 @@
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1110,6 +1187,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_a19_pa0_c: fmc_a19_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_d8_pa4: fmc_d8_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF12)>;
 				bias-pull-up;
@@ -1182,8 +1265,20 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1972,6 +2067,10 @@
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 			};
 
+			/omit-if-no-ref/ i2s6_ws_pa0_c: i2s6_ws_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF5)>;
+			};
+
 			/omit-if-no-ref/ i2s6_ws_pa4: i2s6_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF8)>;
 			};
@@ -1987,6 +2086,10 @@
 			/* LTDC */
 
 			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			/omit-if-no-ref/ ltdc_r2_pa1_c: ltdc_r2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
@@ -2318,6 +2421,16 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_dqs_pa1_c: octospim_p1_dqs_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1_c: octospim_p1_io3_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
 				slew-rate = "very-high-speed";
@@ -2403,6 +2516,16 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 				slew-rate = "very-high-speed";
@@ -2410,6 +2533,16 @@
 
 			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -2721,6 +2854,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ sdmmc2_cmd_pa0_c: sdmmc2_cmd_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2856,6 +2995,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2930,6 +3074,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3056,6 +3205,11 @@
 			};
 
 			/omit-if-no-ref/ spi6_nss_pa0: spi6_nss_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF5)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ spi6_nss_pa0_c: spi6_nss_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 				bias-pull-up;
 			};
@@ -3259,7 +3413,15 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			/omit-if-no-ref/ tim2_ch1_pa0_c: tim2_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pa1_c: tim2_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
@@ -3459,11 +3621,23 @@
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
+			/omit-if-no-ref/ tim5_ch1_pa0_c: tim5_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
 			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1n_pa1_c: tim15_ch1n_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pa1_c: tim5_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
@@ -3621,6 +3795,12 @@
 				drive-open-drain;
 			};
 
+			/omit-if-no-ref/ usart2_cts_pa0_c: usart2_cts_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3715,6 +3895,11 @@
 				drive-push-pull;
 			};
 
+			/omit-if-no-ref/ usart2_de_pa1_c: usart2_de_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3796,6 +3981,12 @@
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			/omit-if-no-ref/ usart2_rts_pa1_c: usart2_rts_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -3924,6 +4115,10 @@
 			};
 
 			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ uart4_rx_pa1_c: uart4_rx_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
@@ -4058,6 +4253,11 @@
 			};
 
 			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ uart4_tx_pa0_c: uart4_tx_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
@@ -4215,8 +4415,16 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h725igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725igtx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -380,6 +392,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -864,6 +884,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -873,6 +900,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1026,6 +1060,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2101,6 +2147,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2529,6 +2595,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2598,6 +2669,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3898,6 +3974,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h725vehx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vehx-pinctrl.dtsi
@@ -172,6 +172,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -308,6 +320,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -596,6 +616,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -605,6 +632,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -737,6 +771,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1474,6 +1520,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1741,6 +1807,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1790,6 +1861,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2749,6 +2825,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h725vetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vetx-pinctrl.dtsi
@@ -172,6 +172,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -308,6 +320,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -564,6 +584,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -573,6 +600,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -705,6 +739,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1378,6 +1424,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1613,6 +1679,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1657,6 +1728,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2538,6 +2614,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h725vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vghx-pinctrl.dtsi
@@ -172,6 +172,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -308,6 +320,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -596,6 +616,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -605,6 +632,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -737,6 +771,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1474,6 +1520,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1741,6 +1807,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1790,6 +1861,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2749,6 +2825,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h725vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vgtx-pinctrl.dtsi
@@ -172,6 +172,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -308,6 +320,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -564,6 +584,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -573,6 +600,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -705,6 +739,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1378,6 +1424,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1613,6 +1679,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1657,6 +1728,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2538,6 +2614,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h725zetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725zetx-pinctrl.dtsi
@@ -184,6 +184,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inn4_pf6: adc3_inn4_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
 			};
@@ -352,6 +364,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -748,6 +768,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -757,6 +784,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -910,6 +944,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1843,6 +1889,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2221,6 +2287,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2285,6 +2356,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3473,6 +3549,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h725zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725zgtx-pinctrl.dtsi
@@ -184,6 +184,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inn4_pf6: adc3_inn4_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
 			};
@@ -352,6 +364,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -748,6 +768,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -757,6 +784,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -910,6 +944,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1843,6 +1889,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2221,6 +2287,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2285,6 +2356,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3473,6 +3549,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h730abixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730abixq-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc1_inn1_pa0_c: adc1_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp0_pa0_c: adc1_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp1_pa1_c: adc1_inp1_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -118,6 +130,18 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inn1_pa0_c: adc2_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pa0_c: adc2_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pa1_c: adc2_inp1_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -236,6 +260,18 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -302,7 +338,15 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pa0_c: analog_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pa1_c: analog_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -438,7 +482,15 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
@@ -811,6 +863,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_crs_pa0_c: eth_crs_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -856,6 +913,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_ref_clk_pa1_c: eth_ref_clk_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -887,6 +949,11 @@
 			/* ETH_RX_CLK */
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rx_clk_pa1_c: eth_rx_clk_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -941,6 +1008,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -957,6 +1029,11 @@
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1056,6 +1133,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_a19_pa0_c: fmc_a19_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_d8_pa4: fmc_d8_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF12)>;
 				bias-pull-up;
@@ -1128,8 +1211,20 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1858,6 +1953,10 @@
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 			};
 
+			/omit-if-no-ref/ i2s6_ws_pa0_c: i2s6_ws_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF5)>;
+			};
+
 			/omit-if-no-ref/ i2s6_ws_pa4: i2s6_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF8)>;
 			};
@@ -1873,6 +1972,10 @@
 			/* LTDC */
 
 			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			/omit-if-no-ref/ ltdc_r2_pa1_c: ltdc_r2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
@@ -2184,6 +2287,16 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_dqs_pa1_c: octospim_p1_dqs_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1_c: octospim_p1_io3_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
 				slew-rate = "very-high-speed";
@@ -2269,6 +2382,16 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 				slew-rate = "very-high-speed";
@@ -2276,6 +2399,16 @@
 
 			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -2587,6 +2720,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ sdmmc2_cmd_pa0_c: sdmmc2_cmd_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2722,6 +2861,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2791,6 +2935,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2912,6 +3061,11 @@
 			};
 
 			/omit-if-no-ref/ spi6_nss_pa0: spi6_nss_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF5)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ spi6_nss_pa0_c: spi6_nss_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 				bias-pull-up;
 			};
@@ -3109,7 +3263,15 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			/omit-if-no-ref/ tim2_ch1_pa0_c: tim2_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pa1_c: tim2_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
@@ -3301,11 +3463,23 @@
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
+			/omit-if-no-ref/ tim5_ch1_pa0_c: tim5_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
 			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1n_pa1_c: tim15_ch1n_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pa1_c: tim5_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
@@ -3459,6 +3633,12 @@
 				drive-open-drain;
 			};
 
+			/omit-if-no-ref/ usart2_cts_pa0_c: usart2_cts_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3553,6 +3733,11 @@
 				drive-push-pull;
 			};
 
+			/omit-if-no-ref/ usart2_de_pa1_c: usart2_de_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3634,6 +3819,12 @@
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			/omit-if-no-ref/ usart2_rts_pa1_c: usart2_rts_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -3762,6 +3953,10 @@
 			};
 
 			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ uart4_rx_pa1_c: uart4_rx_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
@@ -3896,6 +4091,11 @@
 			};
 
 			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ uart4_tx_pa0_c: uart4_tx_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
@@ -4053,8 +4253,16 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h730ibkxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730ibkxq-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc1_inn1_pa0_c: adc1_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp0_pa0_c: adc1_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp1_pa1_c: adc1_inp1_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -118,6 +130,18 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inn1_pa0_c: adc2_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pa0_c: adc2_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pa1_c: adc2_inp1_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -236,6 +260,18 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -318,7 +354,15 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pa0_c: analog_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pa1_c: analog_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -454,7 +498,15 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
@@ -855,6 +907,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_crs_pa0_c: eth_crs_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -900,6 +957,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_ref_clk_pa1_c: eth_ref_clk_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -941,6 +1003,11 @@
 			/* ETH_RX_CLK */
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rx_clk_pa1_c: eth_rx_clk_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -995,6 +1062,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1011,6 +1083,11 @@
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1110,6 +1187,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_a19_pa0_c: fmc_a19_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_d8_pa4: fmc_d8_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF12)>;
 				bias-pull-up;
@@ -1182,8 +1265,20 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1972,6 +2067,10 @@
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 			};
 
+			/omit-if-no-ref/ i2s6_ws_pa0_c: i2s6_ws_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF5)>;
+			};
+
 			/omit-if-no-ref/ i2s6_ws_pa4: i2s6_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF8)>;
 			};
@@ -1987,6 +2086,10 @@
 			/* LTDC */
 
 			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			/omit-if-no-ref/ ltdc_r2_pa1_c: ltdc_r2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
@@ -2318,6 +2421,16 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_dqs_pa1_c: octospim_p1_dqs_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1_c: octospim_p1_io3_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
 				slew-rate = "very-high-speed";
@@ -2403,6 +2516,16 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 				slew-rate = "very-high-speed";
@@ -2410,6 +2533,16 @@
 
 			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -2721,6 +2854,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ sdmmc2_cmd_pa0_c: sdmmc2_cmd_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2856,6 +2995,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2930,6 +3074,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3056,6 +3205,11 @@
 			};
 
 			/omit-if-no-ref/ spi6_nss_pa0: spi6_nss_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF5)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ spi6_nss_pa0_c: spi6_nss_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 				bias-pull-up;
 			};
@@ -3259,7 +3413,15 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			/omit-if-no-ref/ tim2_ch1_pa0_c: tim2_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pa1_c: tim2_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
@@ -3459,11 +3621,23 @@
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
+			/omit-if-no-ref/ tim5_ch1_pa0_c: tim5_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
 			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1n_pa1_c: tim15_ch1n_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pa1_c: tim5_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
@@ -3621,6 +3795,12 @@
 				drive-open-drain;
 			};
 
+			/omit-if-no-ref/ usart2_cts_pa0_c: usart2_cts_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3715,6 +3895,11 @@
 				drive-push-pull;
 			};
 
+			/omit-if-no-ref/ usart2_de_pa1_c: usart2_de_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3796,6 +3981,12 @@
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			/omit-if-no-ref/ usart2_rts_pa1_c: usart2_rts_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -3924,6 +4115,10 @@
 			};
 
 			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ uart4_rx_pa1_c: uart4_rx_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
@@ -4058,6 +4253,11 @@
 			};
 
 			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ uart4_tx_pa0_c: uart4_tx_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
@@ -4215,8 +4415,16 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h730ibtxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730ibtxq-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -380,6 +392,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -864,6 +884,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -873,6 +900,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1026,6 +1060,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2101,6 +2147,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2529,6 +2595,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2598,6 +2669,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3898,6 +3974,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h730vbhx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730vbhx-pinctrl.dtsi
@@ -172,6 +172,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -308,6 +320,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -616,6 +636,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -625,6 +652,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -757,6 +791,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1544,6 +1590,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1816,6 +1882,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1870,6 +1941,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2861,6 +2937,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h730vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730vbtx-pinctrl.dtsi
@@ -172,6 +172,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -308,6 +320,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -616,6 +636,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -625,6 +652,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -757,6 +791,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1544,6 +1590,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1816,6 +1882,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1870,6 +1941,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2861,6 +2937,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h730zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730zbtx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -380,6 +392,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -836,6 +856,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -845,6 +872,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -998,6 +1032,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2045,6 +2091,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2473,6 +2539,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2537,6 +2608,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3764,6 +3840,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h733vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733vghx-pinctrl.dtsi
@@ -172,6 +172,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -308,6 +320,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -616,6 +636,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -625,6 +652,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -757,6 +791,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1544,6 +1590,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1816,6 +1882,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1870,6 +1941,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2861,6 +2937,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h733vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733vgtx-pinctrl.dtsi
@@ -172,6 +172,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -308,6 +320,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -616,6 +636,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -625,6 +652,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -757,6 +791,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1544,6 +1590,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1816,6 +1882,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1870,6 +1941,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2861,6 +2937,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h733zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733zgtx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -380,6 +392,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -836,6 +856,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -845,6 +872,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -998,6 +1032,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2045,6 +2091,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2473,6 +2539,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2537,6 +2608,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3764,6 +3840,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h735agix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735agix-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc1_inn1_pa0_c: adc1_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp0_pa0_c: adc1_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp1_pa1_c: adc1_inp1_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -118,6 +130,18 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inn1_pa0_c: adc2_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pa0_c: adc2_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pa1_c: adc2_inp1_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -236,6 +260,18 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -302,7 +338,15 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pa0_c: analog_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pa1_c: analog_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -438,7 +482,15 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
@@ -811,6 +863,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_crs_pa0_c: eth_crs_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -856,6 +913,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_ref_clk_pa1_c: eth_ref_clk_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -887,6 +949,11 @@
 			/* ETH_RX_CLK */
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rx_clk_pa1_c: eth_rx_clk_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -941,6 +1008,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -957,6 +1029,11 @@
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1056,6 +1133,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_a19_pa0_c: fmc_a19_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_d8_pa4: fmc_d8_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF12)>;
 				bias-pull-up;
@@ -1128,8 +1211,20 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1858,6 +1953,10 @@
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 			};
 
+			/omit-if-no-ref/ i2s6_ws_pa0_c: i2s6_ws_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF5)>;
+			};
+
 			/omit-if-no-ref/ i2s6_ws_pa4: i2s6_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF8)>;
 			};
@@ -1873,6 +1972,10 @@
 			/* LTDC */
 
 			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			/omit-if-no-ref/ ltdc_r2_pa1_c: ltdc_r2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
@@ -2184,6 +2287,16 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_dqs_pa1_c: octospim_p1_dqs_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1_c: octospim_p1_io3_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
 				slew-rate = "very-high-speed";
@@ -2269,6 +2382,16 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 				slew-rate = "very-high-speed";
@@ -2276,6 +2399,16 @@
 
 			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -2587,6 +2720,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ sdmmc2_cmd_pa0_c: sdmmc2_cmd_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2722,6 +2861,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2791,6 +2935,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2912,6 +3061,11 @@
 			};
 
 			/omit-if-no-ref/ spi6_nss_pa0: spi6_nss_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF5)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ spi6_nss_pa0_c: spi6_nss_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 				bias-pull-up;
 			};
@@ -3109,7 +3263,15 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			/omit-if-no-ref/ tim2_ch1_pa0_c: tim2_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pa1_c: tim2_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
@@ -3301,11 +3463,23 @@
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
+			/omit-if-no-ref/ tim5_ch1_pa0_c: tim5_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
 			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1n_pa1_c: tim15_ch1n_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pa1_c: tim5_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
@@ -3459,6 +3633,12 @@
 				drive-open-drain;
 			};
 
+			/omit-if-no-ref/ usart2_cts_pa0_c: usart2_cts_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3553,6 +3733,11 @@
 				drive-push-pull;
 			};
 
+			/omit-if-no-ref/ usart2_de_pa1_c: usart2_de_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3634,6 +3819,12 @@
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			/omit-if-no-ref/ usart2_rts_pa1_c: usart2_rts_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -3762,6 +3953,10 @@
 			};
 
 			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ uart4_rx_pa1_c: uart4_rx_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
@@ -3896,6 +4091,11 @@
 			};
 
 			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ uart4_tx_pa0_c: uart4_tx_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
@@ -4053,8 +4253,16 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h735igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735igkx-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc1_inn1_pa0_c: adc1_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp0_pa0_c: adc1_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp1_pa1_c: adc1_inp1_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -118,6 +130,18 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inn1_pa0_c: adc2_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pa0_c: adc2_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pa1_c: adc2_inp1_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -236,6 +260,18 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -318,7 +354,15 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pa0_c: analog_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pa1_c: analog_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -454,7 +498,15 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
@@ -855,6 +907,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_crs_pa0_c: eth_crs_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -900,6 +957,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_ref_clk_pa1_c: eth_ref_clk_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -941,6 +1003,11 @@
 			/* ETH_RX_CLK */
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rx_clk_pa1_c: eth_rx_clk_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -995,6 +1062,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1011,6 +1083,11 @@
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1110,6 +1187,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_a19_pa0_c: fmc_a19_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_d8_pa4: fmc_d8_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF12)>;
 				bias-pull-up;
@@ -1182,8 +1265,20 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1972,6 +2067,10 @@
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 			};
 
+			/omit-if-no-ref/ i2s6_ws_pa0_c: i2s6_ws_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF5)>;
+			};
+
 			/omit-if-no-ref/ i2s6_ws_pa4: i2s6_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF8)>;
 			};
@@ -1987,6 +2086,10 @@
 			/* LTDC */
 
 			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			/omit-if-no-ref/ ltdc_r2_pa1_c: ltdc_r2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
@@ -2318,6 +2421,16 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_dqs_pa1_c: octospim_p1_dqs_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF12)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1_c: octospim_p1_io3_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_io0_pa2: octospim_p1_io0_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF6)>;
 				slew-rate = "very-high-speed";
@@ -2403,6 +2516,16 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 				slew-rate = "very-high-speed";
@@ -2410,6 +2533,16 @@
 
 			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -2721,6 +2854,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ sdmmc2_cmd_pa0_c: sdmmc2_cmd_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2856,6 +2995,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2930,6 +3074,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3056,6 +3205,11 @@
 			};
 
 			/omit-if-no-ref/ spi6_nss_pa0: spi6_nss_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF5)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ spi6_nss_pa0_c: spi6_nss_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 				bias-pull-up;
 			};
@@ -3259,7 +3413,15 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			/omit-if-no-ref/ tim2_ch1_pa0_c: tim2_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pa1_c: tim2_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
@@ -3459,11 +3621,23 @@
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
+			/omit-if-no-ref/ tim5_ch1_pa0_c: tim5_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
 			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1n_pa1_c: tim15_ch1n_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pa1_c: tim5_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
@@ -3621,6 +3795,12 @@
 				drive-open-drain;
 			};
 
+			/omit-if-no-ref/ usart2_cts_pa0_c: usart2_cts_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3715,6 +3895,11 @@
 				drive-push-pull;
 			};
 
+			/omit-if-no-ref/ usart2_de_pa1_c: usart2_de_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3796,6 +3981,12 @@
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			/omit-if-no-ref/ usart2_rts_pa1_c: usart2_rts_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -3924,6 +4115,10 @@
 			};
 
 			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ uart4_rx_pa1_c: uart4_rx_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
@@ -4058,6 +4253,11 @@
 			};
 
 			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ uart4_tx_pa0_c: uart4_tx_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
@@ -4215,8 +4415,16 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h735igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735igtx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -380,6 +392,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -864,6 +884,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -873,6 +900,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1026,6 +1060,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2101,6 +2147,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2529,6 +2595,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2598,6 +2669,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3898,6 +3974,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h735vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vghx-pinctrl.dtsi
@@ -172,6 +172,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -308,6 +320,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -596,6 +616,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -605,6 +632,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -737,6 +771,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1474,6 +1520,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1741,6 +1807,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1790,6 +1861,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2749,6 +2825,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h735vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vgtx-pinctrl.dtsi
@@ -172,6 +172,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -308,6 +320,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -564,6 +584,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -573,6 +600,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -705,6 +739,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1378,6 +1424,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1613,6 +1679,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1657,6 +1728,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2538,6 +2614,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h735zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735zgtx-pinctrl.dtsi
@@ -184,6 +184,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inn4_pf6: adc3_inn4_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
 			};
@@ -352,6 +364,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -748,6 +768,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -757,6 +784,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -910,6 +944,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1843,6 +1889,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2221,6 +2287,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2285,6 +2356,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3473,6 +3549,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -408,6 +420,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -946,6 +966,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -955,6 +982,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1042,6 +1076,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2050,6 +2096,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2119,6 +2170,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3272,6 +3328,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -408,6 +420,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -1105,6 +1125,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1114,6 +1141,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1213,6 +1247,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2299,6 +2345,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2378,6 +2429,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3655,6 +3711,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -408,6 +420,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -993,6 +1013,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1002,6 +1029,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1101,6 +1135,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2187,6 +2233,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2261,6 +2312,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3457,6 +3513,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -408,6 +420,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -993,6 +1013,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1002,6 +1029,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1101,6 +1135,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2187,6 +2233,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2261,6 +2312,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3457,6 +3513,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
@@ -172,6 +172,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -308,6 +320,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -616,6 +636,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -625,6 +652,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -707,6 +741,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1354,6 +1400,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1408,6 +1459,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2371,6 +2427,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
@@ -172,6 +172,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -308,6 +320,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -616,6 +636,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -625,6 +652,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -707,6 +741,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1354,6 +1400,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1408,6 +1459,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2371,6 +2427,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc1_inn1_pa0_c: adc1_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp0_pa0_c: adc1_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp1_pa1_c: adc1_inp1_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -118,6 +130,18 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inn1_pa0_c: adc2_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pa0_c: adc2_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pa1_c: adc2_inp1_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -236,6 +260,18 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -318,7 +354,15 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pa0_c: analog_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pa1_c: analog_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -454,7 +498,15 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
@@ -1015,6 +1067,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_crs_pa0_c: eth_crs_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -1060,6 +1117,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_ref_clk_pa1_c: eth_ref_clk_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -1101,6 +1163,11 @@
 			/* ETH_RX_CLK */
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rx_clk_pa1_c: eth_rx_clk_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -1160,6 +1227,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1175,6 +1247,11 @@
 			/* ETH_TX_CLK */
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -1285,7 +1362,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
@@ -2060,9 +2149,20 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* LTDC */
+
+			/omit-if-no-ref/ ltdc_r2_pa1_c: ltdc_r2_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
 			/* QUADSPI */
 
 			/omit-if-no-ref/ quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ quadspi_bk1_io3_pa1_c: quadspi_bk1_io3_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF9)>;
 				slew-rate = "very-high-speed";
 			};
@@ -2279,6 +2379,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ sdmmc2_cmd_pa0_c: sdmmc2_cmd_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2378,6 +2484,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2461,6 +2572,11 @@
 			};
 
 			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
@@ -2836,7 +2952,15 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			/omit-if-no-ref/ tim2_ch1_pa0_c: tim2_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pa1_c: tim2_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
@@ -2976,11 +3100,23 @@
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
+			/omit-if-no-ref/ tim5_ch1_pa0_c: tim5_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
 			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1n_pa1_c: tim15_ch1n_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pa1_c: tim5_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
@@ -3180,6 +3316,12 @@
 				drive-open-drain;
 			};
 
+			/omit-if-no-ref/ usart2_cts_pa0_c: usart2_cts_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3263,6 +3405,11 @@
 				drive-push-pull;
 			};
 
+			/omit-if-no-ref/ usart2_de_pa1_c: usart2_de_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3333,6 +3480,12 @@
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			/omit-if-no-ref/ usart2_rts_pa1_c: usart2_rts_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -3447,6 +3600,10 @@
 			};
 
 			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ uart4_rx_pa1_c: uart4_rx_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
@@ -3571,6 +3728,11 @@
 			};
 
 			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ uart4_tx_pa0_c: uart4_tx_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
@@ -3745,7 +3907,15 @@
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
 			};
 
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 

--- a/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -380,6 +392,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -836,6 +856,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -845,6 +872,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -932,6 +966,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1825,6 +1871,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1889,6 +1940,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2993,6 +3049,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -408,6 +420,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -946,6 +966,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -955,6 +982,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1042,6 +1076,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2324,6 +2370,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2393,6 +2444,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3546,6 +3602,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -408,6 +420,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -1105,6 +1125,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1114,6 +1141,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1213,6 +1247,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2717,6 +2763,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2796,6 +2847,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -4073,6 +4129,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h743bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bitx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -408,6 +420,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -1105,6 +1125,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1114,6 +1141,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1213,6 +1247,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2717,6 +2763,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2796,6 +2847,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -4073,6 +4129,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h743igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igkx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -408,6 +420,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -993,6 +1013,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1002,6 +1029,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1101,6 +1135,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2477,6 +2523,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2551,6 +2602,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3747,6 +3803,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h743igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igtx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -408,6 +420,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -993,6 +1013,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1002,6 +1029,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1101,6 +1135,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2477,6 +2523,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2551,6 +2602,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3747,6 +3803,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h743iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iikx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -408,6 +420,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -993,6 +1013,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1002,6 +1029,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1101,6 +1135,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2477,6 +2523,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2551,6 +2602,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3747,6 +3803,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h743iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iitx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -408,6 +420,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -993,6 +1013,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1002,6 +1029,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1101,6 +1135,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2477,6 +2523,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2551,6 +2602,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3747,6 +3803,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
@@ -172,6 +172,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -308,6 +320,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -616,6 +636,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -625,6 +652,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -707,6 +741,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1512,6 +1558,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1566,6 +1617,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2529,6 +2585,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
@@ -172,6 +172,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -308,6 +320,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -616,6 +636,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -625,6 +652,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -707,6 +741,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1512,6 +1558,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1566,6 +1617,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2529,6 +2585,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h743vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vitx-pinctrl.dtsi
@@ -172,6 +172,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -308,6 +320,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -616,6 +636,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -625,6 +652,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -707,6 +741,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1512,6 +1558,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1566,6 +1617,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2529,6 +2585,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h743xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xghx-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc1_inn1_pa0_c: adc1_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp0_pa0_c: adc1_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp1_pa1_c: adc1_inp1_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -118,6 +130,18 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inn1_pa0_c: adc2_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pa0_c: adc2_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pa1_c: adc2_inp1_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -236,6 +260,18 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -318,7 +354,15 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pa0_c: analog_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pa1_c: analog_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -454,7 +498,15 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
@@ -1015,6 +1067,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_crs_pa0_c: eth_crs_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -1060,6 +1117,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_ref_clk_pa1_c: eth_ref_clk_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -1101,6 +1163,11 @@
 			/* ETH_RX_CLK */
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rx_clk_pa1_c: eth_rx_clk_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -1160,6 +1227,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1175,6 +1247,11 @@
 			/* ETH_TX_CLK */
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -1285,7 +1362,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
@@ -2066,6 +2155,10 @@
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
+			/omit-if-no-ref/ ltdc_r2_pa1_c: ltdc_r2_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
 			/omit-if-no-ref/ ltdc_r1_pa2: ltdc_r1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
@@ -2485,6 +2578,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ quadspi_bk1_io3_pa1_c: quadspi_bk1_io3_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -2697,6 +2795,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ sdmmc2_cmd_pa0_c: sdmmc2_cmd_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2796,6 +2900,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2879,6 +2988,11 @@
 			};
 
 			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
@@ -3254,7 +3368,15 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			/omit-if-no-ref/ tim2_ch1_pa0_c: tim2_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pa1_c: tim2_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
@@ -3394,11 +3516,23 @@
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
+			/omit-if-no-ref/ tim5_ch1_pa0_c: tim5_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
 			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1n_pa1_c: tim15_ch1n_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pa1_c: tim5_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
@@ -3598,6 +3732,12 @@
 				drive-open-drain;
 			};
 
+			/omit-if-no-ref/ usart2_cts_pa0_c: usart2_cts_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3681,6 +3821,11 @@
 				drive-push-pull;
 			};
 
+			/omit-if-no-ref/ usart2_de_pa1_c: usart2_de_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3751,6 +3896,12 @@
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			/omit-if-no-ref/ usart2_rts_pa1_c: usart2_rts_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -3865,6 +4016,10 @@
 			};
 
 			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ uart4_rx_pa1_c: uart4_rx_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
@@ -3989,6 +4144,11 @@
 			};
 
 			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ uart4_tx_pa0_c: uart4_tx_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
@@ -4163,7 +4323,15 @@
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
 			};
 
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 

--- a/dts/st/h7/stm32h743xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xihx-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc1_inn1_pa0_c: adc1_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp0_pa0_c: adc1_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp1_pa1_c: adc1_inp1_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -118,6 +130,18 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inn1_pa0_c: adc2_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pa0_c: adc2_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pa1_c: adc2_inp1_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -236,6 +260,18 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -318,7 +354,15 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pa0_c: analog_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pa1_c: analog_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -454,7 +498,15 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
@@ -1015,6 +1067,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_crs_pa0_c: eth_crs_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -1060,6 +1117,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_ref_clk_pa1_c: eth_ref_clk_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -1101,6 +1163,11 @@
 			/* ETH_RX_CLK */
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rx_clk_pa1_c: eth_rx_clk_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -1160,6 +1227,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1175,6 +1247,11 @@
 			/* ETH_TX_CLK */
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -1285,7 +1362,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
@@ -2066,6 +2155,10 @@
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
+			/omit-if-no-ref/ ltdc_r2_pa1_c: ltdc_r2_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
 			/omit-if-no-ref/ ltdc_r1_pa2: ltdc_r1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
@@ -2485,6 +2578,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ quadspi_bk1_io3_pa1_c: quadspi_bk1_io3_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -2697,6 +2795,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ sdmmc2_cmd_pa0_c: sdmmc2_cmd_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2796,6 +2900,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2879,6 +2988,11 @@
 			};
 
 			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
@@ -3254,7 +3368,15 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			/omit-if-no-ref/ tim2_ch1_pa0_c: tim2_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pa1_c: tim2_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
@@ -3394,11 +3516,23 @@
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
+			/omit-if-no-ref/ tim5_ch1_pa0_c: tim5_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
 			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1n_pa1_c: tim15_ch1n_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pa1_c: tim5_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
@@ -3598,6 +3732,12 @@
 				drive-open-drain;
 			};
 
+			/omit-if-no-ref/ usart2_cts_pa0_c: usart2_cts_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3681,6 +3821,11 @@
 				drive-push-pull;
 			};
 
+			/omit-if-no-ref/ usart2_de_pa1_c: usart2_de_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3751,6 +3896,12 @@
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			/omit-if-no-ref/ usart2_rts_pa1_c: usart2_rts_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -3865,6 +4016,10 @@
 			};
 
 			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ uart4_rx_pa1_c: uart4_rx_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
@@ -3989,6 +4144,11 @@
 			};
 
 			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ uart4_tx_pa0_c: uart4_tx_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
@@ -4163,7 +4323,15 @@
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
 			};
 
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 

--- a/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -380,6 +392,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -836,6 +856,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -845,6 +872,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -932,6 +966,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2027,6 +2073,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2091,6 +2142,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3195,6 +3251,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h743zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zitx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -380,6 +392,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -836,6 +856,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -845,6 +872,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -932,6 +966,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2027,6 +2073,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2091,6 +2142,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3195,6 +3251,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -408,6 +420,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -1033,6 +1053,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1042,6 +1069,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1141,6 +1175,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2561,6 +2607,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2640,6 +2691,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3917,6 +3973,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h745bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bitx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -408,6 +420,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -1033,6 +1053,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1042,6 +1069,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1141,6 +1175,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2561,6 +2607,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2640,6 +2691,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3917,6 +3973,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h745igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igkx-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc1_inn1_pa0_c: adc1_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp0_pa0_c: adc1_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp1_pa1_c: adc1_inp1_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -118,6 +130,18 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inn1_pa0_c: adc2_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pa0_c: adc2_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pa1_c: adc2_inp1_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -236,6 +260,18 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -318,7 +354,15 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pa0_c: analog_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pa1_c: analog_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -454,7 +498,15 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
@@ -855,6 +907,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_crs_pa0_c: eth_crs_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -900,6 +957,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_ref_clk_pa1_c: eth_ref_clk_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -941,6 +1003,11 @@
 			/* ETH_RX_CLK */
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rx_clk_pa1_c: eth_rx_clk_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -995,6 +1062,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1010,6 +1082,11 @@
 			/* ETH_TX_CLK */
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -1116,7 +1193,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
@@ -1828,6 +1917,10 @@
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
+			/omit-if-no-ref/ ltdc_r2_pa1_c: ltdc_r2_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
 			/omit-if-no-ref/ ltdc_r1_pa2: ltdc_r1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
@@ -2079,6 +2172,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ quadspi_bk1_io3_pa1_c: quadspi_bk1_io3_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -2291,6 +2389,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ sdmmc2_cmd_pa0_c: sdmmc2_cmd_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2390,6 +2494,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2463,6 +2572,11 @@
 			};
 
 			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
@@ -2782,7 +2896,15 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			/omit-if-no-ref/ tim2_ch1_pa0_c: tim2_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pa1_c: tim2_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
@@ -2922,11 +3044,23 @@
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
+			/omit-if-no-ref/ tim5_ch1_pa0_c: tim5_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
 			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1n_pa1_c: tim15_ch1n_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pa1_c: tim5_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
@@ -3074,6 +3208,12 @@
 				drive-open-drain;
 			};
 
+			/omit-if-no-ref/ usart2_cts_pa0_c: usart2_cts_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3157,6 +3297,11 @@
 				drive-push-pull;
 			};
 
+			/omit-if-no-ref/ usart2_de_pa1_c: usart2_de_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3227,6 +3372,12 @@
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			/omit-if-no-ref/ usart2_rts_pa1_c: usart2_rts_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -3344,6 +3495,10 @@
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
+			/omit-if-no-ref/ uart4_rx_pa1_c: uart4_rx_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+			};
+
 			/omit-if-no-ref/ uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
@@ -3457,6 +3612,11 @@
 			};
 
 			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ uart4_tx_pa0_c: uart4_tx_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
@@ -3626,7 +3786,15 @@
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
 			};
 
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 

--- a/dts/st/h7/stm32h745igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igtx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -380,6 +392,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -864,6 +884,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -873,6 +900,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -960,6 +994,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2083,6 +2129,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2152,6 +2203,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3329,6 +3385,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h745iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iikx-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc1_inn1_pa0_c: adc1_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp0_pa0_c: adc1_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp1_pa1_c: adc1_inp1_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -118,6 +130,18 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inn1_pa0_c: adc2_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pa0_c: adc2_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pa1_c: adc2_inp1_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -236,6 +260,18 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -318,7 +354,15 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pa0_c: analog_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pa1_c: analog_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -454,7 +498,15 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
@@ -855,6 +907,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_crs_pa0_c: eth_crs_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -900,6 +957,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_ref_clk_pa1_c: eth_ref_clk_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -941,6 +1003,11 @@
 			/* ETH_RX_CLK */
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rx_clk_pa1_c: eth_rx_clk_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -995,6 +1062,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1010,6 +1082,11 @@
 			/* ETH_TX_CLK */
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -1116,7 +1193,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
@@ -1828,6 +1917,10 @@
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
+			/omit-if-no-ref/ ltdc_r2_pa1_c: ltdc_r2_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
 			/omit-if-no-ref/ ltdc_r1_pa2: ltdc_r1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
@@ -2079,6 +2172,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ quadspi_bk1_io3_pa1_c: quadspi_bk1_io3_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -2291,6 +2389,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ sdmmc2_cmd_pa0_c: sdmmc2_cmd_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2390,6 +2494,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2463,6 +2572,11 @@
 			};
 
 			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
@@ -2782,7 +2896,15 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			/omit-if-no-ref/ tim2_ch1_pa0_c: tim2_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pa1_c: tim2_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
@@ -2922,11 +3044,23 @@
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
+			/omit-if-no-ref/ tim5_ch1_pa0_c: tim5_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
 			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1n_pa1_c: tim15_ch1n_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pa1_c: tim5_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
@@ -3074,6 +3208,12 @@
 				drive-open-drain;
 			};
 
+			/omit-if-no-ref/ usart2_cts_pa0_c: usart2_cts_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3157,6 +3297,11 @@
 				drive-push-pull;
 			};
 
+			/omit-if-no-ref/ usart2_de_pa1_c: usart2_de_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3227,6 +3372,12 @@
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			/omit-if-no-ref/ usart2_rts_pa1_c: usart2_rts_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -3344,6 +3495,10 @@
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
+			/omit-if-no-ref/ uart4_rx_pa1_c: uart4_rx_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+			};
+
 			/omit-if-no-ref/ uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
@@ -3457,6 +3612,11 @@
 			};
 
 			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ uart4_tx_pa0_c: uart4_tx_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
@@ -3626,7 +3786,15 @@
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
 			};
 
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 

--- a/dts/st/h7/stm32h745iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iitx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -380,6 +392,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -864,6 +884,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -873,6 +900,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -960,6 +994,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2083,6 +2129,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2152,6 +2203,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3329,6 +3385,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h745xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xghx-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc1_inn1_pa0_c: adc1_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp0_pa0_c: adc1_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp1_pa1_c: adc1_inp1_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -118,6 +130,18 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inn1_pa0_c: adc2_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pa0_c: adc2_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pa1_c: adc2_inp1_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -236,6 +260,18 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -318,7 +354,15 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pa0_c: analog_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pa1_c: analog_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -454,7 +498,15 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
@@ -1015,6 +1067,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_crs_pa0_c: eth_crs_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -1060,6 +1117,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_ref_clk_pa1_c: eth_ref_clk_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -1101,6 +1163,11 @@
 			/* ETH_RX_CLK */
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rx_clk_pa1_c: eth_rx_clk_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -1160,6 +1227,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1175,6 +1247,11 @@
 			/* ETH_TX_CLK */
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -1285,7 +1362,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
@@ -2066,6 +2155,10 @@
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
+			/omit-if-no-ref/ ltdc_r2_pa1_c: ltdc_r2_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
 			/omit-if-no-ref/ ltdc_r1_pa2: ltdc_r1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
@@ -2485,6 +2578,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ quadspi_bk1_io3_pa1_c: quadspi_bk1_io3_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -2697,6 +2795,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ sdmmc2_cmd_pa0_c: sdmmc2_cmd_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2796,6 +2900,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2879,6 +2988,11 @@
 			};
 
 			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
@@ -3254,7 +3368,15 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			/omit-if-no-ref/ tim2_ch1_pa0_c: tim2_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pa1_c: tim2_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
@@ -3394,11 +3516,23 @@
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
+			/omit-if-no-ref/ tim5_ch1_pa0_c: tim5_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
 			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1n_pa1_c: tim15_ch1n_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pa1_c: tim5_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
@@ -3598,6 +3732,12 @@
 				drive-open-drain;
 			};
 
+			/omit-if-no-ref/ usart2_cts_pa0_c: usart2_cts_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3681,6 +3821,11 @@
 				drive-push-pull;
 			};
 
+			/omit-if-no-ref/ usart2_de_pa1_c: usart2_de_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3751,6 +3896,12 @@
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			/omit-if-no-ref/ usart2_rts_pa1_c: usart2_rts_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -3865,6 +4016,10 @@
 			};
 
 			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ uart4_rx_pa1_c: uart4_rx_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
@@ -3989,6 +4144,11 @@
 			};
 
 			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ uart4_tx_pa0_c: uart4_tx_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
@@ -4163,7 +4323,15 @@
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
 			};
 
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 

--- a/dts/st/h7/stm32h745xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xihx-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc1_inn1_pa0_c: adc1_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp0_pa0_c: adc1_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp1_pa1_c: adc1_inp1_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -118,6 +130,18 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inn1_pa0_c: adc2_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pa0_c: adc2_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pa1_c: adc2_inp1_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -236,6 +260,18 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -318,7 +354,15 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pa0_c: analog_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pa1_c: analog_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -454,7 +498,15 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
@@ -1015,6 +1067,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_crs_pa0_c: eth_crs_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -1060,6 +1117,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_ref_clk_pa1_c: eth_ref_clk_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -1101,6 +1163,11 @@
 			/* ETH_RX_CLK */
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rx_clk_pa1_c: eth_rx_clk_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -1160,6 +1227,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1175,6 +1247,11 @@
 			/* ETH_TX_CLK */
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -1285,7 +1362,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
@@ -2066,6 +2155,10 @@
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
+			/omit-if-no-ref/ ltdc_r2_pa1_c: ltdc_r2_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
 			/omit-if-no-ref/ ltdc_r1_pa2: ltdc_r1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
@@ -2485,6 +2578,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ quadspi_bk1_io3_pa1_c: quadspi_bk1_io3_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -2697,6 +2795,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ sdmmc2_cmd_pa0_c: sdmmc2_cmd_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2796,6 +2900,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2879,6 +2988,11 @@
 			};
 
 			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
@@ -3254,7 +3368,15 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			/omit-if-no-ref/ tim2_ch1_pa0_c: tim2_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pa1_c: tim2_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
@@ -3394,11 +3516,23 @@
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
+			/omit-if-no-ref/ tim5_ch1_pa0_c: tim5_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
 			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1n_pa1_c: tim15_ch1n_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pa1_c: tim5_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
@@ -3598,6 +3732,12 @@
 				drive-open-drain;
 			};
 
+			/omit-if-no-ref/ usart2_cts_pa0_c: usart2_cts_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3681,6 +3821,11 @@
 				drive-push-pull;
 			};
 
+			/omit-if-no-ref/ usart2_de_pa1_c: usart2_de_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3751,6 +3896,12 @@
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			/omit-if-no-ref/ usart2_rts_pa1_c: usart2_rts_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -3865,6 +4016,10 @@
 			};
 
 			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ uart4_rx_pa1_c: uart4_rx_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
@@ -3989,6 +4144,11 @@
 			};
 
 			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ uart4_tx_pa0_c: uart4_tx_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
@@ -4163,7 +4323,15 @@
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
 			};
 
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 

--- a/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
@@ -184,6 +184,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp8_pf6: adc3_inp8_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
 			};
@@ -348,6 +360,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -744,6 +764,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -753,6 +780,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -840,6 +874,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1833,6 +1879,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1897,6 +1948,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2995,6 +3051,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h745zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zitx-pinctrl.dtsi
@@ -184,6 +184,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp8_pf6: adc3_inp8_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
 			};
@@ -348,6 +360,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -744,6 +764,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -753,6 +780,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -840,6 +874,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1833,6 +1879,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1897,6 +1948,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2995,6 +3051,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -380,6 +392,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -836,6 +856,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -845,6 +872,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -932,6 +966,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2027,6 +2073,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2091,6 +2142,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3195,6 +3251,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -408,6 +420,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -997,6 +1017,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1006,6 +1033,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1105,6 +1139,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2489,6 +2535,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2563,6 +2614,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3759,6 +3815,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h747bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bitx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -408,6 +420,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -997,6 +1017,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1006,6 +1033,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1105,6 +1139,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2489,6 +2535,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2563,6 +2614,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3759,6 +3815,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h747igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747igtx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -380,6 +392,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -836,6 +856,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -845,6 +872,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -932,6 +966,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2027,6 +2073,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2091,6 +2142,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3195,6 +3251,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h747iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747iitx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -380,6 +392,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -836,6 +856,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -845,6 +872,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -932,6 +966,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2027,6 +2073,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2091,6 +2142,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3195,6 +3251,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h747xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xghx-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc1_inn1_pa0_c: adc1_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp0_pa0_c: adc1_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp1_pa1_c: adc1_inp1_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -118,6 +130,18 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inn1_pa0_c: adc2_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pa0_c: adc2_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pa1_c: adc2_inp1_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -236,6 +260,18 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -318,7 +354,15 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pa0_c: analog_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pa1_c: analog_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -454,7 +498,15 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
@@ -1015,6 +1067,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_crs_pa0_c: eth_crs_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -1060,6 +1117,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_ref_clk_pa1_c: eth_ref_clk_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -1101,6 +1163,11 @@
 			/* ETH_RX_CLK */
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rx_clk_pa1_c: eth_rx_clk_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -1160,6 +1227,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1175,6 +1247,11 @@
 			/* ETH_TX_CLK */
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -1285,7 +1362,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
@@ -2066,6 +2155,10 @@
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
+			/omit-if-no-ref/ ltdc_r2_pa1_c: ltdc_r2_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
 			/omit-if-no-ref/ ltdc_r1_pa2: ltdc_r1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
@@ -2485,6 +2578,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ quadspi_bk1_io3_pa1_c: quadspi_bk1_io3_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -2697,6 +2795,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ sdmmc2_cmd_pa0_c: sdmmc2_cmd_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2796,6 +2900,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2879,6 +2988,11 @@
 			};
 
 			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
@@ -3254,7 +3368,15 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			/omit-if-no-ref/ tim2_ch1_pa0_c: tim2_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pa1_c: tim2_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
@@ -3394,11 +3516,23 @@
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
+			/omit-if-no-ref/ tim5_ch1_pa0_c: tim5_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
 			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1n_pa1_c: tim15_ch1n_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pa1_c: tim5_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
@@ -3598,6 +3732,12 @@
 				drive-open-drain;
 			};
 
+			/omit-if-no-ref/ usart2_cts_pa0_c: usart2_cts_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3681,6 +3821,11 @@
 				drive-push-pull;
 			};
 
+			/omit-if-no-ref/ usart2_de_pa1_c: usart2_de_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3751,6 +3896,12 @@
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			/omit-if-no-ref/ usart2_rts_pa1_c: usart2_rts_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -3865,6 +4016,10 @@
 			};
 
 			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ uart4_rx_pa1_c: uart4_rx_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
@@ -3989,6 +4144,11 @@
 			};
 
 			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ uart4_tx_pa0_c: uart4_tx_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
@@ -4163,7 +4323,15 @@
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
 			};
 
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 

--- a/dts/st/h7/stm32h747xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xihx-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc1_inn1_pa0_c: adc1_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp0_pa0_c: adc1_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp1_pa1_c: adc1_inp1_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -118,6 +130,18 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inn1_pa0_c: adc2_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pa0_c: adc2_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pa1_c: adc2_inp1_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -236,6 +260,18 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -318,7 +354,15 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pa0_c: analog_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pa1_c: analog_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -454,7 +498,15 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
@@ -1015,6 +1067,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_crs_pa0_c: eth_crs_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -1060,6 +1117,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_ref_clk_pa1_c: eth_ref_clk_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -1101,6 +1163,11 @@
 			/* ETH_RX_CLK */
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rx_clk_pa1_c: eth_rx_clk_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -1160,6 +1227,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1175,6 +1247,11 @@
 			/* ETH_TX_CLK */
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -1285,7 +1362,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
@@ -2066,6 +2155,10 @@
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
+			/omit-if-no-ref/ ltdc_r2_pa1_c: ltdc_r2_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
 			/omit-if-no-ref/ ltdc_r1_pa2: ltdc_r1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
@@ -2485,6 +2578,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ quadspi_bk1_io3_pa1_c: quadspi_bk1_io3_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -2697,6 +2795,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ sdmmc2_cmd_pa0_c: sdmmc2_cmd_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2796,6 +2900,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2879,6 +2988,11 @@
 			};
 
 			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
@@ -3254,7 +3368,15 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			/omit-if-no-ref/ tim2_ch1_pa0_c: tim2_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pa1_c: tim2_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
@@ -3394,11 +3516,23 @@
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
+			/omit-if-no-ref/ tim5_ch1_pa0_c: tim5_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
 			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1n_pa1_c: tim15_ch1n_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pa1_c: tim5_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
@@ -3598,6 +3732,12 @@
 				drive-open-drain;
 			};
 
+			/omit-if-no-ref/ usart2_cts_pa0_c: usart2_cts_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3681,6 +3821,11 @@
 				drive-push-pull;
 			};
 
+			/omit-if-no-ref/ usart2_de_pa1_c: usart2_de_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3751,6 +3896,12 @@
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			/omit-if-no-ref/ usart2_rts_pa1_c: usart2_rts_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -3865,6 +4016,10 @@
 			};
 
 			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ uart4_rx_pa1_c: uart4_rx_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
@@ -3989,6 +4144,11 @@
 			};
 
 			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ uart4_tx_pa0_c: uart4_tx_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
@@ -4163,7 +4323,15 @@
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
 			};
 
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 

--- a/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -348,6 +360,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -737,6 +757,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -746,6 +773,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -828,6 +862,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1775,6 +1821,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1829,6 +1880,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2814,6 +2870,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -408,6 +420,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -993,6 +1013,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1002,6 +1029,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1101,6 +1135,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2477,6 +2523,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2551,6 +2602,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3747,6 +3803,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -408,6 +420,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -993,6 +1013,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1002,6 +1029,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1101,6 +1135,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2477,6 +2523,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2551,6 +2602,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3747,6 +3803,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
@@ -172,6 +172,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -308,6 +320,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -616,6 +636,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -625,6 +652,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -707,6 +741,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1512,6 +1558,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1566,6 +1617,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2529,6 +2585,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc1_inn1_pa0_c: adc1_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp0_pa0_c: adc1_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp1_pa1_c: adc1_inp1_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -118,6 +130,18 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inn1_pa0_c: adc2_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pa0_c: adc2_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pa1_c: adc2_inp1_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -236,6 +260,18 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -318,7 +354,15 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pa0_c: analog_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pa1_c: analog_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -454,7 +498,15 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
@@ -1015,6 +1067,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_crs_pa0_c: eth_crs_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -1060,6 +1117,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_ref_clk_pa1_c: eth_ref_clk_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -1101,6 +1163,11 @@
 			/* ETH_RX_CLK */
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rx_clk_pa1_c: eth_rx_clk_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -1160,6 +1227,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1175,6 +1247,11 @@
 			/* ETH_TX_CLK */
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -1285,7 +1362,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
@@ -2066,6 +2155,10 @@
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
+			/omit-if-no-ref/ ltdc_r2_pa1_c: ltdc_r2_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
 			/omit-if-no-ref/ ltdc_r1_pa2: ltdc_r1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
@@ -2485,6 +2578,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ quadspi_bk1_io3_pa1_c: quadspi_bk1_io3_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -2697,6 +2795,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ sdmmc2_cmd_pa0_c: sdmmc2_cmd_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2796,6 +2900,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2879,6 +2988,11 @@
 			};
 
 			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
@@ -3254,7 +3368,15 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			/omit-if-no-ref/ tim2_ch1_pa0_c: tim2_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pa1_c: tim2_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
@@ -3394,11 +3516,23 @@
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
+			/omit-if-no-ref/ tim5_ch1_pa0_c: tim5_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
 			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1n_pa1_c: tim15_ch1n_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pa1_c: tim5_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
@@ -3598,6 +3732,12 @@
 				drive-open-drain;
 			};
 
+			/omit-if-no-ref/ usart2_cts_pa0_c: usart2_cts_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3681,6 +3821,11 @@
 				drive-push-pull;
 			};
 
+			/omit-if-no-ref/ usart2_de_pa1_c: usart2_de_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3751,6 +3896,12 @@
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			/omit-if-no-ref/ usart2_rts_pa1_c: usart2_rts_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -3865,6 +4016,10 @@
 			};
 
 			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ uart4_rx_pa1_c: uart4_rx_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
@@ -3989,6 +4144,11 @@
 			};
 
 			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ uart4_tx_pa0_c: uart4_tx_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
@@ -4163,7 +4323,15 @@
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
 			};
 
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 

--- a/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -380,6 +392,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -836,6 +856,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -845,6 +872,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -932,6 +966,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2027,6 +2073,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2091,6 +2142,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3195,6 +3251,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h753aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753aiix-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -408,6 +420,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -946,6 +966,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -955,6 +982,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1042,6 +1076,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2324,6 +2370,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2393,6 +2444,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3546,6 +3602,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h753bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753bitx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -408,6 +420,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -1105,6 +1125,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1114,6 +1141,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1213,6 +1247,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2717,6 +2763,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2796,6 +2847,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -4073,6 +4129,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h753iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iikx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -408,6 +420,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -993,6 +1013,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1002,6 +1029,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1101,6 +1135,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2477,6 +2523,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2551,6 +2602,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3747,6 +3803,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h753iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iitx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -408,6 +420,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -993,6 +1013,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1002,6 +1029,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1101,6 +1135,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2477,6 +2523,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2551,6 +2602,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3747,6 +3803,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h753vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vihx-pinctrl.dtsi
@@ -172,6 +172,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -308,6 +320,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -616,6 +636,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -625,6 +652,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -707,6 +741,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1512,6 +1558,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1566,6 +1617,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2529,6 +2585,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h753vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vitx-pinctrl.dtsi
@@ -172,6 +172,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/* Analog */
 
 			/omit-if-no-ref/ analog_pa0: analog_pa0 {
@@ -308,6 +320,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -616,6 +636,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -625,6 +652,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -707,6 +741,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1512,6 +1558,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1566,6 +1617,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2529,6 +2585,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h753xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753xihx-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc1_inn1_pa0_c: adc1_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp0_pa0_c: adc1_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp1_pa1_c: adc1_inp1_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -118,6 +130,18 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inn1_pa0_c: adc2_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pa0_c: adc2_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pa1_c: adc2_inp1_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -236,6 +260,18 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -318,7 +354,15 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pa0_c: analog_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pa1_c: analog_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -454,7 +498,15 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
@@ -1015,6 +1067,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_crs_pa0_c: eth_crs_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -1060,6 +1117,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_ref_clk_pa1_c: eth_ref_clk_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -1101,6 +1163,11 @@
 			/* ETH_RX_CLK */
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rx_clk_pa1_c: eth_rx_clk_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -1160,6 +1227,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1175,6 +1247,11 @@
 			/* ETH_TX_CLK */
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -1285,7 +1362,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
@@ -2066,6 +2155,10 @@
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
+			/omit-if-no-ref/ ltdc_r2_pa1_c: ltdc_r2_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
 			/omit-if-no-ref/ ltdc_r1_pa2: ltdc_r1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
@@ -2485,6 +2578,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ quadspi_bk1_io3_pa1_c: quadspi_bk1_io3_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -2697,6 +2795,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ sdmmc2_cmd_pa0_c: sdmmc2_cmd_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2796,6 +2900,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2879,6 +2988,11 @@
 			};
 
 			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
@@ -3254,7 +3368,15 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			/omit-if-no-ref/ tim2_ch1_pa0_c: tim2_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pa1_c: tim2_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
@@ -3394,11 +3516,23 @@
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
+			/omit-if-no-ref/ tim5_ch1_pa0_c: tim5_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
 			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1n_pa1_c: tim15_ch1n_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pa1_c: tim5_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
@@ -3598,6 +3732,12 @@
 				drive-open-drain;
 			};
 
+			/omit-if-no-ref/ usart2_cts_pa0_c: usart2_cts_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3681,6 +3821,11 @@
 				drive-push-pull;
 			};
 
+			/omit-if-no-ref/ usart2_de_pa1_c: usart2_de_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3751,6 +3896,12 @@
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			/omit-if-no-ref/ usart2_rts_pa1_c: usart2_rts_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -3865,6 +4016,10 @@
 			};
 
 			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ uart4_rx_pa1_c: uart4_rx_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
@@ -3989,6 +4144,11 @@
 			};
 
 			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ uart4_tx_pa0_c: uart4_tx_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
@@ -4163,7 +4323,15 @@
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
 			};
 
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 

--- a/dts/st/h7/stm32h753zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753zitx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -380,6 +392,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -836,6 +856,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -845,6 +872,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -932,6 +966,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2027,6 +2073,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2091,6 +2142,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3195,6 +3251,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h755bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755bitx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -408,6 +420,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -1033,6 +1053,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1042,6 +1069,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1141,6 +1175,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2561,6 +2607,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2640,6 +2691,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3917,6 +3973,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h755iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iikx-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc1_inn1_pa0_c: adc1_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp0_pa0_c: adc1_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp1_pa1_c: adc1_inp1_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -118,6 +130,18 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inn1_pa0_c: adc2_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pa0_c: adc2_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pa1_c: adc2_inp1_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -236,6 +260,18 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -318,7 +354,15 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pa0_c: analog_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pa1_c: analog_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -454,7 +498,15 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
@@ -855,6 +907,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_crs_pa0_c: eth_crs_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -900,6 +957,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_ref_clk_pa1_c: eth_ref_clk_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -941,6 +1003,11 @@
 			/* ETH_RX_CLK */
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rx_clk_pa1_c: eth_rx_clk_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -995,6 +1062,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1010,6 +1082,11 @@
 			/* ETH_TX_CLK */
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -1116,7 +1193,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
@@ -1828,6 +1917,10 @@
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
+			/omit-if-no-ref/ ltdc_r2_pa1_c: ltdc_r2_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
 			/omit-if-no-ref/ ltdc_r1_pa2: ltdc_r1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
@@ -2079,6 +2172,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ quadspi_bk1_io3_pa1_c: quadspi_bk1_io3_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -2291,6 +2389,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ sdmmc2_cmd_pa0_c: sdmmc2_cmd_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2390,6 +2494,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2463,6 +2572,11 @@
 			};
 
 			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
@@ -2782,7 +2896,15 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			/omit-if-no-ref/ tim2_ch1_pa0_c: tim2_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pa1_c: tim2_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
@@ -2922,11 +3044,23 @@
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
+			/omit-if-no-ref/ tim5_ch1_pa0_c: tim5_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
 			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1n_pa1_c: tim15_ch1n_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pa1_c: tim5_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
@@ -3074,6 +3208,12 @@
 				drive-open-drain;
 			};
 
+			/omit-if-no-ref/ usart2_cts_pa0_c: usart2_cts_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3157,6 +3297,11 @@
 				drive-push-pull;
 			};
 
+			/omit-if-no-ref/ usart2_de_pa1_c: usart2_de_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3227,6 +3372,12 @@
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			/omit-if-no-ref/ usart2_rts_pa1_c: usart2_rts_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -3344,6 +3495,10 @@
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
+			/omit-if-no-ref/ uart4_rx_pa1_c: uart4_rx_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+			};
+
 			/omit-if-no-ref/ uart4_rx_pa11: uart4_rx_pa11 {
 				pinmux = <STM32_PINMUX('A', 11, AF6)>;
 			};
@@ -3457,6 +3612,11 @@
 			};
 
 			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ uart4_tx_pa0_c: uart4_tx_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
@@ -3626,7 +3786,15 @@
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
 			};
 
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 

--- a/dts/st/h7/stm32h755iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iitx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -380,6 +392,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -864,6 +884,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -873,6 +900,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -960,6 +994,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2083,6 +2129,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2152,6 +2203,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3329,6 +3385,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h755xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755xihx-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc1_inn1_pa0_c: adc1_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp0_pa0_c: adc1_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp1_pa1_c: adc1_inp1_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -118,6 +130,18 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inn1_pa0_c: adc2_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pa0_c: adc2_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pa1_c: adc2_inp1_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -236,6 +260,18 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -318,7 +354,15 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pa0_c: analog_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pa1_c: analog_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -454,7 +498,15 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
@@ -1015,6 +1067,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_crs_pa0_c: eth_crs_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -1060,6 +1117,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_ref_clk_pa1_c: eth_ref_clk_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -1101,6 +1163,11 @@
 			/* ETH_RX_CLK */
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rx_clk_pa1_c: eth_rx_clk_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -1160,6 +1227,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1175,6 +1247,11 @@
 			/* ETH_TX_CLK */
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -1285,7 +1362,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
@@ -2066,6 +2155,10 @@
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
+			/omit-if-no-ref/ ltdc_r2_pa1_c: ltdc_r2_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
 			/omit-if-no-ref/ ltdc_r1_pa2: ltdc_r1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
@@ -2485,6 +2578,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ quadspi_bk1_io3_pa1_c: quadspi_bk1_io3_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -2697,6 +2795,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ sdmmc2_cmd_pa0_c: sdmmc2_cmd_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2796,6 +2900,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2879,6 +2988,11 @@
 			};
 
 			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
@@ -3254,7 +3368,15 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			/omit-if-no-ref/ tim2_ch1_pa0_c: tim2_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pa1_c: tim2_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
@@ -3394,11 +3516,23 @@
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
+			/omit-if-no-ref/ tim5_ch1_pa0_c: tim5_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
 			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1n_pa1_c: tim15_ch1n_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pa1_c: tim5_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
@@ -3598,6 +3732,12 @@
 				drive-open-drain;
 			};
 
+			/omit-if-no-ref/ usart2_cts_pa0_c: usart2_cts_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3681,6 +3821,11 @@
 				drive-push-pull;
 			};
 
+			/omit-if-no-ref/ usart2_de_pa1_c: usart2_de_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3751,6 +3896,12 @@
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			/omit-if-no-ref/ usart2_rts_pa1_c: usart2_rts_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -3865,6 +4016,10 @@
 			};
 
 			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ uart4_rx_pa1_c: uart4_rx_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
@@ -3989,6 +4144,11 @@
 			};
 
 			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ uart4_tx_pa0_c: uart4_tx_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
@@ -4163,7 +4323,15 @@
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
 			};
 
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 

--- a/dts/st/h7/stm32h755zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755zitx-pinctrl.dtsi
@@ -184,6 +184,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp8_pf6: adc3_inp8_pf6 {
 				pinmux = <STM32_PINMUX('F', 6, ANALOG)>;
 			};
@@ -348,6 +360,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -744,6 +764,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -753,6 +780,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -840,6 +874,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1833,6 +1879,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1897,6 +1948,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2995,6 +3051,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h757aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757aiix-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -380,6 +392,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -836,6 +856,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -845,6 +872,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -932,6 +966,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2027,6 +2073,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2091,6 +2142,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3195,6 +3251,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h757bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757bitx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -408,6 +420,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -997,6 +1017,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1006,6 +1033,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -1105,6 +1139,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2489,6 +2535,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2563,6 +2614,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3759,6 +3815,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h757iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757iitx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -380,6 +392,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -836,6 +856,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -845,6 +872,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -932,6 +966,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2027,6 +2073,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2091,6 +2142,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3195,6 +3251,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h757xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757xihx-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc1_inn1_pa0_c: adc1_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp0_pa0_c: adc1_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp1_pa1_c: adc1_inp1_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -118,6 +130,18 @@
 
 			/omit-if-no-ref/ adc1_inp6_pf12: adc1_inp6_pf12 {
 				pinmux = <STM32_PINMUX('F', 12, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inn1_pa0_c: adc2_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pa0_c: adc2_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pa1_c: adc2_inp1_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp14_pa2: adc2_inp14_pa2 {
@@ -236,6 +260,18 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -318,7 +354,15 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pa0_c: analog_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pa1_c: analog_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -454,7 +498,15 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
@@ -1015,6 +1067,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_crs_pa0_c: eth_crs_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ eth_crs_ph2: eth_crs_ph2 {
 				pinmux = <STM32_PINMUX('H', 2, AF11)>;
 				slew-rate = "very-high-speed";
@@ -1060,6 +1117,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_ref_clk_pa1_c: eth_ref_clk_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_RXD0 */
 
 			/omit-if-no-ref/ eth_rxd0_pc4: eth_rxd0_pc4 {
@@ -1101,6 +1163,11 @@
 			/* ETH_RX_CLK */
 
 			/omit-if-no-ref/ eth_rx_clk_pa1: eth_rx_clk_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_rx_clk_pa1_c: eth_rx_clk_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -1160,6 +1227,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -1175,6 +1247,11 @@
 			/* ETH_TX_CLK */
 
 			/omit-if-no-ref/ eth_tx_clk_pc3: eth_tx_clk_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -1285,7 +1362,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
@@ -2066,6 +2155,10 @@
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
+			/omit-if-no-ref/ ltdc_r2_pa1_c: ltdc_r2_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
 			/omit-if-no-ref/ ltdc_r1_pa2: ltdc_r1_pa2 {
 				pinmux = <STM32_PINMUX('A', 2, AF14)>;
 			};
@@ -2485,6 +2578,11 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ quadspi_bk1_io3_pa1_c: quadspi_bk1_io3_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ quadspi_clk_pb2: quadspi_clk_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF9)>;
 				slew-rate = "very-high-speed";
@@ -2697,6 +2795,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ sdmmc2_cmd_pa0_c: sdmmc2_cmd_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2796,6 +2900,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2879,6 +2988,11 @@
 			};
 
 			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
@@ -3254,7 +3368,15 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			/omit-if-no-ref/ tim2_ch1_pa0_c: tim2_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pa1_c: tim2_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
@@ -3394,11 +3516,23 @@
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
+			/omit-if-no-ref/ tim5_ch1_pa0_c: tim5_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
 			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1n_pa1_c: tim15_ch1n_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pa1_c: tim5_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
@@ -3598,6 +3732,12 @@
 				drive-open-drain;
 			};
 
+			/omit-if-no-ref/ usart2_cts_pa0_c: usart2_cts_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3681,6 +3821,11 @@
 				drive-push-pull;
 			};
 
+			/omit-if-no-ref/ usart2_de_pa1_c: usart2_de_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3751,6 +3896,12 @@
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			/omit-if-no-ref/ usart2_rts_pa1_c: usart2_rts_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -3865,6 +4016,10 @@
 			};
 
 			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ uart4_rx_pa1_c: uart4_rx_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
@@ -3989,6 +4144,11 @@
 			};
 
 			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ uart4_tx_pa0_c: uart4_tx_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
@@ -4163,7 +4323,15 @@
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
 			};
 
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 

--- a/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
@@ -196,6 +196,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc3_inn1_pc2_c: adc3_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp0_pc2_c: adc3_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc3_inp1_pc3_c: adc3_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc3_inp5_pf3: adc3_inp5_pf3 {
 				pinmux = <STM32_PINMUX('F', 3, ANALOG)>;
 			};
@@ -348,6 +360,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -737,6 +757,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* ETH_TXD2 */
+
+			/omit-if-no-ref/ eth_txd2_pc2_c: eth_txd2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* ETH_TXD3 */
 
 			/omit-if-no-ref/ eth_txd3_pb8: eth_txd3_pb8 {
@@ -746,6 +773,13 @@
 
 			/omit-if-no-ref/ eth_txd3_pe2: eth_txd3_pe2 {
 				pinmux = <STM32_PINMUX('E', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/* ETH_TX_CLK */
+
+			/omit-if-no-ref/ eth_tx_clk_pc3_c: eth_tx_clk_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -828,6 +862,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1775,6 +1821,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1829,6 +1880,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2814,6 +2870,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc1_inn1_pa0_c: adc1_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp0_pa0_c: adc1_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp1_pa1_c: adc1_inp1_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -164,11 +176,23 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc2_inn1_pc2_c: adc2_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pc2_c: adc2_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc2_inn12_pc3: adc2_inn12_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp13_pc3: adc2_inp13_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pc3_c: adc2_inp1_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
@@ -202,7 +226,15 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pa0_c: analog_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pa1_c: analog_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -338,7 +370,15 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
@@ -792,7 +832,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
@@ -1468,6 +1520,10 @@
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 			};
 
+			/omit-if-no-ref/ i2s6_ws_pa0_c: i2s6_ws_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF5)>;
+			};
+
 			/omit-if-no-ref/ i2s6_ws_pa4: i2s6_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF8)>;
 			};
@@ -1483,6 +1539,10 @@
 			/* LTDC */
 
 			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			/omit-if-no-ref/ ltdc_r2_pa1_c: ltdc_r2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
@@ -1794,6 +1854,16 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_dqs_pa1_c: octospim_p1_dqs_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1_c: octospim_p1_io3_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 				slew-rate = "very-high-speed";
@@ -1859,12 +1929,32 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 
 			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -2177,6 +2267,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ sdmmc2_cmd_pa0_c: sdmmc2_cmd_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2306,6 +2402,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2374,6 +2475,11 @@
 			};
 
 			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
@@ -2496,6 +2602,11 @@
 			};
 
 			/omit-if-no-ref/ spi6_nss_pa0: spi6_nss_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF5)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ spi6_nss_pa0_c: spi6_nss_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 				bias-pull-up;
 			};
@@ -2693,7 +2804,15 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			/omit-if-no-ref/ tim2_ch1_pa0_c: tim2_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pa1_c: tim2_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
@@ -2825,11 +2944,23 @@
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
+			/omit-if-no-ref/ tim5_ch1_pa0_c: tim5_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
 			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1n_pa1_c: tim15_ch1n_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pa1_c: tim5_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
@@ -2983,6 +3114,12 @@
 				drive-open-drain;
 			};
 
+			/omit-if-no-ref/ usart2_cts_pa0_c: usart2_cts_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3077,6 +3214,11 @@
 				drive-push-pull;
 			};
 
+			/omit-if-no-ref/ usart2_de_pa1_c: usart2_de_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3158,6 +3300,12 @@
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			/omit-if-no-ref/ usart2_rts_pa1_c: usart2_rts_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -3286,6 +3434,10 @@
 			};
 
 			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ uart4_rx_pa1_c: uart4_rx_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
@@ -3420,6 +3572,11 @@
 			};
 
 			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ uart4_tx_pa0_c: uart4_tx_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
@@ -3577,7 +3734,15 @@
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
 			};
 
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 

--- a/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
@@ -140,6 +140,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc2_inn1_pc2_c: adc2_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pc2_c: adc2_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pc3_c: adc2_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -300,6 +312,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -822,6 +842,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2066,6 +2098,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2513,6 +2565,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2587,6 +2644,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3846,6 +3908,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc1_inn1_pa0_c: adc1_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp0_pa0_c: adc1_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp1_pa1_c: adc1_inp1_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -164,11 +176,23 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc2_inn1_pc2_c: adc2_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pc2_c: adc2_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc2_inn12_pc3: adc2_inn12_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp13_pc3: adc2_inp13_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pc3_c: adc2_inp1_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
@@ -202,7 +226,15 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pa0_c: analog_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pa1_c: analog_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -338,7 +370,15 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
@@ -820,7 +860,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
@@ -1556,6 +1608,10 @@
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 			};
 
+			/omit-if-no-ref/ i2s6_ws_pa0_c: i2s6_ws_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF5)>;
+			};
+
 			/omit-if-no-ref/ i2s6_ws_pa4: i2s6_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF8)>;
 			};
@@ -1571,6 +1627,10 @@
 			/* LTDC */
 
 			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			/omit-if-no-ref/ ltdc_r2_pa1_c: ltdc_r2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
@@ -1902,6 +1962,16 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_dqs_pa1_c: octospim_p1_dqs_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1_c: octospim_p1_io3_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 				slew-rate = "very-high-speed";
@@ -1967,12 +2037,32 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 
 			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -2285,6 +2375,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ sdmmc2_cmd_pa0_c: sdmmc2_cmd_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2414,6 +2510,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2487,6 +2588,11 @@
 			};
 
 			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
@@ -2614,6 +2720,11 @@
 			};
 
 			/omit-if-no-ref/ spi6_nss_pa0: spi6_nss_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF5)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ spi6_nss_pa0_c: spi6_nss_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 				bias-pull-up;
 			};
@@ -2817,7 +2928,15 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			/omit-if-no-ref/ tim2_ch1_pa0_c: tim2_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pa1_c: tim2_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
@@ -2957,11 +3076,23 @@
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
+			/omit-if-no-ref/ tim5_ch1_pa0_c: tim5_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
 			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1n_pa1_c: tim15_ch1n_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pa1_c: tim5_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
@@ -3119,6 +3250,12 @@
 				drive-open-drain;
 			};
 
+			/omit-if-no-ref/ usart2_cts_pa0_c: usart2_cts_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3213,6 +3350,11 @@
 				drive-push-pull;
 			};
 
+			/omit-if-no-ref/ usart2_de_pa1_c: usart2_de_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3294,6 +3436,12 @@
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			/omit-if-no-ref/ usart2_rts_pa1_c: usart2_rts_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -3422,6 +3570,10 @@
 			};
 
 			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ uart4_rx_pa1_c: uart4_rx_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
@@ -3556,6 +3708,11 @@
 			};
 
 			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ uart4_tx_pa0_c: uart4_tx_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
@@ -3713,7 +3870,15 @@
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
 			};
 
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 

--- a/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
@@ -140,6 +140,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc2_inn1_pc2_c: adc2_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pc2_c: adc2_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pc3_c: adc2_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -300,6 +312,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -822,6 +842,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2066,6 +2098,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2513,6 +2565,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2587,6 +2644,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3846,6 +3908,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
@@ -140,6 +140,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc2_inn1_pc2_c: adc2_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pc2_c: adc2_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pc3_c: adc2_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -300,6 +312,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -734,6 +754,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1735,6 +1767,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2157,6 +2209,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2226,6 +2283,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3466,6 +3528,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc1_inn1_pa0_c: adc1_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp0_pa0_c: adc1_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp1_pa1_c: adc1_inp1_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -164,6 +176,18 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc2_inn1_pc2_c: adc2_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pc2_c: adc2_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pc3_c: adc2_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc2_inn12_pc3: adc2_inn12_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
@@ -202,7 +226,15 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pa0_c: analog_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pa1_c: analog_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -336,6 +368,14 @@
 
 			/omit-if-no-ref/ analog_pc2: analog_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
@@ -980,6 +1020,18 @@
 
 			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1789,6 +1841,10 @@
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 			};
 
+			/omit-if-no-ref/ i2s6_ws_pa0_c: i2s6_ws_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF5)>;
+			};
+
 			/omit-if-no-ref/ i2s6_ws_pa4: i2s6_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF8)>;
 			};
@@ -1804,6 +1860,10 @@
 			/* LTDC */
 
 			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			/omit-if-no-ref/ ltdc_r2_pa1_c: ltdc_r2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
@@ -2303,6 +2363,16 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_dqs_pa1_c: octospim_p1_dqs_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1_c: octospim_p1_io3_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 				slew-rate = "very-high-speed";
@@ -2365,6 +2435,26 @@
 
 			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -2746,6 +2836,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ sdmmc2_cmd_pa0_c: sdmmc2_cmd_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2875,6 +2971,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2954,6 +3055,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3105,6 +3211,11 @@
 			};
 
 			/omit-if-no-ref/ spi6_nss_pa0: spi6_nss_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF5)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ spi6_nss_pa0_c: spi6_nss_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 				bias-pull-up;
 			};
@@ -3344,7 +3455,15 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			/omit-if-no-ref/ tim2_ch1_pa0_c: tim2_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pa1_c: tim2_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
@@ -3484,11 +3603,23 @@
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
+			/omit-if-no-ref/ tim5_ch1_pa0_c: tim5_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
 			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1n_pa1_c: tim15_ch1n_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pa1_c: tim5_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
@@ -3698,6 +3829,12 @@
 				drive-open-drain;
 			};
 
+			/omit-if-no-ref/ usart2_cts_pa0_c: usart2_cts_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3798,6 +3935,11 @@
 				drive-push-pull;
 			};
 
+			/omit-if-no-ref/ usart2_de_pa1_c: usart2_de_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3884,6 +4026,12 @@
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			/omit-if-no-ref/ usart2_rts_pa1_c: usart2_rts_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -4018,6 +4166,10 @@
 			};
 
 			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ uart4_rx_pa1_c: uart4_rx_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
@@ -4160,6 +4312,11 @@
 			};
 
 			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ uart4_tx_pa0_c: uart4_tx_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
@@ -4320,6 +4477,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {

--- a/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
@@ -140,6 +140,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc2_inn1_pc2_c: adc2_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pc2_c: adc2_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pc3_c: adc2_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -300,6 +312,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -934,6 +954,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2306,6 +2338,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2798,6 +2850,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2877,6 +2934,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -4234,6 +4296,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h7a3v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)hx-pinctrl.dtsi
@@ -128,6 +128,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc2_inn1_pc2_c: adc2_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pc2_c: adc2_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pc3_c: adc2_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -276,6 +288,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -554,6 +574,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1279,6 +1311,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1545,6 +1597,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1599,6 +1656,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2590,6 +2652,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h7a3v(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)hxq-pinctrl.dtsi
@@ -128,6 +128,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc2_inn1_pc2_c: adc2_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pc2_c: adc2_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pc3_c: adc2_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -276,6 +288,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -534,6 +554,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1209,6 +1241,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1470,6 +1522,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1519,6 +1576,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2478,6 +2540,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h7a3v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)tx-pinctrl.dtsi
@@ -128,6 +128,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc2_inn1_pc2_c: adc2_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pc2_c: adc2_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pc3_c: adc2_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -276,6 +288,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -554,6 +574,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1279,6 +1311,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1545,6 +1597,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1599,6 +1656,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2590,6 +2652,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h7a3v(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)txq-pinctrl.dtsi
@@ -128,6 +128,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc2_inn1_pc2_c: adc2_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pc2_c: adc2_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pc3_c: adc2_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -276,6 +288,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -506,6 +526,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1127,6 +1159,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1356,6 +1408,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1400,6 +1457,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2302,6 +2364,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
@@ -140,6 +140,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc2_inn1_pc2_c: adc2_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pc2_c: adc2_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pc3_c: adc2_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -300,6 +312,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -706,6 +726,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1679,6 +1711,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2101,6 +2153,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2165,6 +2222,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3332,6 +3394,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h7a3z(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)txq-pinctrl.dtsi
@@ -132,6 +132,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc2_inn1_pc2_c: adc2_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pc2_c: adc2_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pc3_c: adc2_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -288,6 +300,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -634,6 +654,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1505,6 +1537,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1877,6 +1929,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1941,6 +1998,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3093,6 +3155,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc1_inn1_pa0_c: adc1_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp0_pa0_c: adc1_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp1_pa1_c: adc1_inp1_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -164,11 +176,23 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc2_inn1_pc2_c: adc2_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pc2_c: adc2_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc2_inn12_pc3: adc2_inn12_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp13_pc3: adc2_inp13_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pc3_c: adc2_inp1_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
@@ -202,7 +226,15 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pa0_c: analog_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pa1_c: analog_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -338,7 +370,15 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
@@ -792,7 +832,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
@@ -1468,6 +1520,10 @@
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 			};
 
+			/omit-if-no-ref/ i2s6_ws_pa0_c: i2s6_ws_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF5)>;
+			};
+
 			/omit-if-no-ref/ i2s6_ws_pa4: i2s6_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF8)>;
 			};
@@ -1483,6 +1539,10 @@
 			/* LTDC */
 
 			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			/omit-if-no-ref/ ltdc_r2_pa1_c: ltdc_r2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
@@ -1794,6 +1854,16 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_dqs_pa1_c: octospim_p1_dqs_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1_c: octospim_p1_io3_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 				slew-rate = "very-high-speed";
@@ -1859,12 +1929,32 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 
 			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -2177,6 +2267,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ sdmmc2_cmd_pa0_c: sdmmc2_cmd_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2306,6 +2402,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2374,6 +2475,11 @@
 			};
 
 			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
@@ -2496,6 +2602,11 @@
 			};
 
 			/omit-if-no-ref/ spi6_nss_pa0: spi6_nss_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF5)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ spi6_nss_pa0_c: spi6_nss_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 				bias-pull-up;
 			};
@@ -2693,7 +2804,15 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			/omit-if-no-ref/ tim2_ch1_pa0_c: tim2_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pa1_c: tim2_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
@@ -2825,11 +2944,23 @@
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
+			/omit-if-no-ref/ tim5_ch1_pa0_c: tim5_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
 			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1n_pa1_c: tim15_ch1n_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pa1_c: tim5_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
@@ -2983,6 +3114,12 @@
 				drive-open-drain;
 			};
 
+			/omit-if-no-ref/ usart2_cts_pa0_c: usart2_cts_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3077,6 +3214,11 @@
 				drive-push-pull;
 			};
 
+			/omit-if-no-ref/ usart2_de_pa1_c: usart2_de_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3158,6 +3300,12 @@
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			/omit-if-no-ref/ usart2_rts_pa1_c: usart2_rts_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -3286,6 +3434,10 @@
 			};
 
 			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ uart4_rx_pa1_c: uart4_rx_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
@@ -3420,6 +3572,11 @@
 			};
 
 			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ uart4_tx_pa0_c: uart4_tx_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
@@ -3577,7 +3734,15 @@
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
 			};
 
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 

--- a/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc1_inn1_pa0_c: adc1_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp0_pa0_c: adc1_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp1_pa1_c: adc1_inp1_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -164,11 +176,23 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc2_inn1_pc2_c: adc2_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pc2_c: adc2_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc2_inn12_pc3: adc2_inn12_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp13_pc3: adc2_inp13_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pc3_c: adc2_inp1_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
@@ -202,7 +226,15 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pa0_c: analog_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pa1_c: analog_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -338,7 +370,15 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
@@ -820,7 +860,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
@@ -1556,6 +1608,10 @@
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 			};
 
+			/omit-if-no-ref/ i2s6_ws_pa0_c: i2s6_ws_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF5)>;
+			};
+
 			/omit-if-no-ref/ i2s6_ws_pa4: i2s6_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF8)>;
 			};
@@ -1571,6 +1627,10 @@
 			/* LTDC */
 
 			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			/omit-if-no-ref/ ltdc_r2_pa1_c: ltdc_r2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
@@ -1902,6 +1962,16 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_dqs_pa1_c: octospim_p1_dqs_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1_c: octospim_p1_io3_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 				slew-rate = "very-high-speed";
@@ -1967,12 +2037,32 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 
 			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -2285,6 +2375,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ sdmmc2_cmd_pa0_c: sdmmc2_cmd_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2414,6 +2510,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2487,6 +2588,11 @@
 			};
 
 			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
@@ -2614,6 +2720,11 @@
 			};
 
 			/omit-if-no-ref/ spi6_nss_pa0: spi6_nss_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF5)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ spi6_nss_pa0_c: spi6_nss_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 				bias-pull-up;
 			};
@@ -2817,7 +2928,15 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			/omit-if-no-ref/ tim2_ch1_pa0_c: tim2_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pa1_c: tim2_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
@@ -2957,11 +3076,23 @@
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
+			/omit-if-no-ref/ tim5_ch1_pa0_c: tim5_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
 			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1n_pa1_c: tim15_ch1n_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pa1_c: tim5_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
@@ -3119,6 +3250,12 @@
 				drive-open-drain;
 			};
 
+			/omit-if-no-ref/ usart2_cts_pa0_c: usart2_cts_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3213,6 +3350,11 @@
 				drive-push-pull;
 			};
 
+			/omit-if-no-ref/ usart2_de_pa1_c: usart2_de_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3294,6 +3436,12 @@
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			/omit-if-no-ref/ usart2_rts_pa1_c: usart2_rts_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -3422,6 +3570,10 @@
 			};
 
 			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ uart4_rx_pa1_c: uart4_rx_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
@@ -3556,6 +3708,11 @@
 			};
 
 			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ uart4_tx_pa0_c: uart4_tx_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
@@ -3713,7 +3870,15 @@
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
 			};
 
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 

--- a/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
@@ -140,6 +140,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc2_inn1_pc2_c: adc2_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pc2_c: adc2_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pc3_c: adc2_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -300,6 +312,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -822,6 +842,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2066,6 +2098,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2513,6 +2565,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2587,6 +2644,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3846,6 +3908,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h7b0vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0vbtx-pinctrl.dtsi
@@ -128,6 +128,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc2_inn1_pc2_c: adc2_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pc2_c: adc2_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pc3_c: adc2_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -276,6 +288,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -554,6 +574,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1279,6 +1311,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1545,6 +1597,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1599,6 +1656,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2590,6 +2652,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
@@ -140,6 +140,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc2_inn1_pc2_c: adc2_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pc2_c: adc2_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pc3_c: adc2_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -300,6 +312,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -706,6 +726,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1679,6 +1711,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2101,6 +2153,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2165,6 +2222,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3332,6 +3394,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc1_inn1_pa0_c: adc1_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp0_pa0_c: adc1_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp1_pa1_c: adc1_inp1_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -164,11 +176,23 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc2_inn1_pc2_c: adc2_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pc2_c: adc2_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc2_inn12_pc3: adc2_inn12_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp13_pc3: adc2_inp13_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pc3_c: adc2_inp1_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
@@ -202,7 +226,15 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pa0_c: analog_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pa1_c: analog_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -338,7 +370,15 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
@@ -792,7 +832,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
@@ -1468,6 +1520,10 @@
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 			};
 
+			/omit-if-no-ref/ i2s6_ws_pa0_c: i2s6_ws_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF5)>;
+			};
+
 			/omit-if-no-ref/ i2s6_ws_pa4: i2s6_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF8)>;
 			};
@@ -1483,6 +1539,10 @@
 			/* LTDC */
 
 			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			/omit-if-no-ref/ ltdc_r2_pa1_c: ltdc_r2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
@@ -1794,6 +1854,16 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_dqs_pa1_c: octospim_p1_dqs_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1_c: octospim_p1_io3_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 				slew-rate = "very-high-speed";
@@ -1859,12 +1929,32 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 
 			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -2177,6 +2267,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ sdmmc2_cmd_pa0_c: sdmmc2_cmd_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2306,6 +2402,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2374,6 +2475,11 @@
 			};
 
 			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
@@ -2496,6 +2602,11 @@
 			};
 
 			/omit-if-no-ref/ spi6_nss_pa0: spi6_nss_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF5)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ spi6_nss_pa0_c: spi6_nss_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 				bias-pull-up;
 			};
@@ -2693,7 +2804,15 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			/omit-if-no-ref/ tim2_ch1_pa0_c: tim2_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pa1_c: tim2_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
@@ -2825,11 +2944,23 @@
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
+			/omit-if-no-ref/ tim5_ch1_pa0_c: tim5_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
 			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1n_pa1_c: tim15_ch1n_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pa1_c: tim5_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
@@ -2983,6 +3114,12 @@
 				drive-open-drain;
 			};
 
+			/omit-if-no-ref/ usart2_cts_pa0_c: usart2_cts_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3077,6 +3214,11 @@
 				drive-push-pull;
 			};
 
+			/omit-if-no-ref/ usart2_de_pa1_c: usart2_de_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3158,6 +3300,12 @@
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			/omit-if-no-ref/ usart2_rts_pa1_c: usart2_rts_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -3286,6 +3434,10 @@
 			};
 
 			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ uart4_rx_pa1_c: uart4_rx_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
@@ -3420,6 +3572,11 @@
 			};
 
 			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ uart4_tx_pa0_c: uart4_tx_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
@@ -3577,7 +3734,15 @@
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
 			};
 
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 

--- a/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
@@ -140,6 +140,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc2_inn1_pc2_c: adc2_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pc2_c: adc2_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pc3_c: adc2_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -300,6 +312,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -822,6 +842,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2066,6 +2098,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2513,6 +2565,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2587,6 +2644,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3846,6 +3908,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc1_inn1_pa0_c: adc1_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp0_pa0_c: adc1_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp1_pa1_c: adc1_inp1_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -164,11 +176,23 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc2_inn1_pc2_c: adc2_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pc2_c: adc2_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc2_inn12_pc3: adc2_inn12_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc2_inp13_pc3: adc2_inp13_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pc3_c: adc2_inp1_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
@@ -202,7 +226,15 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pa0_c: analog_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pa1_c: analog_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -338,7 +370,15 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
@@ -820,7 +860,19 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
@@ -1556,6 +1608,10 @@
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 			};
 
+			/omit-if-no-ref/ i2s6_ws_pa0_c: i2s6_ws_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF5)>;
+			};
+
 			/omit-if-no-ref/ i2s6_ws_pa4: i2s6_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF8)>;
 			};
@@ -1571,6 +1627,10 @@
 			/* LTDC */
 
 			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			/omit-if-no-ref/ ltdc_r2_pa1_c: ltdc_r2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
@@ -1902,6 +1962,16 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_dqs_pa1_c: octospim_p1_dqs_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1_c: octospim_p1_io3_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 				slew-rate = "very-high-speed";
@@ -1967,12 +2037,32 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_io0_pc3: octospim_p1_io0_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF9)>;
 				slew-rate = "very-high-speed";
 			};
 
 			/omit-if-no-ref/ octospim_p1_io6_pc3: octospim_p1_io6_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
@@ -2285,6 +2375,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ sdmmc2_cmd_pa0_c: sdmmc2_cmd_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2414,6 +2510,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2487,6 +2588,11 @@
 			};
 
 			/omit-if-no-ref/ spi2_mosi_pc3: spi2_mosi_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
@@ -2614,6 +2720,11 @@
 			};
 
 			/omit-if-no-ref/ spi6_nss_pa0: spi6_nss_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF5)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ spi6_nss_pa0_c: spi6_nss_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 				bias-pull-up;
 			};
@@ -2817,7 +2928,15 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			/omit-if-no-ref/ tim2_ch1_pa0_c: tim2_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pa1_c: tim2_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
@@ -2957,11 +3076,23 @@
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
+			/omit-if-no-ref/ tim5_ch1_pa0_c: tim5_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
 			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1n_pa1_c: tim15_ch1n_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pa1_c: tim5_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
@@ -3119,6 +3250,12 @@
 				drive-open-drain;
 			};
 
+			/omit-if-no-ref/ usart2_cts_pa0_c: usart2_cts_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3213,6 +3350,11 @@
 				drive-push-pull;
 			};
 
+			/omit-if-no-ref/ usart2_de_pa1_c: usart2_de_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3294,6 +3436,12 @@
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			/omit-if-no-ref/ usart2_rts_pa1_c: usart2_rts_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -3422,6 +3570,10 @@
 			};
 
 			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ uart4_rx_pa1_c: uart4_rx_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
@@ -3556,6 +3708,11 @@
 			};
 
 			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ uart4_tx_pa0_c: uart4_tx_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
@@ -3713,7 +3870,15 @@
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
 			};
 
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 

--- a/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
@@ -140,6 +140,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc2_inn1_pc2_c: adc2_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pc2_c: adc2_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pc3_c: adc2_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -300,6 +312,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -822,6 +842,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2066,6 +2098,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2513,6 +2565,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2587,6 +2644,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3846,6 +3908,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
@@ -140,6 +140,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc2_inn1_pc2_c: adc2_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pc2_c: adc2_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pc3_c: adc2_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -300,6 +312,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -734,6 +754,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1735,6 +1767,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2157,6 +2209,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2226,6 +2283,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3466,6 +3528,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
@@ -16,11 +16,23 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc1_inn1_pa0_c: adc1_inn1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp0_pa0_c: adc1_inp0_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc1_inn16_pa1: adc1_inn16_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ adc1_inp17_pa1: adc1_inp17_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc1_inp1_pa1_c: adc1_inp1_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -164,6 +176,18 @@
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc2_inn1_pc2_c: adc2_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pc2_c: adc2_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pc3_c: adc2_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc2_inn12_pc3: adc2_inn12_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
@@ -202,7 +226,15 @@
 				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ analog_pa0_c: analog_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ analog_pa1: analog_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pa1_c: analog_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, ANALOG)>;
 			};
 
@@ -336,6 +368,14 @@
 
 			/omit-if-no-ref/ analog_pc2: analog_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc3: analog_pc3 {
@@ -980,6 +1020,18 @@
 
 			/omit-if-no-ref/ fmc_sdne0_pc2: fmc_sdne0_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1789,6 +1841,10 @@
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 			};
 
+			/omit-if-no-ref/ i2s6_ws_pa0_c: i2s6_ws_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF5)>;
+			};
+
 			/omit-if-no-ref/ i2s6_ws_pa4: i2s6_ws_pa4 {
 				pinmux = <STM32_PINMUX('A', 4, AF8)>;
 			};
@@ -1804,6 +1860,10 @@
 			/* LTDC */
 
 			/omit-if-no-ref/ ltdc_r2_pa1: ltdc_r2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF14)>;
+			};
+
+			/omit-if-no-ref/ ltdc_r2_pa1_c: ltdc_r2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF14)>;
 			};
 
@@ -2303,6 +2363,16 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_dqs_pa1_c: octospim_p1_dqs_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io3_pa1_c: octospim_p1_io3_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_clk_pa3: octospim_p1_clk_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF3)>;
 				slew-rate = "very-high-speed";
@@ -2365,6 +2435,26 @@
 
 			/omit-if-no-ref/ octospim_p1_io5_pc2: octospim_p1_io5_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
 				slew-rate = "very-high-speed";
 			};
 
@@ -2746,6 +2836,12 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ sdmmc2_cmd_pa0_c: sdmmc2_cmd_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ sdmmc2_d2_pb3: sdmmc2_d2_pb3 {
 				pinmux = <STM32_PINMUX('B', 3, AF9)>;
 				bias-pull-up;
@@ -2875,6 +2971,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2954,6 +3055,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3105,6 +3211,11 @@
 			};
 
 			/omit-if-no-ref/ spi6_nss_pa0: spi6_nss_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF5)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ spi6_nss_pa0_c: spi6_nss_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF5)>;
 				bias-pull-up;
 			};
@@ -3344,7 +3455,15 @@
 				pinmux = <STM32_PINMUX('A', 0, AF1)>;
 			};
 
+			/omit-if-no-ref/ tim2_ch1_pa0_c: tim2_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF1)>;
+			};
+
 			/omit-if-no-ref/ tim2_ch2_pa1: tim2_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pa1_c: tim2_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF1)>;
 			};
 
@@ -3484,11 +3603,23 @@
 				pinmux = <STM32_PINMUX('A', 0, AF2)>;
 			};
 
+			/omit-if-no-ref/ tim5_ch1_pa0_c: tim5_ch1_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF2)>;
+			};
+
 			/omit-if-no-ref/ tim15_ch1n_pa1: tim15_ch1n_pa1 {
 				pinmux = <STM32_PINMUX('A', 1, AF4)>;
 			};
 
 			/omit-if-no-ref/ tim5_ch2_pa1: tim5_ch2_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF2)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1n_pa1_c: tim15_ch1n_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF4)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pa1_c: tim5_ch2_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF2)>;
 			};
 
@@ -3698,6 +3829,12 @@
 				drive-open-drain;
 			};
 
+			/omit-if-no-ref/ usart2_cts_pa0_c: usart2_cts_pa0_c {
+				pinmux = <STM32_PINMUX('A', 0, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
 			/omit-if-no-ref/ usart2_cts_pd3: usart2_cts_pd3 {
 				pinmux = <STM32_PINMUX('D', 3, AF7)>;
 				bias-pull-up;
@@ -3798,6 +3935,11 @@
 				drive-push-pull;
 			};
 
+			/omit-if-no-ref/ usart2_de_pa1_c: usart2_de_pa1_c {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				drive-push-pull;
+			};
+
 			/omit-if-no-ref/ usart2_de_pd4: usart2_de_pd4 {
 				pinmux = <STM32_PINMUX('D', 4, AF7)>;
 				drive-push-pull;
@@ -3884,6 +4026,12 @@
 			};
 
 			/omit-if-no-ref/ usart2_rts_pa1: usart2_rts_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF7)>;
+				bias-pull-up;
+				drive-open-drain;
+			};
+
+			/omit-if-no-ref/ usart2_rts_pa1_c: usart2_rts_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF7)>;
 				bias-pull-up;
 				drive-open-drain;
@@ -4018,6 +4166,10 @@
 			};
 
 			/omit-if-no-ref/ uart4_rx_pa1: uart4_rx_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF8)>;
+			};
+
+			/omit-if-no-ref/ uart4_rx_pa1_c: uart4_rx_pa1_c {
 				pinmux = <STM32_PINMUX('A', 1, AF8)>;
 			};
 
@@ -4160,6 +4312,11 @@
 			};
 
 			/omit-if-no-ref/ uart4_tx_pa0: uart4_tx_pa0 {
+				pinmux = <STM32_PINMUX('A', 0, AF8)>;
+				bias-pull-up;
+			};
+
+			/omit-if-no-ref/ uart4_tx_pa0_c: uart4_tx_pa0_c {
 				pinmux = <STM32_PINMUX('A', 0, AF8)>;
 				bias-pull-up;
 			};
@@ -4320,6 +4477,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {

--- a/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
@@ -140,6 +140,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc2_inn1_pc2_c: adc2_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pc2_c: adc2_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pc3_c: adc2_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -300,6 +312,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -934,6 +954,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -2306,6 +2338,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2798,6 +2850,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi2_miso_pi2: spi2_miso_pi2 {
 				pinmux = <STM32_PINMUX('I', 2, AF5)>;
 				bias-pull-down;
@@ -2877,6 +2934,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -4234,6 +4296,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {

--- a/dts/st/h7/stm32h7b3vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vihx-pinctrl.dtsi
@@ -128,6 +128,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc2_inn1_pc2_c: adc2_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pc2_c: adc2_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pc3_c: adc2_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -276,6 +288,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -554,6 +574,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1279,6 +1311,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1545,6 +1597,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1599,6 +1656,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2590,6 +2652,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h7b3vihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vihxq-pinctrl.dtsi
@@ -128,6 +128,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc2_inn1_pc2_c: adc2_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pc2_c: adc2_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pc3_c: adc2_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -276,6 +288,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -534,6 +554,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1209,6 +1241,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1470,6 +1522,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1519,6 +1576,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2478,6 +2540,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h7b3vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vitx-pinctrl.dtsi
@@ -128,6 +128,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc2_inn1_pc2_c: adc2_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pc2_c: adc2_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pc3_c: adc2_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -276,6 +288,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -554,6 +574,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1279,6 +1311,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1545,6 +1597,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1599,6 +1656,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2590,6 +2652,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h7b3vitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vitxq-pinctrl.dtsi
@@ -128,6 +128,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc2_inn1_pc2_c: adc2_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pc2_c: adc2_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pc3_c: adc2_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -276,6 +288,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -506,6 +526,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1127,6 +1159,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1356,6 +1408,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1400,6 +1457,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -2302,6 +2364,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
@@ -140,6 +140,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc2_inn1_pc2_c: adc2_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pc2_c: adc2_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pc3_c: adc2_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -300,6 +312,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -706,6 +726,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1679,6 +1711,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -2101,6 +2153,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -2165,6 +2222,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3332,6 +3394,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/dts/st/h7/stm32h7b3zitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitxq-pinctrl.dtsi
@@ -132,6 +132,18 @@
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
 			};
 
+			/omit-if-no-ref/ adc2_inn1_pc2_c: adc2_inn1_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp0_pc2_c: adc2_inp0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ adc2_inp1_pc3_c: adc2_inp1_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+			};
+
 			/omit-if-no-ref/ adc2_inp4_pc4: adc2_inp4_pc4 {
 				pinmux = <STM32_PINMUX('C', 4, ANALOG)>;
 			};
@@ -288,6 +300,14 @@
 
 			/omit-if-no-ref/ analog_pc1: analog_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc2_c: analog_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+			};
+
+			/omit-if-no-ref/ analog_pc3_c: analog_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
 			};
 
 			/omit-if-no-ref/ analog_pc4: analog_pc4 {
@@ -634,6 +654,18 @@
 
 			/omit-if-no-ref/ fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdne0_pc2_c: fmc_sdne0_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ fmc_sdcke0_pc3_c: fmc_sdcke0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
 				bias-pull-up;
 				slew-rate = "very-high-speed";
 			};
@@ -1505,6 +1537,26 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/omit-if-no-ref/ octospim_p1_io2_pc2_c: octospim_p1_io2_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io5_pc2_c: octospim_p1_io5_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io0_pc3_c: octospim_p1_io0_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ octospim_p1_io6_pc3_c: octospim_p1_io6_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/omit-if-no-ref/ octospim_p1_dqs_pc5: octospim_p1_dqs_pc5 {
 				pinmux = <STM32_PINMUX('C', 5, AF10)>;
 				slew-rate = "very-high-speed";
@@ -1877,6 +1929,11 @@
 				bias-pull-down;
 			};
 
+			/omit-if-no-ref/ spi2_miso_pc2_c: spi2_miso_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				bias-pull-down;
+			};
+
 			/omit-if-no-ref/ spi3_miso_pb4: spi3_miso_pb4 {
 				pinmux = <STM32_PINMUX('B', 4, AF6)>;
 				bias-pull-down;
@@ -1941,6 +1998,11 @@
 
 			/omit-if-no-ref/ spi2_mosi_pc1: spi2_mosi_pc1 {
 				pinmux = <STM32_PINMUX('C', 1, AF5)>;
+				bias-pull-down;
+			};
+
+			/omit-if-no-ref/ spi2_mosi_pc3_c: spi2_mosi_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF5)>;
 				bias-pull-down;
 			};
 
@@ -3093,6 +3155,14 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+			};
+
+			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
 			};
 
 		};

--- a/scripts/genpinctrl/genpinctrl.py
+++ b/scripts/genpinctrl/genpinctrl.py
@@ -69,6 +69,11 @@ PINCTRL_ADDRESSES = {
 }
 """pinctrl peripheral addresses for each family."""
 
+PIN_MODS = [
+    "_C",  # Pins with analog switch (H7)
+]
+"""Allowed pin modifiers"""
+
 
 def validate_config_entry(entry, family):
     """Validates pin configuration entry.
@@ -338,6 +343,7 @@ def get_mcu_signals(data_path, gpio_ip_afs):
                         {
                             "port": "a",
                             "number": 0,
+                            "mod": "",
                             "signals" : [
                                 {
                                     "name": "ADC1_IN5",
@@ -416,17 +422,14 @@ def get_mcu_signals(data_path, gpio_ip_afs):
             if family == "STM32G0" and pin_name in ("PA9", "PA10"):
                 continue
 
-            # skip pins with analog switch (Pxy_C) (not supported)
-            if pin_name.endswith("_C"):
-                continue
-
-            # obtain pin port (A, B, ...) and number (0, 1, ...)
-            m = re.search(r"^P([A-Z])(\d+).*$", pin_name)
+            # obtain pin port (A, B, ...), number (0, 1, ...) and modifier
+            m = re.search(r"^P([A-Z])(\d+)(.*)$", pin_name)
             if not m:
                 continue
 
             pin_port = m.group(1).lower()
             pin_number = int(m.group(2))
+            pin_mod = m.group(3).lower() if m.group(3) in PIN_MODS else ""
 
             if pin_name not in gpio_ip:
                 continue
@@ -438,6 +441,7 @@ def get_mcu_signals(data_path, gpio_ip_afs):
                 {
                     "port": pin_port,
                     "pin": pin_number,
+                    "mod": pin_mod,
                     "signals": pin_signals,
                 }
             )
@@ -552,6 +556,7 @@ def main(data_path, output):
                             {
                                 "port": pin["port"],
                                 "pin": pin["pin"],
+                                "mod": pin["mod"],
                                 "signal": signal["name"].lower(),
                                 "af": signal["af"],
                                 "mode": signal["mode"],

--- a/scripts/genpinctrl/pinctrl-template.j2
+++ b/scripts/genpinctrl/pinctrl-template.j2
@@ -20,7 +20,7 @@
 			{% for entry in group_entries %}
 			{% set variant = "_" + entry["variant"] if entry["variant"] else "" %}
 			{% set remap = (entry["af"] | format_remap_name) if family == "STM32F1" else "" %}
-			{% set name = "%s%s%s_p%s%d" | format(entry["signal"], remap, variant, entry["port"], entry["pin"]) %}
+			{% set name = "%s%s%s_p%s%d%s" | format(entry["signal"], remap, variant, entry["port"], entry["pin"], entry["mod"]) %}
 			/omit-if-no-ref/ {{ name }}: {{ name }} {
 				{% if family == "STM32F1" %}
 				pinmux = <STM32F1_PINMUX('{{ entry["port"] | upper }}', {{ entry["pin"] }}, {{ entry["mode"] | format_mode_f1 }}, {{ entry["af"] | format_remap }})>;

--- a/scripts/tests/genpinctrl/test_genpinctrl.py
+++ b/scripts/tests/genpinctrl/test_genpinctrl.py
@@ -198,6 +198,7 @@ def test_get_mcu_signals(pindata):
                     {
                         "port": "a",
                         "pin": 0,
+                        "mod": "",
                         "signals": [
                             {"name": "UART1_TX", "af": 0},
                             {"name": "UART1_RX", "af": 1},
@@ -214,6 +215,7 @@ def test_get_mcu_signals(pindata):
                     {
                         "port": "a",
                         "pin": 0,
+                        "mod": "",
                         "signals": [
                             {"name": "UART1_TX", "af": "UART1_REMAP0"},
                             {"name": "UART1_TX", "af": "UART1_REMAP1"},


### PR DESCRIPTION
This patch adds support for handling pins with analog switch (found in
H7 series). This feature was removed in a previous patch because it was
generating duplicate nodes. However, it removed some valid combinations.
This patch adds them back but with proper suffix (_c) avoiding duplicate
entries.