### PR TITLE
lib: stm32wb: hci list do not disable irq when LST_remove_node will

### DIFF
--- a/lib/stm32wb/hci/stm_list.c
+++ b/lib/stm32wb/hci/stm_list.c
@@ -101,29 +101,15 @@ void LST_remove_node (tListNode * node)
 
 void LST_remove_head (tListNode * listHead, tListNode ** node )
 {
-  uint32_t primask_bit;
-
-  primask_bit = __get_PRIMASK();  /**< backup PRIMASK bit */
-  __disable_irq();                  /**< Disable all interrupts by setting PRIMASK bit on Cortex*/
-
   *node = listHead->next;
   LST_remove_node (listHead->next);
-
-  __set_PRIMASK(primask_bit);     /**< Restore PRIMASK bit*/
 }
 
 
 void LST_remove_tail (tListNode * listHead, tListNode ** node )
 {
-  uint32_t primask_bit;
-
-  primask_bit = __get_PRIMASK();  /**< backup PRIMASK bit */
-  __disable_irq();                  /**< Disable all interrupts by setting PRIMASK bit on Cortex*/
-
   *node = listHead->prev;
   LST_remove_node (listHead->prev);
-
-  __set_PRIMASK(primask_bit);     /**< Restore PRIMASK bit*/
 }
 
 


### PR DESCRIPTION
There is no need to disable the irq and backup/restore PRIMASK in the LST_remove_head and LST_remove_tail functions of the lib/stm32wb/hci/stm_list.c because the call to LST_remove_node() will do. If done twice a BUS FAULT occurs.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/50655

Signed-off-by: Francois Ramu <francois.ramu@st.com>