### PR TITLE
stm32 ulpi pins set to "high-speed" slew rate

### DIFF
--- a/dts/st/f2/stm32f205r(b-c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205r(b-c-e-f-g)tx-pinctrl.dtsi
@@ -1107,50 +1107,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f2/stm32f205r(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205r(e-g)yx-pinctrl.dtsi
@@ -1107,50 +1107,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f2/stm32f205rgex-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205rgex-pinctrl.dtsi
@@ -1107,50 +1107,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f2/stm32f205v(b-c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205v(b-c-e-f-g)tx-pinctrl.dtsi
@@ -1334,50 +1334,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f2/stm32f205z(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205z(c-e-f-g)tx-pinctrl.dtsi
@@ -1555,50 +1555,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f2/stm32f207i(c-e-f-g)hx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207i(c-e-f-g)hx-pinctrl.dtsi
@@ -1963,58 +1963,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f2/stm32f207i(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207i(c-e-f-g)tx-pinctrl.dtsi
@@ -1963,58 +1963,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f2/stm32f207v(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207v(c-e-f-g)tx-pinctrl.dtsi
@@ -1479,50 +1479,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f2/stm32f207z(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207z(c-e-f-g)tx-pinctrl.dtsi
@@ -1720,50 +1720,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f2/stm32f215r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f215r(e-g)tx-pinctrl.dtsi
@@ -1107,50 +1107,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f2/stm32f215v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f215v(e-g)tx-pinctrl.dtsi
@@ -1334,50 +1334,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f2/stm32f215z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f215z(e-g)tx-pinctrl.dtsi
@@ -1555,50 +1555,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f2/stm32f217i(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217i(e-g)hx-pinctrl.dtsi
@@ -1963,58 +1963,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f2/stm32f217i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217i(e-g)tx-pinctrl.dtsi
@@ -1963,58 +1963,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f2/stm32f217v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217v(e-g)tx-pinctrl.dtsi
@@ -1479,50 +1479,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f2/stm32f217z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217z(e-g)tx-pinctrl.dtsi
@@ -1720,50 +1720,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f405o(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405o(e-g)yx-pinctrl.dtsi
@@ -1294,50 +1294,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f405rgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405rgtx-pinctrl.dtsi
@@ -1129,50 +1129,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f405vgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405vgtx-pinctrl.dtsi
@@ -1356,50 +1356,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f405zgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405zgtx-pinctrl.dtsi
@@ -1577,50 +1577,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f407i(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407i(e-g)hx-pinctrl.dtsi
@@ -1990,58 +1990,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f407i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407i(e-g)tx-pinctrl.dtsi
@@ -1990,58 +1990,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f407v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407v(e-g)tx-pinctrl.dtsi
@@ -1501,50 +1501,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f407z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407z(e-g)tx-pinctrl.dtsi
@@ -1742,50 +1742,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f415ogyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415ogyx-pinctrl.dtsi
@@ -1294,50 +1294,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f415rgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415rgtx-pinctrl.dtsi
@@ -1129,50 +1129,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f415vgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415vgtx-pinctrl.dtsi
@@ -1356,50 +1356,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f415zgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415zgtx-pinctrl.dtsi
@@ -1577,50 +1577,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f417i(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417i(e-g)hx-pinctrl.dtsi
@@ -1990,58 +1990,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f417i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417i(e-g)tx-pinctrl.dtsi
@@ -1990,58 +1990,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f417v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417v(e-g)tx-pinctrl.dtsi
@@ -1501,50 +1501,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f417z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417z(e-g)tx-pinctrl.dtsi
@@ -1742,50 +1742,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f427a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427a(g-i)hx-pinctrl.dtsi
@@ -2476,54 +2476,67 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f427i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427i(g-i)hx-pinctrl.dtsi
@@ -2648,58 +2648,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f427i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427i(g-i)tx-pinctrl.dtsi
@@ -2648,58 +2648,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f427v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427v(g-i)tx-pinctrl.dtsi
@@ -1805,50 +1805,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f427z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427z(g-i)tx-pinctrl.dtsi
@@ -2246,50 +2246,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f429a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429a(g-i)hx-pinctrl.dtsi
@@ -2690,54 +2690,67 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f429b(e-g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429b(e-g-i)tx-pinctrl.dtsi
@@ -3086,58 +3086,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f429i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429i(e-g)tx-pinctrl.dtsi
@@ -2862,58 +2862,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f429i(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429i(e-g-i)hx-pinctrl.dtsi
@@ -2862,58 +2862,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f429iitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429iitx-pinctrl.dtsi
@@ -2862,58 +2862,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f429n(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429n(e-g)hx-pinctrl.dtsi
@@ -3086,58 +3086,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f429nihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429nihx-pinctrl.dtsi
@@ -3086,58 +3086,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f429v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429v(e-g)tx-pinctrl.dtsi
@@ -1881,50 +1881,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f429vitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429vitx-pinctrl.dtsi
@@ -1881,50 +1881,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f429z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429z(e-g)tx-pinctrl.dtsi
@@ -2384,50 +2384,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f429zgyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429zgyx-pinctrl.dtsi
@@ -2384,50 +2384,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f429zitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429zitx-pinctrl.dtsi
@@ -2384,50 +2384,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f429ziyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429ziyx-pinctrl.dtsi
@@ -2384,50 +2384,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f437aihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437aihx-pinctrl.dtsi
@@ -2476,54 +2476,67 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f437i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437i(g-i)hx-pinctrl.dtsi
@@ -2648,58 +2648,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f437i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437i(g-i)tx-pinctrl.dtsi
@@ -2648,58 +2648,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f437v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437v(g-i)tx-pinctrl.dtsi
@@ -1805,50 +1805,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f437z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437z(g-i)tx-pinctrl.dtsi
@@ -2246,50 +2246,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f439aihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439aihx-pinctrl.dtsi
@@ -2690,54 +2690,67 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f439b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439b(g-i)tx-pinctrl.dtsi
@@ -3086,58 +3086,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f439i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439i(g-i)hx-pinctrl.dtsi
@@ -2862,58 +2862,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f439i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439i(g-i)tx-pinctrl.dtsi
@@ -2862,58 +2862,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f439n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439n(g-i)hx-pinctrl.dtsi
@@ -3086,58 +3086,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f439v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439v(g-i)tx-pinctrl.dtsi
@@ -1881,50 +1881,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f439z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439z(g-i)tx-pinctrl.dtsi
@@ -2384,50 +2384,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f439z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439z(g-i)yx-pinctrl.dtsi
@@ -2384,50 +2384,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f446m(c-e)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446m(c-e)yx-pinctrl.dtsi
@@ -1465,50 +1465,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb2: usb_otg_hs_ulpi_d4_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f446r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446r(c-e)tx-pinctrl.dtsi
@@ -1312,50 +1312,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb2: usb_otg_hs_ulpi_d4_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f446v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446v(c-e)tx-pinctrl.dtsi
@@ -1920,50 +1920,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb2: usb_otg_hs_ulpi_d4_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f446z(c-e)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)hx-pinctrl.dtsi
@@ -2359,50 +2359,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb2: usb_otg_hs_ulpi_d4_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f446z(c-e)jx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)jx-pinctrl.dtsi
@@ -2359,50 +2359,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb2: usb_otg_hs_ulpi_d4_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f446z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)tx-pinctrl.dtsi
@@ -2359,50 +2359,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb2: usb_otg_hs_ulpi_d4_pb2 {
 				pinmux = <STM32_PINMUX('B', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f469a(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469a(e-g-i)hx-pinctrl.dtsi
@@ -2618,50 +2618,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f469a(e-g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469a(e-g-i)yx-pinctrl.dtsi
@@ -2618,50 +2618,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f469b(e-g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469b(e-g-i)tx-pinctrl.dtsi
@@ -3252,58 +3252,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f469i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469i(e-g)tx-pinctrl.dtsi
@@ -2911,58 +2911,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f469i(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469i(e-g-i)hx-pinctrl.dtsi
@@ -2911,58 +2911,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f469iitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469iitx-pinctrl.dtsi
@@ -2911,58 +2911,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f469n(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469n(e-g)hx-pinctrl.dtsi
@@ -3252,58 +3252,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f469nihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469nihx-pinctrl.dtsi
@@ -3252,58 +3252,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f469v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469v(e-g)tx-pinctrl.dtsi
@@ -1702,50 +1702,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f469vitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469vitx-pinctrl.dtsi
@@ -1702,50 +1702,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f469z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469z(e-g)tx-pinctrl.dtsi
@@ -2222,50 +2222,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f469zitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469zitx-pinctrl.dtsi
@@ -2222,50 +2222,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f479a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479a(g-i)hx-pinctrl.dtsi
@@ -2618,50 +2618,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f479a(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479a(g-i)yx-pinctrl.dtsi
@@ -2618,50 +2618,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f479b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479b(g-i)tx-pinctrl.dtsi
@@ -3252,58 +3252,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f479i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479i(g-i)hx-pinctrl.dtsi
@@ -2911,58 +2911,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f479i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479i(g-i)tx-pinctrl.dtsi
@@ -2911,58 +2911,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f479n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479n(g-i)hx-pinctrl.dtsi
@@ -3252,58 +3252,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f479v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479v(g-i)tx-pinctrl.dtsi
@@ -1702,50 +1702,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f4/stm32f479z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479z(g-i)tx-pinctrl.dtsi
@@ -2222,50 +2222,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f722i(c-e)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722i(c-e)kx-pinctrl.dtsi
@@ -2855,58 +2855,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f722i(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722i(c-e)tx-pinctrl.dtsi
@@ -2855,58 +2855,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f722r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722r(c-e)tx-pinctrl.dtsi
@@ -1246,50 +1246,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f722v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722v(c-e)tx-pinctrl.dtsi
@@ -1951,50 +1951,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f722z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722z(c-e)tx-pinctrl.dtsi
@@ -2450,50 +2450,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f730r8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730r8tx-pinctrl.dtsi
@@ -1246,50 +1246,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f730v8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730v8tx-pinctrl.dtsi
@@ -1951,50 +1951,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f732iekx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732iekx-pinctrl.dtsi
@@ -2855,58 +2855,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f732ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732ietx-pinctrl.dtsi
@@ -2855,58 +2855,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f732retx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732retx-pinctrl.dtsi
@@ -1246,50 +1246,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f732vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732vetx-pinctrl.dtsi
@@ -1951,50 +1951,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f732zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732zetx-pinctrl.dtsi
@@ -2450,50 +2450,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f745i(e-g)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745i(e-g)kx-pinctrl.dtsi
@@ -3012,58 +3012,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f745i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745i(e-g)tx-pinctrl.dtsi
@@ -3012,58 +3012,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f745v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745v(e-g)hx-pinctrl.dtsi
@@ -2066,50 +2066,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f745v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745v(e-g)tx-pinctrl.dtsi
@@ -2066,50 +2066,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f745z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745z(e-g)tx-pinctrl.dtsi
@@ -2588,50 +2588,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f746b(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746b(e-g)tx-pinctrl.dtsi
@@ -3474,58 +3474,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f746i(e-g)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746i(e-g)kx-pinctrl.dtsi
@@ -3250,58 +3250,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f746ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746ietx-pinctrl.dtsi
@@ -3250,58 +3250,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f746igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746igtx-pinctrl.dtsi
@@ -3250,58 +3250,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f746nehx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746nehx-pinctrl.dtsi
@@ -3474,58 +3474,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f746nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746nghx-pinctrl.dtsi
@@ -3474,58 +3474,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f746v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746v(e-g)hx-pinctrl.dtsi
@@ -2188,50 +2188,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f746vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746vetx-pinctrl.dtsi
@@ -2188,50 +2188,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f746vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746vgtx-pinctrl.dtsi
@@ -2188,50 +2188,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f746z(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746z(e-g)yx-pinctrl.dtsi
@@ -2750,50 +2750,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f746zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746zetx-pinctrl.dtsi
@@ -2750,50 +2750,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f746zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746zgtx-pinctrl.dtsi
@@ -2750,50 +2750,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f750n8hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750n8hx-pinctrl.dtsi
@@ -3474,58 +3474,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f750v8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750v8tx-pinctrl.dtsi
@@ -2188,50 +2188,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f750z8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750z8tx-pinctrl.dtsi
@@ -2750,50 +2750,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f756bgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756bgtx-pinctrl.dtsi
@@ -3474,58 +3474,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f756igkx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756igkx-pinctrl.dtsi
@@ -3250,58 +3250,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f756igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756igtx-pinctrl.dtsi
@@ -3250,58 +3250,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f756nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756nghx-pinctrl.dtsi
@@ -3474,58 +3474,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f756vghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756vghx-pinctrl.dtsi
@@ -2188,50 +2188,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f756vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756vgtx-pinctrl.dtsi
@@ -2188,50 +2188,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f756zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756zgtx-pinctrl.dtsi
@@ -2750,50 +2750,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f756zgyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756zgyx-pinctrl.dtsi
@@ -2750,50 +2750,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f765b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765b(g-i)tx-pinctrl.dtsi
@@ -3493,58 +3493,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f765i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765i(g-i)kx-pinctrl.dtsi
@@ -3381,58 +3381,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f765i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765i(g-i)tx-pinctrl.dtsi
@@ -3381,58 +3381,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f765n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765n(g-i)hx-pinctrl.dtsi
@@ -3493,58 +3493,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f765v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765v(g-i)hx-pinctrl.dtsi
@@ -2357,50 +2357,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f765v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765v(g-i)tx-pinctrl.dtsi
@@ -2357,50 +2357,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f765z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765z(g-i)tx-pinctrl.dtsi
@@ -2939,50 +2939,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f767b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767b(g-i)tx-pinctrl.dtsi
@@ -3915,58 +3915,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f767i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767i(g-i)kx-pinctrl.dtsi
@@ -3675,58 +3675,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f767i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767i(g-i)tx-pinctrl.dtsi
@@ -3675,58 +3675,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f767n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767n(g-i)hx-pinctrl.dtsi
@@ -3915,58 +3915,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f767vghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vghx-pinctrl.dtsi
@@ -2519,50 +2519,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f767vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vgtx-pinctrl.dtsi
@@ -2519,50 +2519,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f767vihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vihx-pinctrl.dtsi
@@ -2519,50 +2519,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f767vitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vitx-pinctrl.dtsi
@@ -2519,50 +2519,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f767zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767zgtx-pinctrl.dtsi
@@ -3145,50 +3145,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f767zitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767zitx-pinctrl.dtsi
@@ -3145,50 +3145,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f768aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f768aiyx-pinctrl.dtsi
@@ -3192,50 +3192,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f769a(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769a(g-i)yx-pinctrl.dtsi
@@ -3192,50 +3192,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f769b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769b(g-i)tx-pinctrl.dtsi
@@ -3843,58 +3843,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f769igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769igtx-pinctrl.dtsi
@@ -3476,58 +3476,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f769iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769iitx-pinctrl.dtsi
@@ -3476,58 +3476,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f769nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769nghx-pinctrl.dtsi
@@ -3843,58 +3843,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f769nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769nihx-pinctrl.dtsi
@@ -3843,58 +3843,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f777bitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777bitx-pinctrl.dtsi
@@ -3915,58 +3915,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f777iikx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777iikx-pinctrl.dtsi
@@ -3675,58 +3675,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f777iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777iitx-pinctrl.dtsi
@@ -3675,58 +3675,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f777nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777nihx-pinctrl.dtsi
@@ -3915,58 +3915,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f777vihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777vihx-pinctrl.dtsi
@@ -2519,50 +2519,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f777vitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777vitx-pinctrl.dtsi
@@ -2519,50 +2519,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f777zitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777zitx-pinctrl.dtsi
@@ -3145,50 +3145,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f778aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f778aiyx-pinctrl.dtsi
@@ -3192,50 +3192,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f779aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779aiyx-pinctrl.dtsi
@@ -3192,50 +3192,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f779bitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779bitx-pinctrl.dtsi
@@ -3843,58 +3843,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f779iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779iitx-pinctrl.dtsi
@@ -3476,58 +3476,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/f7/stm32f779nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779nihx-pinctrl.dtsi
@@ -3843,58 +3843,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h723vehx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vehx-pinctrl.dtsi
@@ -2901,50 +2901,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h723vetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vetx-pinctrl.dtsi
@@ -2901,50 +2901,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h723vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vghx-pinctrl.dtsi
@@ -2901,50 +2901,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h723vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vgtx-pinctrl.dtsi
@@ -2901,50 +2901,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h723zeix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zeix-pinctrl.dtsi
@@ -3832,50 +3832,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h723zetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zetx-pinctrl.dtsi
@@ -3804,50 +3804,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h723zgix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zgix-pinctrl.dtsi
@@ -3832,50 +3832,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h723zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zgtx-pinctrl.dtsi
@@ -3804,50 +3804,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h725aeix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725aeix-pinctrl.dtsi
@@ -4211,58 +4211,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h725agix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725agix-pinctrl.dtsi
@@ -4211,58 +4211,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h725iekx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725iekx-pinctrl.dtsi
@@ -4373,62 +4373,77 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h725ietx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725ietx-pinctrl.dtsi
@@ -3938,50 +3938,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h725igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725igkx-pinctrl.dtsi
@@ -4373,62 +4373,77 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h725igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725igtx-pinctrl.dtsi
@@ -3938,50 +3938,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h725revx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725revx-pinctrl.dtsi
@@ -1734,38 +1734,47 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h725rgvx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725rgvx-pinctrl.dtsi
@@ -1734,38 +1734,47 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h725vehx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vehx-pinctrl.dtsi
@@ -2789,50 +2789,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h725vetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vetx-pinctrl.dtsi
@@ -2578,50 +2578,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h725vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vghx-pinctrl.dtsi
@@ -2789,50 +2789,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h725vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vgtx-pinctrl.dtsi
@@ -2578,50 +2578,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h725vgyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vgyx-pinctrl.dtsi
@@ -2482,42 +2482,52 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h725zetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725zetx-pinctrl.dtsi
@@ -3513,50 +3513,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h725zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725zgtx-pinctrl.dtsi
@@ -3513,50 +3513,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h730abixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730abixq-pinctrl.dtsi
@@ -4211,58 +4211,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h730ibkxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730ibkxq-pinctrl.dtsi
@@ -4373,62 +4373,77 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h730ibtxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730ibtxq-pinctrl.dtsi
@@ -3938,50 +3938,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h730vbhx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730vbhx-pinctrl.dtsi
@@ -2901,50 +2901,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h730vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730vbtx-pinctrl.dtsi
@@ -2901,50 +2901,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h730zbix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730zbix-pinctrl.dtsi
@@ -3832,50 +3832,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h730zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730zbtx-pinctrl.dtsi
@@ -3804,50 +3804,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h733vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733vghx-pinctrl.dtsi
@@ -2901,50 +2901,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h733vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733vgtx-pinctrl.dtsi
@@ -2901,50 +2901,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h733zgix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733zgix-pinctrl.dtsi
@@ -3832,50 +3832,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h733zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733zgtx-pinctrl.dtsi
@@ -3804,50 +3804,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h735agix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735agix-pinctrl.dtsi
@@ -4211,58 +4211,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h735igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735igkx-pinctrl.dtsi
@@ -4373,62 +4373,77 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, ANALOG)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, ANALOG)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h735igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735igtx-pinctrl.dtsi
@@ -3938,50 +3938,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h735rgvx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735rgvx-pinctrl.dtsi
@@ -1734,38 +1734,47 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h735vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vghx-pinctrl.dtsi
@@ -2789,50 +2789,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h735vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vgtx-pinctrl.dtsi
@@ -2578,50 +2578,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h735vgyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vgyx-pinctrl.dtsi
@@ -2482,42 +2482,52 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h735zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735zgtx-pinctrl.dtsi
@@ -3513,50 +3513,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
@@ -3292,58 +3292,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
@@ -3675,58 +3675,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
@@ -3477,58 +3477,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
@@ -3477,58 +3477,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
@@ -2391,50 +2391,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
@@ -2391,50 +2391,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
@@ -3865,66 +3865,82 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
@@ -3013,50 +3013,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
@@ -3566,58 +3566,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
@@ -4093,58 +4093,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h743bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bitx-pinctrl.dtsi
@@ -4093,58 +4093,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h743igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igkx-pinctrl.dtsi
@@ -3767,58 +3767,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h743igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igtx-pinctrl.dtsi
@@ -3767,58 +3767,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h743iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iikx-pinctrl.dtsi
@@ -3767,58 +3767,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h743iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iitx-pinctrl.dtsi
@@ -3767,58 +3767,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
@@ -2549,50 +2549,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
@@ -2549,50 +2549,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h743vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vitx-pinctrl.dtsi
@@ -2549,50 +2549,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h743xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xghx-pinctrl.dtsi
@@ -4281,66 +4281,82 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h743xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xihx-pinctrl.dtsi
@@ -4281,66 +4281,82 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
@@ -3215,50 +3215,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h743zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zitx-pinctrl.dtsi
@@ -3215,50 +3215,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
@@ -3937,58 +3937,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h745bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bitx-pinctrl.dtsi
@@ -3937,58 +3937,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h745igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igkx-pinctrl.dtsi
@@ -3744,62 +3744,77 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h745igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igtx-pinctrl.dtsi
@@ -3349,50 +3349,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h745iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iikx-pinctrl.dtsi
@@ -3744,62 +3744,77 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h745iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iitx-pinctrl.dtsi
@@ -3349,50 +3349,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h745xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xghx-pinctrl.dtsi
@@ -4281,66 +4281,82 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h745xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xihx-pinctrl.dtsi
@@ -4281,66 +4281,82 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
@@ -3015,50 +3015,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h745zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zitx-pinctrl.dtsi
@@ -3015,50 +3015,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
@@ -3215,50 +3215,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
@@ -3779,58 +3779,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h747bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bitx-pinctrl.dtsi
@@ -3779,58 +3779,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h747igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747igtx-pinctrl.dtsi
@@ -3215,50 +3215,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h747iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747iitx-pinctrl.dtsi
@@ -3215,50 +3215,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h747xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xghx-pinctrl.dtsi
@@ -4281,66 +4281,82 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h747xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xihx-pinctrl.dtsi
@@ -4281,66 +4281,82 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
@@ -2834,50 +2834,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
@@ -3767,58 +3767,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
@@ -3767,58 +3767,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
@@ -2549,50 +2549,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
@@ -4281,66 +4281,82 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
@@ -3215,50 +3215,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h753aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753aiix-pinctrl.dtsi
@@ -3566,58 +3566,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h753bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753bitx-pinctrl.dtsi
@@ -4093,58 +4093,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h753iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iikx-pinctrl.dtsi
@@ -3767,58 +3767,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h753iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iitx-pinctrl.dtsi
@@ -3767,58 +3767,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h753vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vihx-pinctrl.dtsi
@@ -2549,50 +2549,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h753vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vitx-pinctrl.dtsi
@@ -2549,50 +2549,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h753xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753xihx-pinctrl.dtsi
@@ -4281,66 +4281,82 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h753zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753zitx-pinctrl.dtsi
@@ -3215,50 +3215,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h755bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755bitx-pinctrl.dtsi
@@ -3937,58 +3937,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h755iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iikx-pinctrl.dtsi
@@ -3744,62 +3744,77 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h755iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iitx-pinctrl.dtsi
@@ -3349,50 +3349,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h755xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755xihx-pinctrl.dtsi
@@ -4281,66 +4281,82 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h755zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755zitx-pinctrl.dtsi
@@ -3015,50 +3015,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h757aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757aiix-pinctrl.dtsi
@@ -3215,50 +3215,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h757bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757bitx-pinctrl.dtsi
@@ -3779,58 +3779,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h757iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757iitx-pinctrl.dtsi
@@ -3215,50 +3215,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h757xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757xihx-pinctrl.dtsi
@@ -4281,66 +4281,82 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
@@ -2834,50 +2834,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
@@ -3692,58 +3692,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
@@ -3872,58 +3872,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
@@ -3828,62 +3828,77 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
@@ -3872,58 +3872,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
@@ -3492,50 +3492,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
@@ -4437,66 +4437,82 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
@@ -4260,58 +4260,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h7a3qiyxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3qiyxq-pinctrl.dtsi
@@ -2835,50 +2835,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h7a3r(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3r(g-i)tx-pinctrl.dtsi
@@ -1757,46 +1757,57 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h7a3v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)hx-pinctrl.dtsi
@@ -2616,50 +2616,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h7a3v(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)hxq-pinctrl.dtsi
@@ -2504,50 +2504,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h7a3v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)tx-pinctrl.dtsi
@@ -2616,50 +2616,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h7a3v(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)txq-pinctrl.dtsi
@@ -2328,50 +2328,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
@@ -3358,50 +3358,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h7a3z(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)txq-pinctrl.dtsi
@@ -3119,50 +3119,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
@@ -3692,58 +3692,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
@@ -3828,62 +3828,77 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
@@ -3872,58 +3872,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h7b0rbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0rbtx-pinctrl.dtsi
@@ -1757,46 +1757,57 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h7b0vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0vbtx-pinctrl.dtsi
@@ -2616,50 +2616,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
@@ -3358,50 +3358,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
@@ -3692,58 +3692,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
@@ -3872,58 +3872,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
@@ -3828,62 +3828,77 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
@@ -3872,58 +3872,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
@@ -3492,50 +3492,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
@@ -4437,66 +4437,82 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
@@ -4260,58 +4260,72 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_ph4: usb_otg_hs_ulpi_nxt_ph4 {
 				pinmux = <STM32_PINMUX('H', 4, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pi11: usb_otg_hs_ulpi_dir_pi11 {
 				pinmux = <STM32_PINMUX('I', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h7b3qiyxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3qiyxq-pinctrl.dtsi
@@ -2835,50 +2835,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h7b3ritx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3ritx-pinctrl.dtsi
@@ -1757,46 +1757,57 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2: usb_otg_hs_ulpi_dir_pc2 {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3: usb_otg_hs_ulpi_nxt_pc3 {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h7b3vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vihx-pinctrl.dtsi
@@ -2616,50 +2616,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h7b3vihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vihxq-pinctrl.dtsi
@@ -2504,50 +2504,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h7b3vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vitx-pinctrl.dtsi
@@ -2616,50 +2616,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h7b3vitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vitxq-pinctrl.dtsi
@@ -2328,50 +2328,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
@@ -3358,50 +3358,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/dts/st/h7/stm32h7b3zitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitxq-pinctrl.dtsi
@@ -3119,50 +3119,62 @@
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d0_pa3: usb_otg_hs_ulpi_d0_pa3 {
 				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_ck_pa5: usb_otg_hs_ulpi_ck_pa5 {
 				pinmux = <STM32_PINMUX('A', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d1_pb0: usb_otg_hs_ulpi_d1_pb0 {
 				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d2_pb1: usb_otg_hs_ulpi_d2_pb1 {
 				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d7_pb5: usb_otg_hs_ulpi_d7_pb5 {
 				pinmux = <STM32_PINMUX('B', 5, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d3_pb10: usb_otg_hs_ulpi_d3_pb10 {
 				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d4_pb11: usb_otg_hs_ulpi_d4_pb11 {
 				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d5_pb12: usb_otg_hs_ulpi_d5_pb12 {
 				pinmux = <STM32_PINMUX('B', 12, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_d6_pb13: usb_otg_hs_ulpi_d6_pb13 {
 				pinmux = <STM32_PINMUX('B', 13, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_stp_pc0: usb_otg_hs_ulpi_stp_pc0 {
 				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_dir_pc2_c: usb_otg_hs_ulpi_dir_pc2_c {
 				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 			/omit-if-no-ref/ usb_otg_hs_ulpi_nxt_pc3_c: usb_otg_hs_ulpi_nxt_pc3_c {
 				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "high-speed";
 			};
 
 		};

--- a/scripts/genpinctrl/stm32-pinctrl-config.yaml
+++ b/scripts/genpinctrl/stm32-pinctrl-config.yaml
@@ -252,6 +252,7 @@
 
 - name: USB_OTG_HS_ULPI
   match: "^USB_OTG_HS_ULPI_(?:CK)?(?:DIR)?(?:STP)?(?:NXT)?(?:D\\d+)?$"
+  slew-rate: high-speed
 
 - name: USB
   match: "^USB_(?:DM)?(?:DP)?(?:NOE)?$"


### PR DESCRIPTION
The ULPI pins need to have a slew rate of high-speed

Related PR: https://github.com/zephyrproject-rtos/zephyr/pull/52772