### PR TITLE
stm32cube: g0: added IsActiveFlag function for RxErr

### DIFF
--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_ucpd.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_ucpd.h
@@ -1490,6 +1490,17 @@ __STATIC_INLINE uint32_t LL_UCPD_IsActiveFlag_RxMsgEnd(UCPD_TypeDef const *const
 }
 
 /**
+  * @brief  Check if Rx error interrupt
+  * @rmtoll SR          RXERR         LL_UCPD_IsActiveFlag_RxErr
+  * @param  UCPDx UCPD Instance
+  * @retval None
+  */
+__STATIC_INLINE uint32_t LL_UCPD_IsActiveFlag_RxErr(UCPD_TypeDef const * const UCPDx)
+{
+  return ((READ_BIT(UCPDx->SR, UCPD_SR_RXERR) == UCPD_SR_RXERR) ? 1UL : 0UL);
+}
+
+/**
   * @brief  Check if Rx overrun interrupt
   * @rmtoll SR          RXOVR         LL_UCPD_IsActiveFlag_RxOvr
   * @param  UCPDx UCPD Instance


### PR DESCRIPTION
This patch adds the missing isActiveFlag_RxErr function for stm32g0xx_ll_ucpd.h

Signed-off-by: Jason Yuan <jasonyuan@google.com>