### PR TITLE
Fix stm32f1 pwm

### DIFF
--- a/dts/st/f1/stm32f100c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100c(4-6)tx-pinctrl.dtsi
@@ -320,201 +320,399 @@
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_in_pa7: tim1_ch1n_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_pwm_in_pa8: tim1_ch1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_in_pa8: tim1_ch1_remap1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_pwm_in_pa9: tim1_ch2_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_in_pa9: tim1_ch2_remap1_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_pwm_in_pa10: tim1_ch3_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_in_pa10: tim1_ch3_remap1_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_pwm_in_pa11: tim1_ch4_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_in_pa11: tim1_ch4_remap1_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_in_pb0: tim1_ch2n_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_in_pb1: tim1_ch3n_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_pwm_in_pb13: tim1_ch1n_pwm_in_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_pwm_in_pb14: tim1_ch2n_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_pwm_in_pb15: tim1_ch3n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1_pwm_in_pa2: tim15_ch1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM15_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch2_pwm_in_pa3: tim15_ch2_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM15_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1_remap1_pwm_in_pb14: tim15_ch1_remap1_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM15_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1n_pwm_in_pb15: tim15_ch1n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch2_remap1_pwm_in_pb15: tim15_ch2_remap1_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM15_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim16_ch1_remap1_pwm_in_pa6: tim16_ch1_remap1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM16_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim16_ch1n_pwm_in_pb6: tim16_ch1n_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim16_ch1_pwm_in_pb8: tim16_ch1_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM16_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim17_ch1_remap1_pwm_in_pa7: tim17_ch1_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM17_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim17_ch1n_pwm_in_pb7: tim17_ch1n_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim17_ch1_pwm_in_pb9: tim17_ch1_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM17_REMAP0)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_out_pa7: tim1_ch1n_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_pwm_out_pa8: tim1_ch1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_out_pa8: tim1_ch1_remap1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_pwm_out_pa9: tim1_ch2_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_out_pa9: tim1_ch2_remap1_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_pwm_out_pa10: tim1_ch3_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_out_pa10: tim1_ch3_remap1_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_pwm_out_pa11: tim1_ch4_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_out_pa11: tim1_ch4_remap1_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_out_pb0: tim1_ch2n_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_out_pb1: tim1_ch3n_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			/omit-if-no-ref/ tim1_ch1n_pwm_out_pb13: tim1_ch1n_pwm_out_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			/omit-if-no-ref/ tim1_ch2n_pwm_out_pb14: tim1_ch2n_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			/omit-if-no-ref/ tim1_ch3n_pwm_out_pb15: tim1_ch3n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			/omit-if-no-ref/ tim15_ch1_pwm_out_pa2: tim15_ch1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM15_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			/omit-if-no-ref/ tim15_ch2_pwm_out_pa3: tim15_ch2_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM15_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch1_remap1_pwm_pb14: tim15_ch1_remap1_pwm_pb14 {
+			/omit-if-no-ref/ tim15_ch1_remap1_pwm_out_pb14: tim15_ch1_remap1_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM15_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			/omit-if-no-ref/ tim15_ch1n_pwm_out_pb15: tim15_ch1n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch2_remap1_pwm_pb15: tim15_ch2_remap1_pwm_pb15 {
+			/omit-if-no-ref/ tim15_ch2_remap1_pwm_out_pb15: tim15_ch2_remap1_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM15_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim16_ch1_remap1_pwm_pa6: tim16_ch1_remap1_pwm_pa6 {
+			/omit-if-no-ref/ tim16_ch1_remap1_pwm_out_pa6: tim16_ch1_remap1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM16_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			/omit-if-no-ref/ tim16_ch1n_pwm_out_pb6: tim16_ch1n_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			/omit-if-no-ref/ tim16_ch1_pwm_out_pb8: tim16_ch1_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM16_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim17_ch1_remap1_pwm_pa7: tim17_ch1_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim17_ch1_remap1_pwm_out_pa7: tim17_ch1_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM17_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			/omit-if-no-ref/ tim17_ch1n_pwm_out_pb7: tim17_ch1n_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			/omit-if-no-ref/ tim17_ch1_pwm_out_pb9: tim17_ch1_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM17_REMAP0)>;
 			};
 

--- a/dts/st/f1/stm32f100c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100c(8-b)tx-pinctrl.dtsi
@@ -364,217 +364,431 @@
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_in_pa7: tim1_ch1n_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_pwm_in_pa8: tim1_ch1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_in_pa8: tim1_ch1_remap1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_pwm_in_pa9: tim1_ch2_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_in_pa9: tim1_ch2_remap1_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_pwm_in_pa10: tim1_ch3_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_in_pa10: tim1_ch3_remap1_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_pwm_in_pa11: tim1_ch4_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_in_pa11: tim1_ch4_remap1_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_in_pb0: tim1_ch2n_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_in_pb1: tim1_ch3n_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_pwm_in_pb13: tim1_ch1n_pwm_in_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_pwm_in_pb14: tim1_ch2n_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_pwm_in_pb15: tim1_ch3n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1_pwm_in_pa2: tim15_ch1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM15_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch2_pwm_in_pa3: tim15_ch2_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM15_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1_remap1_pwm_in_pb14: tim15_ch1_remap1_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM15_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1n_pwm_in_pb15: tim15_ch1n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch2_remap1_pwm_in_pb15: tim15_ch2_remap1_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM15_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim16_ch1_remap1_pwm_in_pa6: tim16_ch1_remap1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM16_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim16_ch1n_pwm_in_pb6: tim16_ch1n_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim16_ch1_pwm_in_pb8: tim16_ch1_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM16_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim17_ch1_remap1_pwm_in_pa7: tim17_ch1_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM17_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim17_ch1n_pwm_in_pb7: tim17_ch1n_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim17_ch1_pwm_in_pb9: tim17_ch1_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM17_REMAP0)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_out_pa7: tim1_ch1n_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_pwm_out_pa8: tim1_ch1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_out_pa8: tim1_ch1_remap1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_pwm_out_pa9: tim1_ch2_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_out_pa9: tim1_ch2_remap1_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_pwm_out_pa10: tim1_ch3_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_out_pa10: tim1_ch3_remap1_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_pwm_out_pa11: tim1_ch4_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_out_pa11: tim1_ch4_remap1_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_out_pb0: tim1_ch2n_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_out_pb1: tim1_ch3n_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			/omit-if-no-ref/ tim1_ch1n_pwm_out_pb13: tim1_ch1n_pwm_out_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			/omit-if-no-ref/ tim1_ch2n_pwm_out_pb14: tim1_ch2n_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			/omit-if-no-ref/ tim1_ch3n_pwm_out_pb15: tim1_ch3n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			/omit-if-no-ref/ tim15_ch1_pwm_out_pa2: tim15_ch1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM15_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			/omit-if-no-ref/ tim15_ch2_pwm_out_pa3: tim15_ch2_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM15_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch1_remap1_pwm_pb14: tim15_ch1_remap1_pwm_pb14 {
+			/omit-if-no-ref/ tim15_ch1_remap1_pwm_out_pb14: tim15_ch1_remap1_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM15_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			/omit-if-no-ref/ tim15_ch1n_pwm_out_pb15: tim15_ch1n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch2_remap1_pwm_pb15: tim15_ch2_remap1_pwm_pb15 {
+			/omit-if-no-ref/ tim15_ch2_remap1_pwm_out_pb15: tim15_ch2_remap1_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM15_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim16_ch1_remap1_pwm_pa6: tim16_ch1_remap1_pwm_pa6 {
+			/omit-if-no-ref/ tim16_ch1_remap1_pwm_out_pa6: tim16_ch1_remap1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM16_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			/omit-if-no-ref/ tim16_ch1n_pwm_out_pb6: tim16_ch1n_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			/omit-if-no-ref/ tim16_ch1_pwm_out_pb8: tim16_ch1_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM16_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim17_ch1_remap1_pwm_pa7: tim17_ch1_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim17_ch1_remap1_pwm_out_pa7: tim17_ch1_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM17_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			/omit-if-no-ref/ tim17_ch1n_pwm_out_pb7: tim17_ch1n_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			/omit-if-no-ref/ tim17_ch1_pwm_out_pb9: tim17_ch1_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM17_REMAP0)>;
 			};
 

--- a/dts/st/f1/stm32f100r(4-6)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(4-6)hx-pinctrl.dtsi
@@ -392,217 +392,431 @@
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_in_pa7: tim1_ch1n_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_pwm_in_pa8: tim1_ch1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_in_pa8: tim1_ch1_remap1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_pwm_in_pa9: tim1_ch2_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_in_pa9: tim1_ch2_remap1_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_pwm_in_pa10: tim1_ch3_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_in_pa10: tim1_ch3_remap1_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_pwm_in_pa11: tim1_ch4_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_in_pa11: tim1_ch4_remap1_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_in_pb0: tim1_ch2n_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_in_pb1: tim1_ch3n_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_pwm_in_pb13: tim1_ch1n_pwm_in_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_pwm_in_pb14: tim1_ch2n_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_pwm_in_pb15: tim1_ch3n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1_pwm_in_pa2: tim15_ch1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM15_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch2_pwm_in_pa3: tim15_ch2_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM15_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1_remap1_pwm_in_pb14: tim15_ch1_remap1_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM15_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1n_pwm_in_pb15: tim15_ch1n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch2_remap1_pwm_in_pb15: tim15_ch2_remap1_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM15_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim16_ch1_remap1_pwm_in_pa6: tim16_ch1_remap1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM16_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim16_ch1n_pwm_in_pb6: tim16_ch1n_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim16_ch1_pwm_in_pb8: tim16_ch1_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM16_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim17_ch1_remap1_pwm_in_pa7: tim17_ch1_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM17_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim17_ch1n_pwm_in_pb7: tim17_ch1n_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim17_ch1_pwm_in_pb9: tim17_ch1_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM17_REMAP0)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_out_pa7: tim1_ch1n_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_pwm_out_pa8: tim1_ch1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_out_pa8: tim1_ch1_remap1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_pwm_out_pa9: tim1_ch2_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_out_pa9: tim1_ch2_remap1_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_pwm_out_pa10: tim1_ch3_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_out_pa10: tim1_ch3_remap1_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_pwm_out_pa11: tim1_ch4_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_out_pa11: tim1_ch4_remap1_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_out_pb0: tim1_ch2n_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_out_pb1: tim1_ch3n_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			/omit-if-no-ref/ tim1_ch1n_pwm_out_pb13: tim1_ch1n_pwm_out_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			/omit-if-no-ref/ tim1_ch2n_pwm_out_pb14: tim1_ch2n_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			/omit-if-no-ref/ tim1_ch3n_pwm_out_pb15: tim1_ch3n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			/omit-if-no-ref/ tim15_ch1_pwm_out_pa2: tim15_ch1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM15_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			/omit-if-no-ref/ tim15_ch2_pwm_out_pa3: tim15_ch2_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM15_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch1_remap1_pwm_pb14: tim15_ch1_remap1_pwm_pb14 {
+			/omit-if-no-ref/ tim15_ch1_remap1_pwm_out_pb14: tim15_ch1_remap1_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM15_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			/omit-if-no-ref/ tim15_ch1n_pwm_out_pb15: tim15_ch1n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch2_remap1_pwm_pb15: tim15_ch2_remap1_pwm_pb15 {
+			/omit-if-no-ref/ tim15_ch2_remap1_pwm_out_pb15: tim15_ch2_remap1_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM15_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim16_ch1_remap1_pwm_pa6: tim16_ch1_remap1_pwm_pa6 {
+			/omit-if-no-ref/ tim16_ch1_remap1_pwm_out_pa6: tim16_ch1_remap1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM16_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			/omit-if-no-ref/ tim16_ch1n_pwm_out_pb6: tim16_ch1n_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			/omit-if-no-ref/ tim16_ch1_pwm_out_pb8: tim16_ch1_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM16_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim17_ch1_remap1_pwm_pa7: tim17_ch1_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim17_ch1_remap1_pwm_out_pa7: tim17_ch1_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM17_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			/omit-if-no-ref/ tim17_ch1n_pwm_out_pb7: tim17_ch1n_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			/omit-if-no-ref/ tim17_ch1_pwm_out_pb9: tim17_ch1_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM17_REMAP0)>;
 			};
 

--- a/dts/st/f1/stm32f100r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(4-6)tx-pinctrl.dtsi
@@ -400,217 +400,431 @@
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_in_pa7: tim1_ch1n_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_pwm_in_pa8: tim1_ch1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_in_pa8: tim1_ch1_remap1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_pwm_in_pa9: tim1_ch2_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_in_pa9: tim1_ch2_remap1_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_pwm_in_pa10: tim1_ch3_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_in_pa10: tim1_ch3_remap1_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_pwm_in_pa11: tim1_ch4_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_in_pa11: tim1_ch4_remap1_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_in_pb0: tim1_ch2n_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_in_pb1: tim1_ch3n_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_pwm_in_pb13: tim1_ch1n_pwm_in_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_pwm_in_pb14: tim1_ch2n_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_pwm_in_pb15: tim1_ch3n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1_pwm_in_pa2: tim15_ch1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM15_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch2_pwm_in_pa3: tim15_ch2_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM15_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1_remap1_pwm_in_pb14: tim15_ch1_remap1_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM15_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1n_pwm_in_pb15: tim15_ch1n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch2_remap1_pwm_in_pb15: tim15_ch2_remap1_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM15_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim16_ch1_remap1_pwm_in_pa6: tim16_ch1_remap1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM16_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim16_ch1n_pwm_in_pb6: tim16_ch1n_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim16_ch1_pwm_in_pb8: tim16_ch1_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM16_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim17_ch1_remap1_pwm_in_pa7: tim17_ch1_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM17_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim17_ch1n_pwm_in_pb7: tim17_ch1n_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim17_ch1_pwm_in_pb9: tim17_ch1_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM17_REMAP0)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_out_pa7: tim1_ch1n_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_pwm_out_pa8: tim1_ch1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_out_pa8: tim1_ch1_remap1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_pwm_out_pa9: tim1_ch2_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_out_pa9: tim1_ch2_remap1_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_pwm_out_pa10: tim1_ch3_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_out_pa10: tim1_ch3_remap1_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_pwm_out_pa11: tim1_ch4_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_out_pa11: tim1_ch4_remap1_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_out_pb0: tim1_ch2n_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_out_pb1: tim1_ch3n_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			/omit-if-no-ref/ tim1_ch1n_pwm_out_pb13: tim1_ch1n_pwm_out_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			/omit-if-no-ref/ tim1_ch2n_pwm_out_pb14: tim1_ch2n_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			/omit-if-no-ref/ tim1_ch3n_pwm_out_pb15: tim1_ch3n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			/omit-if-no-ref/ tim15_ch1_pwm_out_pa2: tim15_ch1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM15_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			/omit-if-no-ref/ tim15_ch2_pwm_out_pa3: tim15_ch2_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM15_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch1_remap1_pwm_pb14: tim15_ch1_remap1_pwm_pb14 {
+			/omit-if-no-ref/ tim15_ch1_remap1_pwm_out_pb14: tim15_ch1_remap1_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM15_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			/omit-if-no-ref/ tim15_ch1n_pwm_out_pb15: tim15_ch1n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch2_remap1_pwm_pb15: tim15_ch2_remap1_pwm_pb15 {
+			/omit-if-no-ref/ tim15_ch2_remap1_pwm_out_pb15: tim15_ch2_remap1_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM15_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim16_ch1_remap1_pwm_pa6: tim16_ch1_remap1_pwm_pa6 {
+			/omit-if-no-ref/ tim16_ch1_remap1_pwm_out_pa6: tim16_ch1_remap1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM16_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			/omit-if-no-ref/ tim16_ch1n_pwm_out_pb6: tim16_ch1n_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			/omit-if-no-ref/ tim16_ch1_pwm_out_pb8: tim16_ch1_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM16_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim17_ch1_remap1_pwm_pa7: tim17_ch1_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim17_ch1_remap1_pwm_out_pa7: tim17_ch1_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM17_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			/omit-if-no-ref/ tim17_ch1n_pwm_out_pb7: tim17_ch1n_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			/omit-if-no-ref/ tim17_ch1_pwm_out_pb9: tim17_ch1_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM17_REMAP0)>;
 			};
 

--- a/dts/st/f1/stm32f100r(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(8-b)hx-pinctrl.dtsi
@@ -436,233 +436,463 @@
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_in_pa7: tim1_ch1n_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_pwm_in_pa8: tim1_ch1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_in_pa8: tim1_ch1_remap1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_pwm_in_pa9: tim1_ch2_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_in_pa9: tim1_ch2_remap1_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_pwm_in_pa10: tim1_ch3_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_in_pa10: tim1_ch3_remap1_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_pwm_in_pa11: tim1_ch4_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_in_pa11: tim1_ch4_remap1_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_in_pb0: tim1_ch2n_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_in_pb1: tim1_ch3n_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_pwm_in_pb13: tim1_ch1n_pwm_in_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_pwm_in_pb14: tim1_ch2n_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_pwm_in_pb15: tim1_ch3n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1_pwm_in_pa2: tim15_ch1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM15_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch2_pwm_in_pa3: tim15_ch2_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM15_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1_remap1_pwm_in_pb14: tim15_ch1_remap1_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM15_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1n_pwm_in_pb15: tim15_ch1n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch2_remap1_pwm_in_pb15: tim15_ch2_remap1_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM15_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim16_ch1_remap1_pwm_in_pa6: tim16_ch1_remap1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM16_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim16_ch1n_pwm_in_pb6: tim16_ch1n_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim16_ch1_pwm_in_pb8: tim16_ch1_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM16_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim17_ch1_remap1_pwm_in_pa7: tim17_ch1_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM17_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim17_ch1n_pwm_in_pb7: tim17_ch1n_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim17_ch1_pwm_in_pb9: tim17_ch1_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM17_REMAP0)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_out_pa7: tim1_ch1n_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_pwm_out_pa8: tim1_ch1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_out_pa8: tim1_ch1_remap1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_pwm_out_pa9: tim1_ch2_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_out_pa9: tim1_ch2_remap1_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_pwm_out_pa10: tim1_ch3_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_out_pa10: tim1_ch3_remap1_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_pwm_out_pa11: tim1_ch4_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_out_pa11: tim1_ch4_remap1_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_out_pb0: tim1_ch2n_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_out_pb1: tim1_ch3n_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			/omit-if-no-ref/ tim1_ch1n_pwm_out_pb13: tim1_ch1n_pwm_out_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			/omit-if-no-ref/ tim1_ch2n_pwm_out_pb14: tim1_ch2n_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			/omit-if-no-ref/ tim1_ch3n_pwm_out_pb15: tim1_ch3n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			/omit-if-no-ref/ tim15_ch1_pwm_out_pa2: tim15_ch1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM15_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			/omit-if-no-ref/ tim15_ch2_pwm_out_pa3: tim15_ch2_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM15_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch1_remap1_pwm_pb14: tim15_ch1_remap1_pwm_pb14 {
+			/omit-if-no-ref/ tim15_ch1_remap1_pwm_out_pb14: tim15_ch1_remap1_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM15_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			/omit-if-no-ref/ tim15_ch1n_pwm_out_pb15: tim15_ch1n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch2_remap1_pwm_pb15: tim15_ch2_remap1_pwm_pb15 {
+			/omit-if-no-ref/ tim15_ch2_remap1_pwm_out_pb15: tim15_ch2_remap1_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM15_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim16_ch1_remap1_pwm_pa6: tim16_ch1_remap1_pwm_pa6 {
+			/omit-if-no-ref/ tim16_ch1_remap1_pwm_out_pa6: tim16_ch1_remap1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM16_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			/omit-if-no-ref/ tim16_ch1n_pwm_out_pb6: tim16_ch1n_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			/omit-if-no-ref/ tim16_ch1_pwm_out_pb8: tim16_ch1_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM16_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim17_ch1_remap1_pwm_pa7: tim17_ch1_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim17_ch1_remap1_pwm_out_pa7: tim17_ch1_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM17_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			/omit-if-no-ref/ tim17_ch1n_pwm_out_pb7: tim17_ch1n_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			/omit-if-no-ref/ tim17_ch1_pwm_out_pb9: tim17_ch1_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM17_REMAP0)>;
 			};
 

--- a/dts/st/f1/stm32f100r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(8-b)tx-pinctrl.dtsi
@@ -444,233 +444,463 @@
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_in_pa7: tim1_ch1n_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_pwm_in_pa8: tim1_ch1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_in_pa8: tim1_ch1_remap1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_pwm_in_pa9: tim1_ch2_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_in_pa9: tim1_ch2_remap1_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_pwm_in_pa10: tim1_ch3_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_in_pa10: tim1_ch3_remap1_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_pwm_in_pa11: tim1_ch4_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_in_pa11: tim1_ch4_remap1_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_in_pb0: tim1_ch2n_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_in_pb1: tim1_ch3n_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_pwm_in_pb13: tim1_ch1n_pwm_in_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_pwm_in_pb14: tim1_ch2n_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_pwm_in_pb15: tim1_ch3n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1_pwm_in_pa2: tim15_ch1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM15_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch2_pwm_in_pa3: tim15_ch2_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM15_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1_remap1_pwm_in_pb14: tim15_ch1_remap1_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM15_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1n_pwm_in_pb15: tim15_ch1n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch2_remap1_pwm_in_pb15: tim15_ch2_remap1_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM15_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim16_ch1_remap1_pwm_in_pa6: tim16_ch1_remap1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM16_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim16_ch1n_pwm_in_pb6: tim16_ch1n_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim16_ch1_pwm_in_pb8: tim16_ch1_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM16_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim17_ch1_remap1_pwm_in_pa7: tim17_ch1_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM17_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim17_ch1n_pwm_in_pb7: tim17_ch1n_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim17_ch1_pwm_in_pb9: tim17_ch1_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM17_REMAP0)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_out_pa7: tim1_ch1n_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_pwm_out_pa8: tim1_ch1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_out_pa8: tim1_ch1_remap1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_pwm_out_pa9: tim1_ch2_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_out_pa9: tim1_ch2_remap1_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_pwm_out_pa10: tim1_ch3_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_out_pa10: tim1_ch3_remap1_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_pwm_out_pa11: tim1_ch4_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_out_pa11: tim1_ch4_remap1_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_out_pb0: tim1_ch2n_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_out_pb1: tim1_ch3n_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			/omit-if-no-ref/ tim1_ch1n_pwm_out_pb13: tim1_ch1n_pwm_out_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			/omit-if-no-ref/ tim1_ch2n_pwm_out_pb14: tim1_ch2n_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			/omit-if-no-ref/ tim1_ch3n_pwm_out_pb15: tim1_ch3n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			/omit-if-no-ref/ tim15_ch1_pwm_out_pa2: tim15_ch1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM15_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			/omit-if-no-ref/ tim15_ch2_pwm_out_pa3: tim15_ch2_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM15_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch1_remap1_pwm_pb14: tim15_ch1_remap1_pwm_pb14 {
+			/omit-if-no-ref/ tim15_ch1_remap1_pwm_out_pb14: tim15_ch1_remap1_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM15_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			/omit-if-no-ref/ tim15_ch1n_pwm_out_pb15: tim15_ch1n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch2_remap1_pwm_pb15: tim15_ch2_remap1_pwm_pb15 {
+			/omit-if-no-ref/ tim15_ch2_remap1_pwm_out_pb15: tim15_ch2_remap1_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM15_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim16_ch1_remap1_pwm_pa6: tim16_ch1_remap1_pwm_pa6 {
+			/omit-if-no-ref/ tim16_ch1_remap1_pwm_out_pa6: tim16_ch1_remap1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM16_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			/omit-if-no-ref/ tim16_ch1n_pwm_out_pb6: tim16_ch1n_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			/omit-if-no-ref/ tim16_ch1_pwm_out_pb8: tim16_ch1_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM16_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim17_ch1_remap1_pwm_pa7: tim17_ch1_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim17_ch1_remap1_pwm_out_pa7: tim17_ch1_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM17_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			/omit-if-no-ref/ tim17_ch1n_pwm_out_pb7: tim17_ch1n_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			/omit-if-no-ref/ tim17_ch1_pwm_out_pb9: tim17_ch1_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM17_REMAP0)>;
 			};
 

--- a/dts/st/f1/stm32f100r(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100r(c-d-e)tx-pinctrl.dtsi
@@ -478,281 +478,559 @@
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_in_pa7: tim1_ch1n_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_pwm_in_pa8: tim1_ch1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_in_pa8: tim1_ch1_remap1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_pwm_in_pa9: tim1_ch2_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_in_pa9: tim1_ch2_remap1_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_pwm_in_pa10: tim1_ch3_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_in_pa10: tim1_ch3_remap1_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_pwm_in_pa11: tim1_ch4_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_in_pa11: tim1_ch4_remap1_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_in_pb0: tim1_ch2n_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_in_pb1: tim1_ch3n_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_pwm_in_pb13: tim1_ch1n_pwm_in_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_pwm_in_pb14: tim1_ch2n_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_pwm_in_pb15: tim1_ch3n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim12_ch1_remap1_pwm_in_pb12: tim12_ch1_remap1_pwm_in_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, TIM12_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim12_ch2_remap1_pwm_in_pb13: tim12_ch2_remap1_pwm_in_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, TIM12_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim12_ch1_pwm_in_pc4: tim12_ch1_pwm_in_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, GPIO_IN, TIM12_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim12_ch2_pwm_in_pc5: tim12_ch2_pwm_in_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, GPIO_IN, TIM12_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim13_ch1_remap1_pwm_in_pb0: tim13_ch1_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM13_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim13_ch1_pwm_in_pc8: tim13_ch1_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM13_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim14_ch1_remap1_pwm_in_pb1: tim14_ch1_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM14_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim14_ch1_pwm_in_pc9: tim14_ch1_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM14_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch1_pwm_in_pa0: tim5_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pwm_in_pa1: tim5_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1_pwm_in_pa2: tim15_ch1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM15_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch3_pwm_in_pa2: tim5_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch2_pwm_in_pa3: tim15_ch2_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM15_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch4_pwm_in_pa3: tim5_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1_remap1_pwm_in_pb14: tim15_ch1_remap1_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM15_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1n_pwm_in_pb15: tim15_ch1n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch2_remap1_pwm_in_pb15: tim15_ch2_remap1_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM15_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim16_ch1_remap1_pwm_in_pa6: tim16_ch1_remap1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM16_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim16_ch1n_pwm_in_pb6: tim16_ch1n_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim16_ch1_pwm_in_pb8: tim16_ch1_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM16_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim17_ch1_remap1_pwm_in_pa7: tim17_ch1_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM17_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim17_ch1n_pwm_in_pb7: tim17_ch1n_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim17_ch1_pwm_in_pb9: tim17_ch1_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM17_REMAP0)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_out_pa7: tim1_ch1n_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_pwm_out_pa8: tim1_ch1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_out_pa8: tim1_ch1_remap1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_pwm_out_pa9: tim1_ch2_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_out_pa9: tim1_ch2_remap1_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_pwm_out_pa10: tim1_ch3_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_out_pa10: tim1_ch3_remap1_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_pwm_out_pa11: tim1_ch4_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_out_pa11: tim1_ch4_remap1_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_out_pb0: tim1_ch2n_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_out_pb1: tim1_ch3n_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			/omit-if-no-ref/ tim1_ch1n_pwm_out_pb13: tim1_ch1n_pwm_out_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			/omit-if-no-ref/ tim1_ch2n_pwm_out_pb14: tim1_ch2n_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			/omit-if-no-ref/ tim1_ch3n_pwm_out_pb15: tim1_ch3n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim12_ch1_remap1_pwm_pb12: tim12_ch1_remap1_pwm_pb12 {
+			/omit-if-no-ref/ tim12_ch1_remap1_pwm_out_pb12: tim12_ch1_remap1_pwm_out_pb12 {
 				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, TIM12_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim12_ch2_remap1_pwm_pb13: tim12_ch2_remap1_pwm_pb13 {
+			/omit-if-no-ref/ tim12_ch2_remap1_pwm_out_pb13: tim12_ch2_remap1_pwm_out_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM12_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim12_ch1_pwm_pc4: tim12_ch1_pwm_pc4 {
+			/omit-if-no-ref/ tim12_ch1_pwm_out_pc4: tim12_ch1_pwm_out_pc4 {
 				pinmux = <STM32F1_PINMUX('C', 4, ALTERNATE, TIM12_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim12_ch2_pwm_pc5: tim12_ch2_pwm_pc5 {
+			/omit-if-no-ref/ tim12_ch2_pwm_out_pc5: tim12_ch2_pwm_out_pc5 {
 				pinmux = <STM32F1_PINMUX('C', 5, ALTERNATE, TIM12_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim13_ch1_remap1_pwm_pb0: tim13_ch1_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim13_ch1_remap1_pwm_out_pb0: tim13_ch1_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM13_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim13_ch1_pwm_pc8: tim13_ch1_pwm_pc8 {
+			/omit-if-no-ref/ tim13_ch1_pwm_out_pc8: tim13_ch1_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM13_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim14_ch1_remap1_pwm_pb1: tim14_ch1_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim14_ch1_remap1_pwm_out_pb1: tim14_ch1_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM14_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim14_ch1_pwm_pc9: tim14_ch1_pwm_pc9 {
+			/omit-if-no-ref/ tim14_ch1_pwm_out_pc9: tim14_ch1_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM14_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim5_ch1_pwm_out_pa0: tim5_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim5_ch2_pwm_out_pa1: tim5_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			/omit-if-no-ref/ tim15_ch1_pwm_out_pa2: tim15_ch1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM15_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim5_ch3_pwm_out_pa2: tim5_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			/omit-if-no-ref/ tim15_ch2_pwm_out_pa3: tim15_ch2_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM15_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim5_ch4_pwm_out_pa3: tim5_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch1_remap1_pwm_pb14: tim15_ch1_remap1_pwm_pb14 {
+			/omit-if-no-ref/ tim15_ch1_remap1_pwm_out_pb14: tim15_ch1_remap1_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM15_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			/omit-if-no-ref/ tim15_ch1n_pwm_out_pb15: tim15_ch1n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch2_remap1_pwm_pb15: tim15_ch2_remap1_pwm_pb15 {
+			/omit-if-no-ref/ tim15_ch2_remap1_pwm_out_pb15: tim15_ch2_remap1_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM15_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim16_ch1_remap1_pwm_pa6: tim16_ch1_remap1_pwm_pa6 {
+			/omit-if-no-ref/ tim16_ch1_remap1_pwm_out_pa6: tim16_ch1_remap1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM16_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			/omit-if-no-ref/ tim16_ch1n_pwm_out_pb6: tim16_ch1n_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			/omit-if-no-ref/ tim16_ch1_pwm_out_pb8: tim16_ch1_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM16_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim17_ch1_remap1_pwm_pa7: tim17_ch1_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim17_ch1_remap1_pwm_out_pa7: tim17_ch1_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM17_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			/omit-if-no-ref/ tim17_ch1n_pwm_out_pb7: tim17_ch1n_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			/omit-if-no-ref/ tim17_ch1_pwm_out_pb9: tim17_ch1_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM17_REMAP0)>;
 			};
 

--- a/dts/st/f1/stm32f100v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100v(8-b)tx-pinctrl.dtsi
@@ -560,277 +560,551 @@
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_in_pa7: tim1_ch1n_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_pwm_in_pa8: tim1_ch1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_in_pa8: tim1_ch1_remap1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_pwm_in_pa9: tim1_ch2_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_in_pa9: tim1_ch2_remap1_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_pwm_in_pa10: tim1_ch3_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_in_pa10: tim1_ch3_remap1_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_pwm_in_pa11: tim1_ch4_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_in_pa11: tim1_ch4_remap1_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_in_pb0: tim1_ch2n_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_in_pb1: tim1_ch3n_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_pwm_in_pb13: tim1_ch1n_pwm_in_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_pwm_in_pb14: tim1_ch2n_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_pwm_in_pb15: tim1_ch3n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_in_pe8: tim1_ch1n_remap2_pwm_in_pe8 {
+				pinmux = <STM32F1_PINMUX('E', 8, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_in_pe9: tim1_ch1_remap2_pwm_in_pe9 {
+				pinmux = <STM32F1_PINMUX('E', 9, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_in_pe10: tim1_ch2n_remap2_pwm_in_pe10 {
+				pinmux = <STM32F1_PINMUX('E', 10, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_in_pe11: tim1_ch2_remap2_pwm_in_pe11 {
+				pinmux = <STM32F1_PINMUX('E', 11, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_in_pe12: tim1_ch3n_remap2_pwm_in_pe12 {
+				pinmux = <STM32F1_PINMUX('E', 12, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_in_pe13: tim1_ch3_remap2_pwm_in_pe13 {
+				pinmux = <STM32F1_PINMUX('E', 13, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_in_pe14: tim1_ch4_remap2_pwm_in_pe14 {
+				pinmux = <STM32F1_PINMUX('E', 14, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_in_pd12: tim4_ch1_remap1_pwm_in_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_in_pd13: tim4_ch2_remap1_pwm_in_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_in_pd14: tim4_ch3_remap1_pwm_in_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_in_pd15: tim4_ch4_remap1_pwm_in_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1_pwm_in_pa2: tim15_ch1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM15_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch2_pwm_in_pa3: tim15_ch2_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM15_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1_remap1_pwm_in_pb14: tim15_ch1_remap1_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM15_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1n_pwm_in_pb15: tim15_ch1n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch2_remap1_pwm_in_pb15: tim15_ch2_remap1_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM15_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim16_ch1_remap1_pwm_in_pa6: tim16_ch1_remap1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM16_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim16_ch1n_pwm_in_pb6: tim16_ch1n_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim16_ch1_pwm_in_pb8: tim16_ch1_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM16_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim17_ch1_remap1_pwm_in_pa7: tim17_ch1_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM17_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim17_ch1n_pwm_in_pb7: tim17_ch1n_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim17_ch1_pwm_in_pb9: tim17_ch1_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM17_REMAP0)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_out_pa7: tim1_ch1n_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_pwm_out_pa8: tim1_ch1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_out_pa8: tim1_ch1_remap1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_pwm_out_pa9: tim1_ch2_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_out_pa9: tim1_ch2_remap1_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_pwm_out_pa10: tim1_ch3_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_out_pa10: tim1_ch3_remap1_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_pwm_out_pa11: tim1_ch4_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_out_pa11: tim1_ch4_remap1_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_out_pb0: tim1_ch2n_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_out_pb1: tim1_ch3n_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			/omit-if-no-ref/ tim1_ch1n_pwm_out_pb13: tim1_ch1n_pwm_out_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			/omit-if-no-ref/ tim1_ch2n_pwm_out_pb14: tim1_ch2n_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			/omit-if-no-ref/ tim1_ch3n_pwm_out_pb15: tim1_ch3n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_pe8: tim1_ch1n_remap2_pwm_pe8 {
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_out_pe8: tim1_ch1n_remap2_pwm_out_pe8 {
 				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap2_pwm_pe9: tim1_ch1_remap2_pwm_pe9 {
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_out_pe9: tim1_ch1_remap2_pwm_out_pe9 {
 				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_pe10: tim1_ch2n_remap2_pwm_pe10 {
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_out_pe10: tim1_ch2n_remap2_pwm_out_pe10 {
 				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap2_pwm_pe11: tim1_ch2_remap2_pwm_pe11 {
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_out_pe11: tim1_ch2_remap2_pwm_out_pe11 {
 				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_pe12: tim1_ch3n_remap2_pwm_pe12 {
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_out_pe12: tim1_ch3n_remap2_pwm_out_pe12 {
 				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap2_pwm_pe13: tim1_ch3_remap2_pwm_pe13 {
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_out_pe13: tim1_ch3_remap2_pwm_out_pe13 {
 				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap2_pwm_pe14: tim1_ch4_remap2_pwm_pe14 {
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_out_pe14: tim1_ch4_remap2_pwm_out_pe14 {
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_out_pd12: tim4_ch1_remap1_pwm_out_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_out_pd13: tim4_ch2_remap1_pwm_out_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_out_pd14: tim4_ch3_remap1_pwm_out_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_out_pd15: tim4_ch4_remap1_pwm_out_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			/omit-if-no-ref/ tim15_ch1_pwm_out_pa2: tim15_ch1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM15_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			/omit-if-no-ref/ tim15_ch2_pwm_out_pa3: tim15_ch2_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM15_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch1_remap1_pwm_pb14: tim15_ch1_remap1_pwm_pb14 {
+			/omit-if-no-ref/ tim15_ch1_remap1_pwm_out_pb14: tim15_ch1_remap1_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM15_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			/omit-if-no-ref/ tim15_ch1n_pwm_out_pb15: tim15_ch1n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch2_remap1_pwm_pb15: tim15_ch2_remap1_pwm_pb15 {
+			/omit-if-no-ref/ tim15_ch2_remap1_pwm_out_pb15: tim15_ch2_remap1_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM15_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim16_ch1_remap1_pwm_pa6: tim16_ch1_remap1_pwm_pa6 {
+			/omit-if-no-ref/ tim16_ch1_remap1_pwm_out_pa6: tim16_ch1_remap1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM16_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			/omit-if-no-ref/ tim16_ch1n_pwm_out_pb6: tim16_ch1n_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			/omit-if-no-ref/ tim16_ch1_pwm_out_pb8: tim16_ch1_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM16_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim17_ch1_remap1_pwm_pa7: tim17_ch1_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim17_ch1_remap1_pwm_out_pa7: tim17_ch1_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM17_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			/omit-if-no-ref/ tim17_ch1n_pwm_out_pb7: tim17_ch1n_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			/omit-if-no-ref/ tim17_ch1_pwm_out_pb9: tim17_ch1_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM17_REMAP0)>;
 			};
 

--- a/dts/st/f1/stm32f100v(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100v(c-d-e)tx-pinctrl.dtsi
@@ -594,325 +594,647 @@
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_in_pa7: tim1_ch1n_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_pwm_in_pa8: tim1_ch1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_in_pa8: tim1_ch1_remap1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_pwm_in_pa9: tim1_ch2_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_in_pa9: tim1_ch2_remap1_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_pwm_in_pa10: tim1_ch3_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_in_pa10: tim1_ch3_remap1_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_pwm_in_pa11: tim1_ch4_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_in_pa11: tim1_ch4_remap1_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_in_pb0: tim1_ch2n_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_in_pb1: tim1_ch3n_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_pwm_in_pb13: tim1_ch1n_pwm_in_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_pwm_in_pb14: tim1_ch2n_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_pwm_in_pb15: tim1_ch3n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_in_pe8: tim1_ch1n_remap2_pwm_in_pe8 {
+				pinmux = <STM32F1_PINMUX('E', 8, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_in_pe9: tim1_ch1_remap2_pwm_in_pe9 {
+				pinmux = <STM32F1_PINMUX('E', 9, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_in_pe10: tim1_ch2n_remap2_pwm_in_pe10 {
+				pinmux = <STM32F1_PINMUX('E', 10, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_in_pe11: tim1_ch2_remap2_pwm_in_pe11 {
+				pinmux = <STM32F1_PINMUX('E', 11, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_in_pe12: tim1_ch3n_remap2_pwm_in_pe12 {
+				pinmux = <STM32F1_PINMUX('E', 12, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_in_pe13: tim1_ch3_remap2_pwm_in_pe13 {
+				pinmux = <STM32F1_PINMUX('E', 13, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_in_pe14: tim1_ch4_remap2_pwm_in_pe14 {
+				pinmux = <STM32F1_PINMUX('E', 14, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim12_ch1_remap1_pwm_in_pb12: tim12_ch1_remap1_pwm_in_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, TIM12_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim12_ch2_remap1_pwm_in_pb13: tim12_ch2_remap1_pwm_in_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, TIM12_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim12_ch1_pwm_in_pc4: tim12_ch1_pwm_in_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, GPIO_IN, TIM12_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim12_ch2_pwm_in_pc5: tim12_ch2_pwm_in_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, GPIO_IN, TIM12_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim13_ch1_remap1_pwm_in_pb0: tim13_ch1_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM13_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim13_ch1_pwm_in_pc8: tim13_ch1_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM13_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim14_ch1_remap1_pwm_in_pb1: tim14_ch1_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM14_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim14_ch1_pwm_in_pc9: tim14_ch1_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM14_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_in_pd12: tim4_ch1_remap1_pwm_in_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_in_pd13: tim4_ch2_remap1_pwm_in_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_in_pd14: tim4_ch3_remap1_pwm_in_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_in_pd15: tim4_ch4_remap1_pwm_in_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch1_pwm_in_pa0: tim5_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pwm_in_pa1: tim5_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1_pwm_in_pa2: tim15_ch1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM15_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch3_pwm_in_pa2: tim5_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch2_pwm_in_pa3: tim15_ch2_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM15_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch4_pwm_in_pa3: tim5_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1_remap1_pwm_in_pb14: tim15_ch1_remap1_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM15_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1n_pwm_in_pb15: tim15_ch1n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch2_remap1_pwm_in_pb15: tim15_ch2_remap1_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM15_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim16_ch1_remap1_pwm_in_pa6: tim16_ch1_remap1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM16_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim16_ch1n_pwm_in_pb6: tim16_ch1n_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim16_ch1_pwm_in_pb8: tim16_ch1_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM16_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim17_ch1_remap1_pwm_in_pa7: tim17_ch1_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM17_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim17_ch1n_pwm_in_pb7: tim17_ch1n_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim17_ch1_pwm_in_pb9: tim17_ch1_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM17_REMAP0)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_out_pa7: tim1_ch1n_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_pwm_out_pa8: tim1_ch1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_out_pa8: tim1_ch1_remap1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_pwm_out_pa9: tim1_ch2_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_out_pa9: tim1_ch2_remap1_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_pwm_out_pa10: tim1_ch3_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_out_pa10: tim1_ch3_remap1_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_pwm_out_pa11: tim1_ch4_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_out_pa11: tim1_ch4_remap1_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_out_pb0: tim1_ch2n_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_out_pb1: tim1_ch3n_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			/omit-if-no-ref/ tim1_ch1n_pwm_out_pb13: tim1_ch1n_pwm_out_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			/omit-if-no-ref/ tim1_ch2n_pwm_out_pb14: tim1_ch2n_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			/omit-if-no-ref/ tim1_ch3n_pwm_out_pb15: tim1_ch3n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_pe8: tim1_ch1n_remap2_pwm_pe8 {
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_out_pe8: tim1_ch1n_remap2_pwm_out_pe8 {
 				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap2_pwm_pe9: tim1_ch1_remap2_pwm_pe9 {
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_out_pe9: tim1_ch1_remap2_pwm_out_pe9 {
 				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_pe10: tim1_ch2n_remap2_pwm_pe10 {
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_out_pe10: tim1_ch2n_remap2_pwm_out_pe10 {
 				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap2_pwm_pe11: tim1_ch2_remap2_pwm_pe11 {
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_out_pe11: tim1_ch2_remap2_pwm_out_pe11 {
 				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_pe12: tim1_ch3n_remap2_pwm_pe12 {
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_out_pe12: tim1_ch3n_remap2_pwm_out_pe12 {
 				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap2_pwm_pe13: tim1_ch3_remap2_pwm_pe13 {
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_out_pe13: tim1_ch3_remap2_pwm_out_pe13 {
 				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap2_pwm_pe14: tim1_ch4_remap2_pwm_pe14 {
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_out_pe14: tim1_ch4_remap2_pwm_out_pe14 {
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim12_ch1_remap1_pwm_pb12: tim12_ch1_remap1_pwm_pb12 {
+			/omit-if-no-ref/ tim12_ch1_remap1_pwm_out_pb12: tim12_ch1_remap1_pwm_out_pb12 {
 				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, TIM12_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim12_ch2_remap1_pwm_pb13: tim12_ch2_remap1_pwm_pb13 {
+			/omit-if-no-ref/ tim12_ch2_remap1_pwm_out_pb13: tim12_ch2_remap1_pwm_out_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM12_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim12_ch1_pwm_pc4: tim12_ch1_pwm_pc4 {
+			/omit-if-no-ref/ tim12_ch1_pwm_out_pc4: tim12_ch1_pwm_out_pc4 {
 				pinmux = <STM32F1_PINMUX('C', 4, ALTERNATE, TIM12_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim12_ch2_pwm_pc5: tim12_ch2_pwm_pc5 {
+			/omit-if-no-ref/ tim12_ch2_pwm_out_pc5: tim12_ch2_pwm_out_pc5 {
 				pinmux = <STM32F1_PINMUX('C', 5, ALTERNATE, TIM12_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim13_ch1_remap1_pwm_pb0: tim13_ch1_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim13_ch1_remap1_pwm_out_pb0: tim13_ch1_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM13_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim13_ch1_pwm_pc8: tim13_ch1_pwm_pc8 {
+			/omit-if-no-ref/ tim13_ch1_pwm_out_pc8: tim13_ch1_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM13_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim14_ch1_remap1_pwm_pb1: tim14_ch1_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim14_ch1_remap1_pwm_out_pb1: tim14_ch1_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM14_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim14_ch1_pwm_pc9: tim14_ch1_pwm_pc9 {
+			/omit-if-no-ref/ tim14_ch1_pwm_out_pc9: tim14_ch1_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM14_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_out_pd12: tim4_ch1_remap1_pwm_out_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_out_pd13: tim4_ch2_remap1_pwm_out_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_out_pd14: tim4_ch3_remap1_pwm_out_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_out_pd15: tim4_ch4_remap1_pwm_out_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim5_ch1_pwm_out_pa0: tim5_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim5_ch2_pwm_out_pa1: tim5_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			/omit-if-no-ref/ tim15_ch1_pwm_out_pa2: tim15_ch1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM15_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim5_ch3_pwm_out_pa2: tim5_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			/omit-if-no-ref/ tim15_ch2_pwm_out_pa3: tim15_ch2_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM15_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim5_ch4_pwm_out_pa3: tim5_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch1_remap1_pwm_pb14: tim15_ch1_remap1_pwm_pb14 {
+			/omit-if-no-ref/ tim15_ch1_remap1_pwm_out_pb14: tim15_ch1_remap1_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM15_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			/omit-if-no-ref/ tim15_ch1n_pwm_out_pb15: tim15_ch1n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch2_remap1_pwm_pb15: tim15_ch2_remap1_pwm_pb15 {
+			/omit-if-no-ref/ tim15_ch2_remap1_pwm_out_pb15: tim15_ch2_remap1_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM15_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim16_ch1_remap1_pwm_pa6: tim16_ch1_remap1_pwm_pa6 {
+			/omit-if-no-ref/ tim16_ch1_remap1_pwm_out_pa6: tim16_ch1_remap1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM16_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			/omit-if-no-ref/ tim16_ch1n_pwm_out_pb6: tim16_ch1n_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			/omit-if-no-ref/ tim16_ch1_pwm_out_pb8: tim16_ch1_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM16_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim17_ch1_remap1_pwm_pa7: tim17_ch1_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim17_ch1_remap1_pwm_out_pa7: tim17_ch1_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM17_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			/omit-if-no-ref/ tim17_ch1n_pwm_out_pb7: tim17_ch1n_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			/omit-if-no-ref/ tim17_ch1_pwm_out_pb9: tim17_ch1_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM17_REMAP0)>;
 			};
 

--- a/dts/st/f1/stm32f100z(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f100z(c-d-e)tx-pinctrl.dtsi
@@ -722,325 +722,647 @@
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, NO_REMAP)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_in_pa7: tim1_ch1n_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_pwm_in_pa8: tim1_ch1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_in_pa8: tim1_ch1_remap1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_pwm_in_pa9: tim1_ch2_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_in_pa9: tim1_ch2_remap1_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_pwm_in_pa10: tim1_ch3_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_in_pa10: tim1_ch3_remap1_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_pwm_in_pa11: tim1_ch4_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_in_pa11: tim1_ch4_remap1_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_in_pb0: tim1_ch2n_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_in_pb1: tim1_ch3n_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_pwm_in_pb13: tim1_ch1n_pwm_in_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_pwm_in_pb14: tim1_ch2n_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_pwm_in_pb15: tim1_ch3n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_in_pe8: tim1_ch1n_remap2_pwm_in_pe8 {
+				pinmux = <STM32F1_PINMUX('E', 8, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_in_pe9: tim1_ch1_remap2_pwm_in_pe9 {
+				pinmux = <STM32F1_PINMUX('E', 9, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_in_pe10: tim1_ch2n_remap2_pwm_in_pe10 {
+				pinmux = <STM32F1_PINMUX('E', 10, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_in_pe11: tim1_ch2_remap2_pwm_in_pe11 {
+				pinmux = <STM32F1_PINMUX('E', 11, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_in_pe12: tim1_ch3n_remap2_pwm_in_pe12 {
+				pinmux = <STM32F1_PINMUX('E', 12, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_in_pe13: tim1_ch3_remap2_pwm_in_pe13 {
+				pinmux = <STM32F1_PINMUX('E', 13, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_in_pe14: tim1_ch4_remap2_pwm_in_pe14 {
+				pinmux = <STM32F1_PINMUX('E', 14, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim12_ch1_remap1_pwm_in_pb12: tim12_ch1_remap1_pwm_in_pb12 {
+				pinmux = <STM32F1_PINMUX('B', 12, GPIO_IN, TIM12_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim12_ch2_remap1_pwm_in_pb13: tim12_ch2_remap1_pwm_in_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, TIM12_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim12_ch1_pwm_in_pc4: tim12_ch1_pwm_in_pc4 {
+				pinmux = <STM32F1_PINMUX('C', 4, GPIO_IN, TIM12_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim12_ch2_pwm_in_pc5: tim12_ch2_pwm_in_pc5 {
+				pinmux = <STM32F1_PINMUX('C', 5, GPIO_IN, TIM12_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim13_ch1_remap1_pwm_in_pb0: tim13_ch1_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM13_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim13_ch1_pwm_in_pc8: tim13_ch1_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM13_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim14_ch1_remap1_pwm_in_pb1: tim14_ch1_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM14_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim14_ch1_pwm_in_pc9: tim14_ch1_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM14_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_in_pd12: tim4_ch1_remap1_pwm_in_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_in_pd13: tim4_ch2_remap1_pwm_in_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_in_pd14: tim4_ch3_remap1_pwm_in_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_in_pd15: tim4_ch4_remap1_pwm_in_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch1_pwm_in_pa0: tim5_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pwm_in_pa1: tim5_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1_pwm_in_pa2: tim15_ch1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM15_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch3_pwm_in_pa2: tim5_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch2_pwm_in_pa3: tim15_ch2_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM15_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch4_pwm_in_pa3: tim5_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1_remap1_pwm_in_pb14: tim15_ch1_remap1_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM15_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch1n_pwm_in_pb15: tim15_ch1n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim15_ch2_remap1_pwm_in_pb15: tim15_ch2_remap1_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM15_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim16_ch1_remap1_pwm_in_pa6: tim16_ch1_remap1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM16_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim16_ch1n_pwm_in_pb6: tim16_ch1n_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim16_ch1_pwm_in_pb8: tim16_ch1_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM16_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim17_ch1_remap1_pwm_in_pa7: tim17_ch1_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM17_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim17_ch1n_pwm_in_pb7: tim17_ch1n_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim17_ch1_pwm_in_pb9: tim17_ch1_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM17_REMAP0)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_out_pa7: tim1_ch1n_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_pwm_out_pa8: tim1_ch1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_out_pa8: tim1_ch1_remap1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_pwm_out_pa9: tim1_ch2_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_out_pa9: tim1_ch2_remap1_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_pwm_out_pa10: tim1_ch3_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_out_pa10: tim1_ch3_remap1_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_pwm_out_pa11: tim1_ch4_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_out_pa11: tim1_ch4_remap1_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_out_pb0: tim1_ch2n_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_out_pb1: tim1_ch3n_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			/omit-if-no-ref/ tim1_ch1n_pwm_out_pb13: tim1_ch1n_pwm_out_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			/omit-if-no-ref/ tim1_ch2n_pwm_out_pb14: tim1_ch2n_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			/omit-if-no-ref/ tim1_ch3n_pwm_out_pb15: tim1_ch3n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_pe8: tim1_ch1n_remap2_pwm_pe8 {
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_out_pe8: tim1_ch1n_remap2_pwm_out_pe8 {
 				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap2_pwm_pe9: tim1_ch1_remap2_pwm_pe9 {
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_out_pe9: tim1_ch1_remap2_pwm_out_pe9 {
 				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_pe10: tim1_ch2n_remap2_pwm_pe10 {
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_out_pe10: tim1_ch2n_remap2_pwm_out_pe10 {
 				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap2_pwm_pe11: tim1_ch2_remap2_pwm_pe11 {
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_out_pe11: tim1_ch2_remap2_pwm_out_pe11 {
 				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_pe12: tim1_ch3n_remap2_pwm_pe12 {
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_out_pe12: tim1_ch3n_remap2_pwm_out_pe12 {
 				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap2_pwm_pe13: tim1_ch3_remap2_pwm_pe13 {
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_out_pe13: tim1_ch3_remap2_pwm_out_pe13 {
 				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap2_pwm_pe14: tim1_ch4_remap2_pwm_pe14 {
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_out_pe14: tim1_ch4_remap2_pwm_out_pe14 {
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim12_ch1_remap1_pwm_pb12: tim12_ch1_remap1_pwm_pb12 {
+			/omit-if-no-ref/ tim12_ch1_remap1_pwm_out_pb12: tim12_ch1_remap1_pwm_out_pb12 {
 				pinmux = <STM32F1_PINMUX('B', 12, ALTERNATE, TIM12_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim12_ch2_remap1_pwm_pb13: tim12_ch2_remap1_pwm_pb13 {
+			/omit-if-no-ref/ tim12_ch2_remap1_pwm_out_pb13: tim12_ch2_remap1_pwm_out_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM12_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim12_ch1_pwm_pc4: tim12_ch1_pwm_pc4 {
+			/omit-if-no-ref/ tim12_ch1_pwm_out_pc4: tim12_ch1_pwm_out_pc4 {
 				pinmux = <STM32F1_PINMUX('C', 4, ALTERNATE, TIM12_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim12_ch2_pwm_pc5: tim12_ch2_pwm_pc5 {
+			/omit-if-no-ref/ tim12_ch2_pwm_out_pc5: tim12_ch2_pwm_out_pc5 {
 				pinmux = <STM32F1_PINMUX('C', 5, ALTERNATE, TIM12_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim13_ch1_remap1_pwm_pb0: tim13_ch1_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim13_ch1_remap1_pwm_out_pb0: tim13_ch1_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM13_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim13_ch1_pwm_pc8: tim13_ch1_pwm_pc8 {
+			/omit-if-no-ref/ tim13_ch1_pwm_out_pc8: tim13_ch1_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM13_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim14_ch1_remap1_pwm_pb1: tim14_ch1_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim14_ch1_remap1_pwm_out_pb1: tim14_ch1_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM14_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim14_ch1_pwm_pc9: tim14_ch1_pwm_pc9 {
+			/omit-if-no-ref/ tim14_ch1_pwm_out_pc9: tim14_ch1_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM14_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_out_pd12: tim4_ch1_remap1_pwm_out_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_out_pd13: tim4_ch2_remap1_pwm_out_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_out_pd14: tim4_ch3_remap1_pwm_out_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_out_pd15: tim4_ch4_remap1_pwm_out_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim5_ch1_pwm_out_pa0: tim5_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim5_ch2_pwm_out_pa1: tim5_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch1_pwm_pa2: tim15_ch1_pwm_pa2 {
+			/omit-if-no-ref/ tim15_ch1_pwm_out_pa2: tim15_ch1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM15_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim5_ch3_pwm_out_pa2: tim5_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch2_pwm_pa3: tim15_ch2_pwm_pa3 {
+			/omit-if-no-ref/ tim15_ch2_pwm_out_pa3: tim15_ch2_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM15_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim5_ch4_pwm_out_pa3: tim5_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch1_remap1_pwm_pb14: tim15_ch1_remap1_pwm_pb14 {
+			/omit-if-no-ref/ tim15_ch1_remap1_pwm_out_pb14: tim15_ch1_remap1_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM15_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch1n_pwm_pb15: tim15_ch1n_pwm_pb15 {
+			/omit-if-no-ref/ tim15_ch1n_pwm_out_pb15: tim15_ch1n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim15_ch2_remap1_pwm_pb15: tim15_ch2_remap1_pwm_pb15 {
+			/omit-if-no-ref/ tim15_ch2_remap1_pwm_out_pb15: tim15_ch2_remap1_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM15_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim16_ch1_remap1_pwm_pa6: tim16_ch1_remap1_pwm_pa6 {
+			/omit-if-no-ref/ tim16_ch1_remap1_pwm_out_pa6: tim16_ch1_remap1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM16_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim16_ch1n_pwm_pb6: tim16_ch1n_pwm_pb6 {
+			/omit-if-no-ref/ tim16_ch1n_pwm_out_pb6: tim16_ch1n_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim16_ch1_pwm_pb8: tim16_ch1_pwm_pb8 {
+			/omit-if-no-ref/ tim16_ch1_pwm_out_pb8: tim16_ch1_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM16_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim17_ch1_remap1_pwm_pa7: tim17_ch1_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim17_ch1_remap1_pwm_out_pa7: tim17_ch1_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM17_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim17_ch1n_pwm_pb7: tim17_ch1n_pwm_pb7 {
+			/omit-if-no-ref/ tim17_ch1n_pwm_out_pb7: tim17_ch1n_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim17_ch1_pwm_pb9: tim17_ch1_pwm_pb9 {
+			/omit-if-no-ref/ tim17_ch1_pwm_out_pb9: tim17_ch1_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM17_REMAP0)>;
 			};
 

--- a/dts/st/f1/stm32f101c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101c(4-6)tx-pinctrl.dtsi
@@ -310,101 +310,199 @@
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f101c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101c(8-b)tx-pinctrl.dtsi
@@ -354,117 +354,231 @@
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 

--- a/dts/st/f1/stm32f101c(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101c(8-b)ux-pinctrl.dtsi
@@ -354,117 +354,231 @@
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 

--- a/dts/st/f1/stm32f101r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101r(4-6)tx-pinctrl.dtsi
@@ -390,117 +390,231 @@
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 

--- a/dts/st/f1/stm32f101r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101r(8-b)tx-pinctrl.dtsi
@@ -434,133 +434,263 @@
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 

--- a/dts/st/f1/stm32f101r(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101r(c-d-e)tx-pinctrl.dtsi
@@ -478,149 +478,295 @@
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch1_pwm_in_pa0: tim5_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pwm_in_pa1: tim5_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch3_pwm_in_pa2: tim5_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch4_pwm_in_pa3: tim5_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim5_ch1_pwm_out_pa0: tim5_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim5_ch2_pwm_out_pa1: tim5_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim5_ch3_pwm_out_pa2: tim5_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim5_ch4_pwm_out_pa3: tim5_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
 			};
 

--- a/dts/st/f1/stm32f101r(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101r(f-g)tx-pinctrl.dtsi
@@ -478,181 +478,359 @@
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			/omit-if-no-ref/ tim10_ch1_pwm_in_pb8: tim10_ch1_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM10_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim11_ch1_pwm_in_pb9: tim11_ch1_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM11_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim12_ch1_pwm_in_pb14: tim12_ch1_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim12_ch2_pwm_in_pb15: tim12_ch2_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim13_ch1_pwm_in_pa6: tim13_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM13_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim14_ch1_pwm_in_pa7: tim14_ch1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM14_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch1_pwm_in_pa0: tim5_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pwm_in_pa1: tim5_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch3_pwm_in_pa2: tim5_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch4_pwm_in_pa3: tim5_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim9_ch1_pwm_in_pa2: tim9_ch1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM9_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim9_ch2_pwm_in_pa3: tim9_ch2_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM9_REMAP0)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim10_ch1_pwm_out_pb8: tim10_ch1_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM10_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			/omit-if-no-ref/ tim11_ch1_pwm_out_pb9: tim11_ch1_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM11_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			/omit-if-no-ref/ tim12_ch1_pwm_out_pb14: tim12_ch1_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			/omit-if-no-ref/ tim12_ch2_pwm_out_pb15: tim12_ch2_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim13_ch1_pwm_out_pa6: tim13_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM13_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			/omit-if-no-ref/ tim14_ch1_pwm_out_pa7: tim14_ch1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM14_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim5_ch1_pwm_out_pa0: tim5_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim5_ch2_pwm_out_pa1: tim5_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim5_ch3_pwm_out_pa2: tim5_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim5_ch4_pwm_out_pa3: tim5_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			/omit-if-no-ref/ tim9_ch1_pwm_out_pa2: tim9_ch1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM9_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			/omit-if-no-ref/ tim9_ch2_pwm_out_pa3: tim9_ch2_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM9_REMAP0)>;
 			};
 

--- a/dts/st/f1/stm32f101rbhx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101rbhx-pinctrl.dtsi
@@ -426,133 +426,263 @@
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 

--- a/dts/st/f1/stm32f101t(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101t(4-6)ux-pinctrl.dtsi
@@ -256,85 +256,167 @@
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f101t(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101t(8-b)ux-pinctrl.dtsi
@@ -256,93 +256,183 @@
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 

--- a/dts/st/f1/stm32f101v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101v(8-b)tx-pinctrl.dtsi
@@ -550,149 +550,295 @@
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_in_pd12: tim4_ch1_remap1_pwm_in_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_in_pd13: tim4_ch2_remap1_pwm_in_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_in_pd14: tim4_ch3_remap1_pwm_in_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_in_pd15: tim4_ch4_remap1_pwm_in_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_out_pd12: tim4_ch1_remap1_pwm_out_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_out_pd13: tim4_ch2_remap1_pwm_out_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_out_pd14: tim4_ch3_remap1_pwm_out_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_out_pd15: tim4_ch4_remap1_pwm_out_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f101v(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101v(c-d-e)tx-pinctrl.dtsi
@@ -594,165 +594,327 @@
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_in_pd12: tim4_ch1_remap1_pwm_in_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_in_pd13: tim4_ch2_remap1_pwm_in_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_in_pd14: tim4_ch3_remap1_pwm_in_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_in_pd15: tim4_ch4_remap1_pwm_in_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch1_pwm_in_pa0: tim5_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pwm_in_pa1: tim5_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch3_pwm_in_pa2: tim5_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch4_pwm_in_pa3: tim5_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_out_pd12: tim4_ch1_remap1_pwm_out_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_out_pd13: tim4_ch2_remap1_pwm_out_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_out_pd14: tim4_ch3_remap1_pwm_out_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_out_pd15: tim4_ch4_remap1_pwm_out_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim5_ch1_pwm_out_pa0: tim5_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim5_ch2_pwm_out_pa1: tim5_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim5_ch3_pwm_out_pa2: tim5_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim5_ch4_pwm_out_pa3: tim5_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
 			};
 

--- a/dts/st/f1/stm32f101v(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101v(f-g)tx-pinctrl.dtsi
@@ -594,205 +594,407 @@
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			/omit-if-no-ref/ tim10_ch1_pwm_in_pb8: tim10_ch1_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM10_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim11_ch1_pwm_in_pb9: tim11_ch1_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM11_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim12_ch1_pwm_in_pb14: tim12_ch1_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim12_ch2_pwm_in_pb15: tim12_ch2_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim13_ch1_pwm_in_pa6: tim13_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM13_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim14_ch1_pwm_in_pa7: tim14_ch1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM14_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_in_pd12: tim4_ch1_remap1_pwm_in_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_in_pd13: tim4_ch2_remap1_pwm_in_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_in_pd14: tim4_ch3_remap1_pwm_in_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_in_pd15: tim4_ch4_remap1_pwm_in_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch1_pwm_in_pa0: tim5_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pwm_in_pa1: tim5_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch3_pwm_in_pa2: tim5_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch4_pwm_in_pa3: tim5_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim9_ch1_pwm_in_pa2: tim9_ch1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM9_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim9_ch2_pwm_in_pa3: tim9_ch2_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM9_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim9_ch1_remap1_pwm_in_pe5: tim9_ch1_remap1_pwm_in_pe5 {
+				pinmux = <STM32F1_PINMUX('E', 5, GPIO_IN, TIM9_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim9_ch2_remap1_pwm_in_pe6: tim9_ch2_remap1_pwm_in_pe6 {
+				pinmux = <STM32F1_PINMUX('E', 6, GPIO_IN, TIM9_REMAP1)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim10_ch1_pwm_out_pb8: tim10_ch1_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM10_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			/omit-if-no-ref/ tim11_ch1_pwm_out_pb9: tim11_ch1_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM11_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			/omit-if-no-ref/ tim12_ch1_pwm_out_pb14: tim12_ch1_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			/omit-if-no-ref/ tim12_ch2_pwm_out_pb15: tim12_ch2_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim13_ch1_pwm_out_pa6: tim13_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM13_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			/omit-if-no-ref/ tim14_ch1_pwm_out_pa7: tim14_ch1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM14_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_out_pd12: tim4_ch1_remap1_pwm_out_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_out_pd13: tim4_ch2_remap1_pwm_out_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_out_pd14: tim4_ch3_remap1_pwm_out_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_out_pd15: tim4_ch4_remap1_pwm_out_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim5_ch1_pwm_out_pa0: tim5_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim5_ch2_pwm_out_pa1: tim5_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim5_ch3_pwm_out_pa2: tim5_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim5_ch4_pwm_out_pa3: tim5_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			/omit-if-no-ref/ tim9_ch1_pwm_out_pa2: tim9_ch1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM9_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			/omit-if-no-ref/ tim9_ch2_pwm_out_pa3: tim9_ch2_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM9_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim9_ch1_remap1_pwm_pe5: tim9_ch1_remap1_pwm_pe5 {
+			/omit-if-no-ref/ tim9_ch1_remap1_pwm_out_pe5: tim9_ch1_remap1_pwm_out_pe5 {
 				pinmux = <STM32F1_PINMUX('E', 5, ALTERNATE, TIM9_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim9_ch2_remap1_pwm_pe6: tim9_ch2_remap1_pwm_pe6 {
+			/omit-if-no-ref/ tim9_ch2_remap1_pwm_out_pe6: tim9_ch2_remap1_pwm_out_pe6 {
 				pinmux = <STM32F1_PINMUX('E', 6, ALTERNATE, TIM9_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f101z(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101z(c-d-e)tx-pinctrl.dtsi
@@ -722,165 +722,327 @@
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_in_pd12: tim4_ch1_remap1_pwm_in_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_in_pd13: tim4_ch2_remap1_pwm_in_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_in_pd14: tim4_ch3_remap1_pwm_in_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_in_pd15: tim4_ch4_remap1_pwm_in_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch1_pwm_in_pa0: tim5_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pwm_in_pa1: tim5_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch3_pwm_in_pa2: tim5_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch4_pwm_in_pa3: tim5_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_out_pd12: tim4_ch1_remap1_pwm_out_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_out_pd13: tim4_ch2_remap1_pwm_out_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_out_pd14: tim4_ch3_remap1_pwm_out_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_out_pd15: tim4_ch4_remap1_pwm_out_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim5_ch1_pwm_out_pa0: tim5_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim5_ch2_pwm_out_pa1: tim5_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim5_ch3_pwm_out_pa2: tim5_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim5_ch4_pwm_out_pa3: tim5_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
 			};
 

--- a/dts/st/f1/stm32f101z(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f101z(f-g)tx-pinctrl.dtsi
@@ -722,221 +722,439 @@
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			/omit-if-no-ref/ tim10_ch1_pwm_in_pb8: tim10_ch1_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM10_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim10_ch1_remap1_pwm_in_pf6: tim10_ch1_remap1_pwm_in_pf6 {
+				pinmux = <STM32F1_PINMUX('F', 6, GPIO_IN, TIM10_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim11_ch1_pwm_in_pb9: tim11_ch1_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM11_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim11_ch1_remap1_pwm_in_pf7: tim11_ch1_remap1_pwm_in_pf7 {
+				pinmux = <STM32F1_PINMUX('F', 7, GPIO_IN, TIM11_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim12_ch1_pwm_in_pb14: tim12_ch1_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim12_ch2_pwm_in_pb15: tim12_ch2_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim13_ch1_pwm_in_pa6: tim13_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM13_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim13_ch1_remap1_pwm_in_pf8: tim13_ch1_remap1_pwm_in_pf8 {
+				pinmux = <STM32F1_PINMUX('F', 8, GPIO_IN, TIM13_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim14_ch1_pwm_in_pa7: tim14_ch1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM14_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_in_pd12: tim4_ch1_remap1_pwm_in_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_in_pd13: tim4_ch2_remap1_pwm_in_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_in_pd14: tim4_ch3_remap1_pwm_in_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_in_pd15: tim4_ch4_remap1_pwm_in_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim14_ch1_remap1_pwm_in_pf9: tim14_ch1_remap1_pwm_in_pf9 {
+				pinmux = <STM32F1_PINMUX('F', 9, GPIO_IN, TIM14_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch1_pwm_in_pa0: tim5_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pwm_in_pa1: tim5_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch3_pwm_in_pa2: tim5_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch4_pwm_in_pa3: tim5_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim9_ch1_pwm_in_pa2: tim9_ch1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM9_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim9_ch2_pwm_in_pa3: tim9_ch2_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM9_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim9_ch1_remap1_pwm_in_pe5: tim9_ch1_remap1_pwm_in_pe5 {
+				pinmux = <STM32F1_PINMUX('E', 5, GPIO_IN, TIM9_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim9_ch2_remap1_pwm_in_pe6: tim9_ch2_remap1_pwm_in_pe6 {
+				pinmux = <STM32F1_PINMUX('E', 6, GPIO_IN, TIM9_REMAP1)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim10_ch1_pwm_out_pb8: tim10_ch1_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM10_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim10_ch1_remap1_pwm_pf6: tim10_ch1_remap1_pwm_pf6 {
+			/omit-if-no-ref/ tim10_ch1_remap1_pwm_out_pf6: tim10_ch1_remap1_pwm_out_pf6 {
 				pinmux = <STM32F1_PINMUX('F', 6, ALTERNATE, TIM10_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			/omit-if-no-ref/ tim11_ch1_pwm_out_pb9: tim11_ch1_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM11_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim11_ch1_remap1_pwm_pf7: tim11_ch1_remap1_pwm_pf7 {
+			/omit-if-no-ref/ tim11_ch1_remap1_pwm_out_pf7: tim11_ch1_remap1_pwm_out_pf7 {
 				pinmux = <STM32F1_PINMUX('F', 7, ALTERNATE, TIM11_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			/omit-if-no-ref/ tim12_ch1_pwm_out_pb14: tim12_ch1_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			/omit-if-no-ref/ tim12_ch2_pwm_out_pb15: tim12_ch2_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim13_ch1_pwm_out_pa6: tim13_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM13_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim13_ch1_remap1_pwm_pf8: tim13_ch1_remap1_pwm_pf8 {
+			/omit-if-no-ref/ tim13_ch1_remap1_pwm_out_pf8: tim13_ch1_remap1_pwm_out_pf8 {
 				pinmux = <STM32F1_PINMUX('F', 8, ALTERNATE, TIM13_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			/omit-if-no-ref/ tim14_ch1_pwm_out_pa7: tim14_ch1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM14_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_out_pd12: tim4_ch1_remap1_pwm_out_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_out_pd13: tim4_ch2_remap1_pwm_out_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_out_pd14: tim4_ch3_remap1_pwm_out_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_out_pd15: tim4_ch4_remap1_pwm_out_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim14_ch1_remap1_pwm_pf9: tim14_ch1_remap1_pwm_pf9 {
+			/omit-if-no-ref/ tim14_ch1_remap1_pwm_out_pf9: tim14_ch1_remap1_pwm_out_pf9 {
 				pinmux = <STM32F1_PINMUX('F', 9, ALTERNATE, TIM14_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim5_ch1_pwm_out_pa0: tim5_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim5_ch2_pwm_out_pa1: tim5_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim5_ch3_pwm_out_pa2: tim5_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim5_ch4_pwm_out_pa3: tim5_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			/omit-if-no-ref/ tim9_ch1_pwm_out_pa2: tim9_ch1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM9_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			/omit-if-no-ref/ tim9_ch2_pwm_out_pa3: tim9_ch2_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM9_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim9_ch1_remap1_pwm_pe5: tim9_ch1_remap1_pwm_pe5 {
+			/omit-if-no-ref/ tim9_ch1_remap1_pwm_out_pe5: tim9_ch1_remap1_pwm_out_pe5 {
 				pinmux = <STM32F1_PINMUX('E', 5, ALTERNATE, TIM9_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim9_ch2_remap1_pwm_pe6: tim9_ch2_remap1_pwm_pe6 {
+			/omit-if-no-ref/ tim9_ch2_remap1_pwm_out_pe6: tim9_ch2_remap1_pwm_out_pe6 {
 				pinmux = <STM32F1_PINMUX('E', 6, ALTERNATE, TIM9_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f102c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102c(4-6)tx-pinctrl.dtsi
@@ -310,101 +310,199 @@
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f102c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102c(8-b)tx-pinctrl.dtsi
@@ -354,117 +354,231 @@
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 

--- a/dts/st/f1/stm32f102r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102r(4-6)tx-pinctrl.dtsi
@@ -390,117 +390,231 @@
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 

--- a/dts/st/f1/stm32f102r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f102r(8-b)tx-pinctrl.dtsi
@@ -434,133 +434,263 @@
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 

--- a/dts/st/f1/stm32f103c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103c(4-6)tx-pinctrl.dtsi
@@ -370,157 +370,311 @@
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_in_pa7: tim1_ch1n_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_pwm_in_pa8: tim1_ch1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_in_pa8: tim1_ch1_remap1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_pwm_in_pa9: tim1_ch2_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_in_pa9: tim1_ch2_remap1_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_pwm_in_pa10: tim1_ch3_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_in_pa10: tim1_ch3_remap1_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_pwm_in_pa11: tim1_ch4_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_in_pa11: tim1_ch4_remap1_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_in_pb0: tim1_ch2n_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_in_pb1: tim1_ch3n_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_pwm_in_pb13: tim1_ch1n_pwm_in_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_pwm_in_pb14: tim1_ch2n_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_pwm_in_pb15: tim1_ch3n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_out_pa7: tim1_ch1n_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_pwm_out_pa8: tim1_ch1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_out_pa8: tim1_ch1_remap1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_pwm_out_pa9: tim1_ch2_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_out_pa9: tim1_ch2_remap1_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_pwm_out_pa10: tim1_ch3_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_out_pa10: tim1_ch3_remap1_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_pwm_out_pa11: tim1_ch4_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_out_pa11: tim1_ch4_remap1_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_out_pb0: tim1_ch2n_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_out_pb1: tim1_ch3n_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			/omit-if-no-ref/ tim1_ch1n_pwm_out_pb13: tim1_ch1n_pwm_out_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			/omit-if-no-ref/ tim1_ch2n_pwm_out_pb14: tim1_ch2n_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			/omit-if-no-ref/ tim1_ch3n_pwm_out_pb15: tim1_ch3n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f103c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103c(8-b)tx-pinctrl.dtsi
@@ -414,173 +414,343 @@
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_in_pa7: tim1_ch1n_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_pwm_in_pa8: tim1_ch1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_in_pa8: tim1_ch1_remap1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_pwm_in_pa9: tim1_ch2_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_in_pa9: tim1_ch2_remap1_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_pwm_in_pa10: tim1_ch3_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_in_pa10: tim1_ch3_remap1_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_pwm_in_pa11: tim1_ch4_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_in_pa11: tim1_ch4_remap1_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_in_pb0: tim1_ch2n_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_in_pb1: tim1_ch3n_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_pwm_in_pb13: tim1_ch1n_pwm_in_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_pwm_in_pb14: tim1_ch2n_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_pwm_in_pb15: tim1_ch3n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_out_pa7: tim1_ch1n_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_pwm_out_pa8: tim1_ch1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_out_pa8: tim1_ch1_remap1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_pwm_out_pa9: tim1_ch2_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_out_pa9: tim1_ch2_remap1_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_pwm_out_pa10: tim1_ch3_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_out_pa10: tim1_ch3_remap1_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_pwm_out_pa11: tim1_ch4_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_out_pa11: tim1_ch4_remap1_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_out_pb0: tim1_ch2n_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_out_pb1: tim1_ch3n_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			/omit-if-no-ref/ tim1_ch1n_pwm_out_pb13: tim1_ch1n_pwm_out_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			/omit-if-no-ref/ tim1_ch2n_pwm_out_pb14: tim1_ch2n_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			/omit-if-no-ref/ tim1_ch3n_pwm_out_pb15: tim1_ch3n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 

--- a/dts/st/f1/stm32f103c6ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103c6ux-pinctrl.dtsi
@@ -370,157 +370,311 @@
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_in_pa7: tim1_ch1n_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_pwm_in_pa8: tim1_ch1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_in_pa8: tim1_ch1_remap1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_pwm_in_pa9: tim1_ch2_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_in_pa9: tim1_ch2_remap1_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_pwm_in_pa10: tim1_ch3_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_in_pa10: tim1_ch3_remap1_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_pwm_in_pa11: tim1_ch4_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_in_pa11: tim1_ch4_remap1_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_in_pb0: tim1_ch2n_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_in_pb1: tim1_ch3n_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_pwm_in_pb13: tim1_ch1n_pwm_in_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_pwm_in_pb14: tim1_ch2n_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_pwm_in_pb15: tim1_ch3n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_out_pa7: tim1_ch1n_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_pwm_out_pa8: tim1_ch1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_out_pa8: tim1_ch1_remap1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_pwm_out_pa9: tim1_ch2_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_out_pa9: tim1_ch2_remap1_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_pwm_out_pa10: tim1_ch3_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_out_pa10: tim1_ch3_remap1_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_pwm_out_pa11: tim1_ch4_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_out_pa11: tim1_ch4_remap1_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_out_pb0: tim1_ch2n_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_out_pb1: tim1_ch3n_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			/omit-if-no-ref/ tim1_ch1n_pwm_out_pb13: tim1_ch1n_pwm_out_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			/omit-if-no-ref/ tim1_ch2n_pwm_out_pb14: tim1_ch2n_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			/omit-if-no-ref/ tim1_ch3n_pwm_out_pb15: tim1_ch3n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f103cbux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103cbux-pinctrl.dtsi
@@ -414,173 +414,343 @@
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_in_pa7: tim1_ch1n_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_pwm_in_pa8: tim1_ch1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_in_pa8: tim1_ch1_remap1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_pwm_in_pa9: tim1_ch2_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_in_pa9: tim1_ch2_remap1_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_pwm_in_pa10: tim1_ch3_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_in_pa10: tim1_ch3_remap1_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_pwm_in_pa11: tim1_ch4_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_in_pa11: tim1_ch4_remap1_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_in_pb0: tim1_ch2n_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_in_pb1: tim1_ch3n_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_pwm_in_pb13: tim1_ch1n_pwm_in_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_pwm_in_pb14: tim1_ch2n_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_pwm_in_pb15: tim1_ch3n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_out_pa7: tim1_ch1n_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_pwm_out_pa8: tim1_ch1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_out_pa8: tim1_ch1_remap1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_pwm_out_pa9: tim1_ch2_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_out_pa9: tim1_ch2_remap1_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_pwm_out_pa10: tim1_ch3_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_out_pa10: tim1_ch3_remap1_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_pwm_out_pa11: tim1_ch4_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_out_pa11: tim1_ch4_remap1_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_out_pb0: tim1_ch2n_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_out_pb1: tim1_ch3n_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			/omit-if-no-ref/ tim1_ch1n_pwm_out_pb13: tim1_ch1n_pwm_out_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			/omit-if-no-ref/ tim1_ch2n_pwm_out_pb14: tim1_ch2n_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			/omit-if-no-ref/ tim1_ch3n_pwm_out_pb15: tim1_ch3n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 

--- a/dts/st/f1/stm32f103r(4-6)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(4-6)hx-pinctrl.dtsi
@@ -462,173 +462,343 @@
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_in_pa7: tim1_ch1n_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_pwm_in_pa8: tim1_ch1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_in_pa8: tim1_ch1_remap1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_pwm_in_pa9: tim1_ch2_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_in_pa9: tim1_ch2_remap1_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_pwm_in_pa10: tim1_ch3_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_in_pa10: tim1_ch3_remap1_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_pwm_in_pa11: tim1_ch4_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_in_pa11: tim1_ch4_remap1_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_in_pb0: tim1_ch2n_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_in_pb1: tim1_ch3n_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_pwm_in_pb13: tim1_ch1n_pwm_in_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_pwm_in_pb14: tim1_ch2n_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_pwm_in_pb15: tim1_ch3n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_out_pa7: tim1_ch1n_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_pwm_out_pa8: tim1_ch1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_out_pa8: tim1_ch1_remap1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_pwm_out_pa9: tim1_ch2_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_out_pa9: tim1_ch2_remap1_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_pwm_out_pa10: tim1_ch3_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_out_pa10: tim1_ch3_remap1_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_pwm_out_pa11: tim1_ch4_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_out_pa11: tim1_ch4_remap1_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_out_pb0: tim1_ch2n_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_out_pb1: tim1_ch3n_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			/omit-if-no-ref/ tim1_ch1n_pwm_out_pb13: tim1_ch1n_pwm_out_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			/omit-if-no-ref/ tim1_ch2n_pwm_out_pb14: tim1_ch2n_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			/omit-if-no-ref/ tim1_ch3n_pwm_out_pb15: tim1_ch3n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 

--- a/dts/st/f1/stm32f103r(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(4-6)tx-pinctrl.dtsi
@@ -474,173 +474,343 @@
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_in_pa7: tim1_ch1n_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_pwm_in_pa8: tim1_ch1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_in_pa8: tim1_ch1_remap1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_pwm_in_pa9: tim1_ch2_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_in_pa9: tim1_ch2_remap1_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_pwm_in_pa10: tim1_ch3_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_in_pa10: tim1_ch3_remap1_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_pwm_in_pa11: tim1_ch4_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_in_pa11: tim1_ch4_remap1_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_in_pb0: tim1_ch2n_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_in_pb1: tim1_ch3n_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_pwm_in_pb13: tim1_ch1n_pwm_in_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_pwm_in_pb14: tim1_ch2n_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_pwm_in_pb15: tim1_ch3n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_out_pa7: tim1_ch1n_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_pwm_out_pa8: tim1_ch1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_out_pa8: tim1_ch1_remap1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_pwm_out_pa9: tim1_ch2_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_out_pa9: tim1_ch2_remap1_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_pwm_out_pa10: tim1_ch3_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_out_pa10: tim1_ch3_remap1_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_pwm_out_pa11: tim1_ch4_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_out_pa11: tim1_ch4_remap1_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_out_pb0: tim1_ch2n_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_out_pb1: tim1_ch3n_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			/omit-if-no-ref/ tim1_ch1n_pwm_out_pb13: tim1_ch1n_pwm_out_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			/omit-if-no-ref/ tim1_ch2n_pwm_out_pb14: tim1_ch2n_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			/omit-if-no-ref/ tim1_ch3n_pwm_out_pb15: tim1_ch3n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 

--- a/dts/st/f1/stm32f103r(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(8-b)hx-pinctrl.dtsi
@@ -506,189 +506,375 @@
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_in_pa7: tim1_ch1n_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_pwm_in_pa8: tim1_ch1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_in_pa8: tim1_ch1_remap1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_pwm_in_pa9: tim1_ch2_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_in_pa9: tim1_ch2_remap1_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_pwm_in_pa10: tim1_ch3_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_in_pa10: tim1_ch3_remap1_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_pwm_in_pa11: tim1_ch4_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_in_pa11: tim1_ch4_remap1_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_in_pb0: tim1_ch2n_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_in_pb1: tim1_ch3n_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_pwm_in_pb13: tim1_ch1n_pwm_in_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_pwm_in_pb14: tim1_ch2n_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_pwm_in_pb15: tim1_ch3n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_out_pa7: tim1_ch1n_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_pwm_out_pa8: tim1_ch1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_out_pa8: tim1_ch1_remap1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_pwm_out_pa9: tim1_ch2_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_out_pa9: tim1_ch2_remap1_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_pwm_out_pa10: tim1_ch3_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_out_pa10: tim1_ch3_remap1_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_pwm_out_pa11: tim1_ch4_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_out_pa11: tim1_ch4_remap1_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_out_pb0: tim1_ch2n_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_out_pb1: tim1_ch3n_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			/omit-if-no-ref/ tim1_ch1n_pwm_out_pb13: tim1_ch1n_pwm_out_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			/omit-if-no-ref/ tim1_ch2n_pwm_out_pb14: tim1_ch2n_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			/omit-if-no-ref/ tim1_ch3n_pwm_out_pb15: tim1_ch3n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 

--- a/dts/st/f1/stm32f103r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(8-b)tx-pinctrl.dtsi
@@ -518,189 +518,375 @@
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_in_pa7: tim1_ch1n_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_pwm_in_pa8: tim1_ch1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_in_pa8: tim1_ch1_remap1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_pwm_in_pa9: tim1_ch2_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_in_pa9: tim1_ch2_remap1_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_pwm_in_pa10: tim1_ch3_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_in_pa10: tim1_ch3_remap1_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_pwm_in_pa11: tim1_ch4_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_in_pa11: tim1_ch4_remap1_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_in_pb0: tim1_ch2n_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_in_pb1: tim1_ch3n_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_pwm_in_pb13: tim1_ch1n_pwm_in_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_pwm_in_pb14: tim1_ch2n_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_pwm_in_pb15: tim1_ch3n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_out_pa7: tim1_ch1n_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_pwm_out_pa8: tim1_ch1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_out_pa8: tim1_ch1_remap1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_pwm_out_pa9: tim1_ch2_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_out_pa9: tim1_ch2_remap1_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_pwm_out_pa10: tim1_ch3_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_out_pa10: tim1_ch3_remap1_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_pwm_out_pa11: tim1_ch4_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_out_pa11: tim1_ch4_remap1_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_out_pb0: tim1_ch2n_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_out_pb1: tim1_ch3n_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			/omit-if-no-ref/ tim1_ch1n_pwm_out_pb13: tim1_ch1n_pwm_out_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			/omit-if-no-ref/ tim1_ch2n_pwm_out_pb14: tim1_ch2n_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			/omit-if-no-ref/ tim1_ch3n_pwm_out_pb15: tim1_ch3n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 

--- a/dts/st/f1/stm32f103r(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(c-d-e)tx-pinctrl.dtsi
@@ -624,233 +624,463 @@
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_in_pa7: tim1_ch1n_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_pwm_in_pa8: tim1_ch1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_in_pa8: tim1_ch1_remap1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_pwm_in_pa9: tim1_ch2_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_in_pa9: tim1_ch2_remap1_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_pwm_in_pa10: tim1_ch3_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_in_pa10: tim1_ch3_remap1_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_pwm_in_pa11: tim1_ch4_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_in_pa11: tim1_ch4_remap1_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_in_pb0: tim1_ch2n_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_in_pb1: tim1_ch3n_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_pwm_in_pb13: tim1_ch1n_pwm_in_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_pwm_in_pb14: tim1_ch2n_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_pwm_in_pb15: tim1_ch3n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch1_pwm_in_pa0: tim5_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pwm_in_pa1: tim5_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch3_pwm_in_pa2: tim5_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch4_pwm_in_pa3: tim5_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch1n_pwm_in_pa7: tim8_ch1n_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch2n_pwm_in_pb0: tim8_ch2n_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch3n_pwm_in_pb1: tim8_ch3n_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch1_pwm_in_pc6: tim8_ch1_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch2_pwm_in_pc7: tim8_ch2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch3_pwm_in_pc8: tim8_ch3_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch4_pwm_in_pc9: tim8_ch4_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_out_pa7: tim1_ch1n_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_pwm_out_pa8: tim1_ch1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_out_pa8: tim1_ch1_remap1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_pwm_out_pa9: tim1_ch2_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_out_pa9: tim1_ch2_remap1_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_pwm_out_pa10: tim1_ch3_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_out_pa10: tim1_ch3_remap1_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_pwm_out_pa11: tim1_ch4_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_out_pa11: tim1_ch4_remap1_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_out_pb0: tim1_ch2n_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_out_pb1: tim1_ch3n_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			/omit-if-no-ref/ tim1_ch1n_pwm_out_pb13: tim1_ch1n_pwm_out_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			/omit-if-no-ref/ tim1_ch2n_pwm_out_pb14: tim1_ch2n_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			/omit-if-no-ref/ tim1_ch3n_pwm_out_pb15: tim1_ch3n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim5_ch1_pwm_out_pa0: tim5_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim5_ch2_pwm_out_pa1: tim5_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim5_ch3_pwm_out_pa2: tim5_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim5_ch4_pwm_out_pa3: tim5_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim8_ch1n_pwm_out_pa7: tim8_ch1n_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim8_ch2n_pwm_out_pb0: tim8_ch2n_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim8_ch3n_pwm_out_pb1: tim8_ch3n_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim8_ch1_pwm_out_pc6: tim8_ch1_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim8_ch2_pwm_out_pc7: tim8_ch2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim8_ch3_pwm_out_pc8: tim8_ch3_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim8_ch4_pwm_out_pc9: tim8_ch4_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, NO_REMAP)>;
 			};
 

--- a/dts/st/f1/stm32f103r(c-d-e)yx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(c-d-e)yx-pinctrl.dtsi
@@ -608,233 +608,463 @@
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_in_pa7: tim1_ch1n_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_pwm_in_pa8: tim1_ch1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_in_pa8: tim1_ch1_remap1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_pwm_in_pa9: tim1_ch2_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_in_pa9: tim1_ch2_remap1_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_pwm_in_pa10: tim1_ch3_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_in_pa10: tim1_ch3_remap1_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_pwm_in_pa11: tim1_ch4_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_in_pa11: tim1_ch4_remap1_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_in_pb0: tim1_ch2n_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_in_pb1: tim1_ch3n_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_pwm_in_pb13: tim1_ch1n_pwm_in_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_pwm_in_pb14: tim1_ch2n_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_pwm_in_pb15: tim1_ch3n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch1_pwm_in_pa0: tim5_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pwm_in_pa1: tim5_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch3_pwm_in_pa2: tim5_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch4_pwm_in_pa3: tim5_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch1n_pwm_in_pa7: tim8_ch1n_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch2n_pwm_in_pb0: tim8_ch2n_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch3n_pwm_in_pb1: tim8_ch3n_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch1_pwm_in_pc6: tim8_ch1_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch2_pwm_in_pc7: tim8_ch2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch3_pwm_in_pc8: tim8_ch3_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch4_pwm_in_pc9: tim8_ch4_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_out_pa7: tim1_ch1n_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_pwm_out_pa8: tim1_ch1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_out_pa8: tim1_ch1_remap1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_pwm_out_pa9: tim1_ch2_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_out_pa9: tim1_ch2_remap1_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_pwm_out_pa10: tim1_ch3_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_out_pa10: tim1_ch3_remap1_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_pwm_out_pa11: tim1_ch4_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_out_pa11: tim1_ch4_remap1_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_out_pb0: tim1_ch2n_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_out_pb1: tim1_ch3n_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			/omit-if-no-ref/ tim1_ch1n_pwm_out_pb13: tim1_ch1n_pwm_out_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			/omit-if-no-ref/ tim1_ch2n_pwm_out_pb14: tim1_ch2n_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			/omit-if-no-ref/ tim1_ch3n_pwm_out_pb15: tim1_ch3n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim5_ch1_pwm_out_pa0: tim5_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim5_ch2_pwm_out_pa1: tim5_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim5_ch3_pwm_out_pa2: tim5_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim5_ch4_pwm_out_pa3: tim5_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim8_ch1n_pwm_out_pa7: tim8_ch1n_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim8_ch2n_pwm_out_pb0: tim8_ch2n_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim8_ch3n_pwm_out_pb1: tim8_ch3n_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim8_ch1_pwm_out_pc6: tim8_ch1_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim8_ch2_pwm_out_pc7: tim8_ch2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim8_ch3_pwm_out_pc8: tim8_ch3_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim8_ch4_pwm_out_pc9: tim8_ch4_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, NO_REMAP)>;
 			};
 

--- a/dts/st/f1/stm32f103r(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103r(f-g)tx-pinctrl.dtsi
@@ -624,265 +624,527 @@
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			/omit-if-no-ref/ tim10_ch1_pwm_in_pb8: tim10_ch1_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM10_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_in_pa7: tim1_ch1n_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_pwm_in_pa8: tim1_ch1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_in_pa8: tim1_ch1_remap1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_pwm_in_pa9: tim1_ch2_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_in_pa9: tim1_ch2_remap1_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_pwm_in_pa10: tim1_ch3_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_in_pa10: tim1_ch3_remap1_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_pwm_in_pa11: tim1_ch4_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_in_pa11: tim1_ch4_remap1_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_in_pb0: tim1_ch2n_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_in_pb1: tim1_ch3n_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim11_ch1_pwm_in_pb9: tim11_ch1_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM11_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_pwm_in_pb13: tim1_ch1n_pwm_in_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_pwm_in_pb14: tim1_ch2n_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_pwm_in_pb15: tim1_ch3n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim12_ch1_pwm_in_pb14: tim12_ch1_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim12_ch2_pwm_in_pb15: tim12_ch2_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim13_ch1_pwm_in_pa6: tim13_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM13_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim14_ch1_pwm_in_pa7: tim14_ch1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM14_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch1_pwm_in_pa0: tim5_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pwm_in_pa1: tim5_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch3_pwm_in_pa2: tim5_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch4_pwm_in_pa3: tim5_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch1n_pwm_in_pa7: tim8_ch1n_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch2n_pwm_in_pb0: tim8_ch2n_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch3n_pwm_in_pb1: tim8_ch3n_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch1_pwm_in_pc6: tim8_ch1_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch2_pwm_in_pc7: tim8_ch2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch3_pwm_in_pc8: tim8_ch3_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch4_pwm_in_pc9: tim8_ch4_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim9_ch1_pwm_in_pa2: tim9_ch1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM9_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim9_ch2_pwm_in_pa3: tim9_ch2_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM9_REMAP0)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim10_ch1_pwm_out_pb8: tim10_ch1_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM10_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_out_pa7: tim1_ch1n_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_pwm_out_pa8: tim1_ch1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_out_pa8: tim1_ch1_remap1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_pwm_out_pa9: tim1_ch2_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_out_pa9: tim1_ch2_remap1_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_pwm_out_pa10: tim1_ch3_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_out_pa10: tim1_ch3_remap1_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_pwm_out_pa11: tim1_ch4_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_out_pa11: tim1_ch4_remap1_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_out_pb0: tim1_ch2n_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_out_pb1: tim1_ch3n_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			/omit-if-no-ref/ tim11_ch1_pwm_out_pb9: tim11_ch1_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM11_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			/omit-if-no-ref/ tim1_ch1n_pwm_out_pb13: tim1_ch1n_pwm_out_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			/omit-if-no-ref/ tim1_ch2n_pwm_out_pb14: tim1_ch2n_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			/omit-if-no-ref/ tim1_ch3n_pwm_out_pb15: tim1_ch3n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			/omit-if-no-ref/ tim12_ch1_pwm_out_pb14: tim12_ch1_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			/omit-if-no-ref/ tim12_ch2_pwm_out_pb15: tim12_ch2_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim13_ch1_pwm_out_pa6: tim13_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM13_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			/omit-if-no-ref/ tim14_ch1_pwm_out_pa7: tim14_ch1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM14_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim5_ch1_pwm_out_pa0: tim5_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim5_ch2_pwm_out_pa1: tim5_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim5_ch3_pwm_out_pa2: tim5_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim5_ch4_pwm_out_pa3: tim5_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim8_ch1n_pwm_out_pa7: tim8_ch1n_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim8_ch2n_pwm_out_pb0: tim8_ch2n_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim8_ch3n_pwm_out_pb1: tim8_ch3n_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim8_ch1_pwm_out_pc6: tim8_ch1_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim8_ch2_pwm_out_pc7: tim8_ch2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim8_ch3_pwm_out_pc8: tim8_ch3_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim8_ch4_pwm_out_pc9: tim8_ch4_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			/omit-if-no-ref/ tim9_ch1_pwm_out_pa2: tim9_ch1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM9_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			/omit-if-no-ref/ tim9_ch2_pwm_out_pa3: tim9_ch2_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM9_REMAP0)>;
 			};
 

--- a/dts/st/f1/stm32f103t(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103t(4-6)ux-pinctrl.dtsi
@@ -308,129 +308,255 @@
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_in_pa7: tim1_ch1n_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_pwm_in_pa8: tim1_ch1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_in_pa8: tim1_ch1_remap1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_pwm_in_pa9: tim1_ch2_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_in_pa9: tim1_ch2_remap1_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_pwm_in_pa10: tim1_ch3_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_in_pa10: tim1_ch3_remap1_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_pwm_in_pa11: tim1_ch4_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_in_pa11: tim1_ch4_remap1_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_in_pb0: tim1_ch2n_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_in_pb1: tim1_ch3n_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_out_pa7: tim1_ch1n_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_pwm_out_pa8: tim1_ch1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_out_pa8: tim1_ch1_remap1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_pwm_out_pa9: tim1_ch2_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_out_pa9: tim1_ch2_remap1_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_pwm_out_pa10: tim1_ch3_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_out_pa10: tim1_ch3_remap1_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_pwm_out_pa11: tim1_ch4_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_out_pa11: tim1_ch4_remap1_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_out_pb0: tim1_ch2n_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_out_pb1: tim1_ch3n_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f103t(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103t(8-b)ux-pinctrl.dtsi
@@ -308,137 +308,271 @@
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI1_REMAP1)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_in_pa7: tim1_ch1n_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_pwm_in_pa8: tim1_ch1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_in_pa8: tim1_ch1_remap1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_pwm_in_pa9: tim1_ch2_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_in_pa9: tim1_ch2_remap1_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_pwm_in_pa10: tim1_ch3_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_in_pa10: tim1_ch3_remap1_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_pwm_in_pa11: tim1_ch4_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_in_pa11: tim1_ch4_remap1_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_in_pb0: tim1_ch2n_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_in_pb1: tim1_ch3n_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_out_pa7: tim1_ch1n_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_pwm_out_pa8: tim1_ch1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_out_pa8: tim1_ch1_remap1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_pwm_out_pa9: tim1_ch2_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_out_pa9: tim1_ch2_remap1_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_pwm_out_pa10: tim1_ch3_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_out_pa10: tim1_ch3_remap1_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_pwm_out_pa11: tim1_ch4_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_out_pa11: tim1_ch4_remap1_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_out_pb0: tim1_ch2n_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_out_pb1: tim1_ch3n_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 

--- a/dts/st/f1/stm32f103v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(8-b)hx-pinctrl.dtsi
@@ -642,233 +642,463 @@
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_in_pa7: tim1_ch1n_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_pwm_in_pa8: tim1_ch1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_in_pa8: tim1_ch1_remap1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_pwm_in_pa9: tim1_ch2_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_in_pa9: tim1_ch2_remap1_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_pwm_in_pa10: tim1_ch3_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_in_pa10: tim1_ch3_remap1_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_pwm_in_pa11: tim1_ch4_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_in_pa11: tim1_ch4_remap1_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_in_pb0: tim1_ch2n_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_in_pb1: tim1_ch3n_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_pwm_in_pb13: tim1_ch1n_pwm_in_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_pwm_in_pb14: tim1_ch2n_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_pwm_in_pb15: tim1_ch3n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_in_pe8: tim1_ch1n_remap2_pwm_in_pe8 {
+				pinmux = <STM32F1_PINMUX('E', 8, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_in_pe9: tim1_ch1_remap2_pwm_in_pe9 {
+				pinmux = <STM32F1_PINMUX('E', 9, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_in_pe10: tim1_ch2n_remap2_pwm_in_pe10 {
+				pinmux = <STM32F1_PINMUX('E', 10, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_in_pe11: tim1_ch2_remap2_pwm_in_pe11 {
+				pinmux = <STM32F1_PINMUX('E', 11, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_in_pe12: tim1_ch3n_remap2_pwm_in_pe12 {
+				pinmux = <STM32F1_PINMUX('E', 12, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_in_pe13: tim1_ch3_remap2_pwm_in_pe13 {
+				pinmux = <STM32F1_PINMUX('E', 13, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_in_pe14: tim1_ch4_remap2_pwm_in_pe14 {
+				pinmux = <STM32F1_PINMUX('E', 14, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_in_pd12: tim4_ch1_remap1_pwm_in_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_in_pd13: tim4_ch2_remap1_pwm_in_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_in_pd14: tim4_ch3_remap1_pwm_in_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_in_pd15: tim4_ch4_remap1_pwm_in_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_out_pa7: tim1_ch1n_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_pwm_out_pa8: tim1_ch1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_out_pa8: tim1_ch1_remap1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_pwm_out_pa9: tim1_ch2_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_out_pa9: tim1_ch2_remap1_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_pwm_out_pa10: tim1_ch3_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_out_pa10: tim1_ch3_remap1_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_pwm_out_pa11: tim1_ch4_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_out_pa11: tim1_ch4_remap1_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_out_pb0: tim1_ch2n_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_out_pb1: tim1_ch3n_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			/omit-if-no-ref/ tim1_ch1n_pwm_out_pb13: tim1_ch1n_pwm_out_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			/omit-if-no-ref/ tim1_ch2n_pwm_out_pb14: tim1_ch2n_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			/omit-if-no-ref/ tim1_ch3n_pwm_out_pb15: tim1_ch3n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_pe8: tim1_ch1n_remap2_pwm_pe8 {
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_out_pe8: tim1_ch1n_remap2_pwm_out_pe8 {
 				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap2_pwm_pe9: tim1_ch1_remap2_pwm_pe9 {
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_out_pe9: tim1_ch1_remap2_pwm_out_pe9 {
 				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_pe10: tim1_ch2n_remap2_pwm_pe10 {
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_out_pe10: tim1_ch2n_remap2_pwm_out_pe10 {
 				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap2_pwm_pe11: tim1_ch2_remap2_pwm_pe11 {
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_out_pe11: tim1_ch2_remap2_pwm_out_pe11 {
 				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_pe12: tim1_ch3n_remap2_pwm_pe12 {
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_out_pe12: tim1_ch3n_remap2_pwm_out_pe12 {
 				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap2_pwm_pe13: tim1_ch3_remap2_pwm_pe13 {
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_out_pe13: tim1_ch3_remap2_pwm_out_pe13 {
 				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap2_pwm_pe14: tim1_ch4_remap2_pwm_pe14 {
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_out_pe14: tim1_ch4_remap2_pwm_out_pe14 {
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_out_pd12: tim4_ch1_remap1_pwm_out_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_out_pd13: tim4_ch2_remap1_pwm_out_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_out_pd14: tim4_ch3_remap1_pwm_out_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_out_pd15: tim4_ch4_remap1_pwm_out_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f103v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(8-b)tx-pinctrl.dtsi
@@ -642,233 +642,463 @@
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_in_pa7: tim1_ch1n_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_pwm_in_pa8: tim1_ch1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_in_pa8: tim1_ch1_remap1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_pwm_in_pa9: tim1_ch2_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_in_pa9: tim1_ch2_remap1_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_pwm_in_pa10: tim1_ch3_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_in_pa10: tim1_ch3_remap1_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_pwm_in_pa11: tim1_ch4_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_in_pa11: tim1_ch4_remap1_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_in_pb0: tim1_ch2n_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_in_pb1: tim1_ch3n_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_pwm_in_pb13: tim1_ch1n_pwm_in_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_pwm_in_pb14: tim1_ch2n_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_pwm_in_pb15: tim1_ch3n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_in_pe8: tim1_ch1n_remap2_pwm_in_pe8 {
+				pinmux = <STM32F1_PINMUX('E', 8, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_in_pe9: tim1_ch1_remap2_pwm_in_pe9 {
+				pinmux = <STM32F1_PINMUX('E', 9, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_in_pe10: tim1_ch2n_remap2_pwm_in_pe10 {
+				pinmux = <STM32F1_PINMUX('E', 10, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_in_pe11: tim1_ch2_remap2_pwm_in_pe11 {
+				pinmux = <STM32F1_PINMUX('E', 11, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_in_pe12: tim1_ch3n_remap2_pwm_in_pe12 {
+				pinmux = <STM32F1_PINMUX('E', 12, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_in_pe13: tim1_ch3_remap2_pwm_in_pe13 {
+				pinmux = <STM32F1_PINMUX('E', 13, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_in_pe14: tim1_ch4_remap2_pwm_in_pe14 {
+				pinmux = <STM32F1_PINMUX('E', 14, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_in_pd12: tim4_ch1_remap1_pwm_in_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_in_pd13: tim4_ch2_remap1_pwm_in_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_in_pd14: tim4_ch3_remap1_pwm_in_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_in_pd15: tim4_ch4_remap1_pwm_in_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_out_pa7: tim1_ch1n_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_pwm_out_pa8: tim1_ch1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_out_pa8: tim1_ch1_remap1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_pwm_out_pa9: tim1_ch2_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_out_pa9: tim1_ch2_remap1_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_pwm_out_pa10: tim1_ch3_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_out_pa10: tim1_ch3_remap1_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_pwm_out_pa11: tim1_ch4_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_out_pa11: tim1_ch4_remap1_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_out_pb0: tim1_ch2n_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_out_pb1: tim1_ch3n_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			/omit-if-no-ref/ tim1_ch1n_pwm_out_pb13: tim1_ch1n_pwm_out_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			/omit-if-no-ref/ tim1_ch2n_pwm_out_pb14: tim1_ch2n_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			/omit-if-no-ref/ tim1_ch3n_pwm_out_pb15: tim1_ch3n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_pe8: tim1_ch1n_remap2_pwm_pe8 {
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_out_pe8: tim1_ch1n_remap2_pwm_out_pe8 {
 				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap2_pwm_pe9: tim1_ch1_remap2_pwm_pe9 {
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_out_pe9: tim1_ch1_remap2_pwm_out_pe9 {
 				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_pe10: tim1_ch2n_remap2_pwm_pe10 {
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_out_pe10: tim1_ch2n_remap2_pwm_out_pe10 {
 				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap2_pwm_pe11: tim1_ch2_remap2_pwm_pe11 {
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_out_pe11: tim1_ch2_remap2_pwm_out_pe11 {
 				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_pe12: tim1_ch3n_remap2_pwm_pe12 {
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_out_pe12: tim1_ch3n_remap2_pwm_out_pe12 {
 				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap2_pwm_pe13: tim1_ch3_remap2_pwm_pe13 {
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_out_pe13: tim1_ch3_remap2_pwm_out_pe13 {
 				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap2_pwm_pe14: tim1_ch4_remap2_pwm_pe14 {
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_out_pe14: tim1_ch4_remap2_pwm_out_pe14 {
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_out_pd12: tim4_ch1_remap1_pwm_out_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_out_pd13: tim4_ch2_remap1_pwm_out_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_out_pd14: tim4_ch3_remap1_pwm_out_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_out_pd15: tim4_ch4_remap1_pwm_out_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f103v(c-d-e)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(c-d-e)hx-pinctrl.dtsi
@@ -748,277 +748,551 @@
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_in_pa7: tim1_ch1n_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_pwm_in_pa8: tim1_ch1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_in_pa8: tim1_ch1_remap1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_pwm_in_pa9: tim1_ch2_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_in_pa9: tim1_ch2_remap1_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_pwm_in_pa10: tim1_ch3_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_in_pa10: tim1_ch3_remap1_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_pwm_in_pa11: tim1_ch4_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_in_pa11: tim1_ch4_remap1_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_in_pb0: tim1_ch2n_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_in_pb1: tim1_ch3n_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_pwm_in_pb13: tim1_ch1n_pwm_in_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_pwm_in_pb14: tim1_ch2n_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_pwm_in_pb15: tim1_ch3n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_in_pe8: tim1_ch1n_remap2_pwm_in_pe8 {
+				pinmux = <STM32F1_PINMUX('E', 8, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_in_pe9: tim1_ch1_remap2_pwm_in_pe9 {
+				pinmux = <STM32F1_PINMUX('E', 9, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_in_pe10: tim1_ch2n_remap2_pwm_in_pe10 {
+				pinmux = <STM32F1_PINMUX('E', 10, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_in_pe11: tim1_ch2_remap2_pwm_in_pe11 {
+				pinmux = <STM32F1_PINMUX('E', 11, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_in_pe12: tim1_ch3n_remap2_pwm_in_pe12 {
+				pinmux = <STM32F1_PINMUX('E', 12, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_in_pe13: tim1_ch3_remap2_pwm_in_pe13 {
+				pinmux = <STM32F1_PINMUX('E', 13, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_in_pe14: tim1_ch4_remap2_pwm_in_pe14 {
+				pinmux = <STM32F1_PINMUX('E', 14, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_in_pd12: tim4_ch1_remap1_pwm_in_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_in_pd13: tim4_ch2_remap1_pwm_in_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_in_pd14: tim4_ch3_remap1_pwm_in_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_in_pd15: tim4_ch4_remap1_pwm_in_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch1_pwm_in_pa0: tim5_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pwm_in_pa1: tim5_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch3_pwm_in_pa2: tim5_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch4_pwm_in_pa3: tim5_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch1n_pwm_in_pa7: tim8_ch1n_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch2n_pwm_in_pb0: tim8_ch2n_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch3n_pwm_in_pb1: tim8_ch3n_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch1_pwm_in_pc6: tim8_ch1_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch2_pwm_in_pc7: tim8_ch2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch3_pwm_in_pc8: tim8_ch3_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch4_pwm_in_pc9: tim8_ch4_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_out_pa7: tim1_ch1n_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_pwm_out_pa8: tim1_ch1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_out_pa8: tim1_ch1_remap1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_pwm_out_pa9: tim1_ch2_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_out_pa9: tim1_ch2_remap1_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_pwm_out_pa10: tim1_ch3_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_out_pa10: tim1_ch3_remap1_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_pwm_out_pa11: tim1_ch4_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_out_pa11: tim1_ch4_remap1_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_out_pb0: tim1_ch2n_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_out_pb1: tim1_ch3n_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			/omit-if-no-ref/ tim1_ch1n_pwm_out_pb13: tim1_ch1n_pwm_out_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			/omit-if-no-ref/ tim1_ch2n_pwm_out_pb14: tim1_ch2n_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			/omit-if-no-ref/ tim1_ch3n_pwm_out_pb15: tim1_ch3n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_pe8: tim1_ch1n_remap2_pwm_pe8 {
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_out_pe8: tim1_ch1n_remap2_pwm_out_pe8 {
 				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap2_pwm_pe9: tim1_ch1_remap2_pwm_pe9 {
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_out_pe9: tim1_ch1_remap2_pwm_out_pe9 {
 				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_pe10: tim1_ch2n_remap2_pwm_pe10 {
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_out_pe10: tim1_ch2n_remap2_pwm_out_pe10 {
 				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap2_pwm_pe11: tim1_ch2_remap2_pwm_pe11 {
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_out_pe11: tim1_ch2_remap2_pwm_out_pe11 {
 				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_pe12: tim1_ch3n_remap2_pwm_pe12 {
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_out_pe12: tim1_ch3n_remap2_pwm_out_pe12 {
 				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap2_pwm_pe13: tim1_ch3_remap2_pwm_pe13 {
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_out_pe13: tim1_ch3_remap2_pwm_out_pe13 {
 				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap2_pwm_pe14: tim1_ch4_remap2_pwm_pe14 {
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_out_pe14: tim1_ch4_remap2_pwm_out_pe14 {
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_out_pd12: tim4_ch1_remap1_pwm_out_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_out_pd13: tim4_ch2_remap1_pwm_out_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_out_pd14: tim4_ch3_remap1_pwm_out_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_out_pd15: tim4_ch4_remap1_pwm_out_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim5_ch1_pwm_out_pa0: tim5_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim5_ch2_pwm_out_pa1: tim5_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim5_ch3_pwm_out_pa2: tim5_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim5_ch4_pwm_out_pa3: tim5_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim8_ch1n_pwm_out_pa7: tim8_ch1n_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim8_ch2n_pwm_out_pb0: tim8_ch2n_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim8_ch3n_pwm_out_pb1: tim8_ch3n_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim8_ch1_pwm_out_pc6: tim8_ch1_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim8_ch2_pwm_out_pc7: tim8_ch2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim8_ch3_pwm_out_pc8: tim8_ch3_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim8_ch4_pwm_out_pc9: tim8_ch4_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, NO_REMAP)>;
 			};
 

--- a/dts/st/f1/stm32f103v(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(c-d-e)tx-pinctrl.dtsi
@@ -748,277 +748,551 @@
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_in_pa7: tim1_ch1n_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_pwm_in_pa8: tim1_ch1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_in_pa8: tim1_ch1_remap1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_pwm_in_pa9: tim1_ch2_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_in_pa9: tim1_ch2_remap1_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_pwm_in_pa10: tim1_ch3_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_in_pa10: tim1_ch3_remap1_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_pwm_in_pa11: tim1_ch4_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_in_pa11: tim1_ch4_remap1_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_in_pb0: tim1_ch2n_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_in_pb1: tim1_ch3n_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_pwm_in_pb13: tim1_ch1n_pwm_in_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_pwm_in_pb14: tim1_ch2n_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_pwm_in_pb15: tim1_ch3n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_in_pe8: tim1_ch1n_remap2_pwm_in_pe8 {
+				pinmux = <STM32F1_PINMUX('E', 8, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_in_pe9: tim1_ch1_remap2_pwm_in_pe9 {
+				pinmux = <STM32F1_PINMUX('E', 9, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_in_pe10: tim1_ch2n_remap2_pwm_in_pe10 {
+				pinmux = <STM32F1_PINMUX('E', 10, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_in_pe11: tim1_ch2_remap2_pwm_in_pe11 {
+				pinmux = <STM32F1_PINMUX('E', 11, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_in_pe12: tim1_ch3n_remap2_pwm_in_pe12 {
+				pinmux = <STM32F1_PINMUX('E', 12, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_in_pe13: tim1_ch3_remap2_pwm_in_pe13 {
+				pinmux = <STM32F1_PINMUX('E', 13, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_in_pe14: tim1_ch4_remap2_pwm_in_pe14 {
+				pinmux = <STM32F1_PINMUX('E', 14, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_in_pd12: tim4_ch1_remap1_pwm_in_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_in_pd13: tim4_ch2_remap1_pwm_in_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_in_pd14: tim4_ch3_remap1_pwm_in_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_in_pd15: tim4_ch4_remap1_pwm_in_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch1_pwm_in_pa0: tim5_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pwm_in_pa1: tim5_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch3_pwm_in_pa2: tim5_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch4_pwm_in_pa3: tim5_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch1n_pwm_in_pa7: tim8_ch1n_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch2n_pwm_in_pb0: tim8_ch2n_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch3n_pwm_in_pb1: tim8_ch3n_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch1_pwm_in_pc6: tim8_ch1_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch2_pwm_in_pc7: tim8_ch2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch3_pwm_in_pc8: tim8_ch3_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch4_pwm_in_pc9: tim8_ch4_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_out_pa7: tim1_ch1n_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_pwm_out_pa8: tim1_ch1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_out_pa8: tim1_ch1_remap1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_pwm_out_pa9: tim1_ch2_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_out_pa9: tim1_ch2_remap1_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_pwm_out_pa10: tim1_ch3_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_out_pa10: tim1_ch3_remap1_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_pwm_out_pa11: tim1_ch4_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_out_pa11: tim1_ch4_remap1_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_out_pb0: tim1_ch2n_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_out_pb1: tim1_ch3n_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			/omit-if-no-ref/ tim1_ch1n_pwm_out_pb13: tim1_ch1n_pwm_out_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			/omit-if-no-ref/ tim1_ch2n_pwm_out_pb14: tim1_ch2n_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			/omit-if-no-ref/ tim1_ch3n_pwm_out_pb15: tim1_ch3n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_pe8: tim1_ch1n_remap2_pwm_pe8 {
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_out_pe8: tim1_ch1n_remap2_pwm_out_pe8 {
 				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap2_pwm_pe9: tim1_ch1_remap2_pwm_pe9 {
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_out_pe9: tim1_ch1_remap2_pwm_out_pe9 {
 				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_pe10: tim1_ch2n_remap2_pwm_pe10 {
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_out_pe10: tim1_ch2n_remap2_pwm_out_pe10 {
 				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap2_pwm_pe11: tim1_ch2_remap2_pwm_pe11 {
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_out_pe11: tim1_ch2_remap2_pwm_out_pe11 {
 				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_pe12: tim1_ch3n_remap2_pwm_pe12 {
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_out_pe12: tim1_ch3n_remap2_pwm_out_pe12 {
 				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap2_pwm_pe13: tim1_ch3_remap2_pwm_pe13 {
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_out_pe13: tim1_ch3_remap2_pwm_out_pe13 {
 				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap2_pwm_pe14: tim1_ch4_remap2_pwm_pe14 {
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_out_pe14: tim1_ch4_remap2_pwm_out_pe14 {
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_out_pd12: tim4_ch1_remap1_pwm_out_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_out_pd13: tim4_ch2_remap1_pwm_out_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_out_pd14: tim4_ch3_remap1_pwm_out_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_out_pd15: tim4_ch4_remap1_pwm_out_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim5_ch1_pwm_out_pa0: tim5_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim5_ch2_pwm_out_pa1: tim5_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim5_ch3_pwm_out_pa2: tim5_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim5_ch4_pwm_out_pa3: tim5_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim8_ch1n_pwm_out_pa7: tim8_ch1n_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim8_ch2n_pwm_out_pb0: tim8_ch2n_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim8_ch3n_pwm_out_pb1: tim8_ch3n_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim8_ch1_pwm_out_pc6: tim8_ch1_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim8_ch2_pwm_out_pc7: tim8_ch2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim8_ch3_pwm_out_pc8: tim8_ch3_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim8_ch4_pwm_out_pc9: tim8_ch4_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, NO_REMAP)>;
 			};
 

--- a/dts/st/f1/stm32f103v(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103v(f-g)tx-pinctrl.dtsi
@@ -748,317 +748,631 @@
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			/omit-if-no-ref/ tim10_ch1_pwm_in_pb8: tim10_ch1_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM10_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_in_pa7: tim1_ch1n_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_pwm_in_pa8: tim1_ch1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_in_pa8: tim1_ch1_remap1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_pwm_in_pa9: tim1_ch2_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_in_pa9: tim1_ch2_remap1_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_pwm_in_pa10: tim1_ch3_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_in_pa10: tim1_ch3_remap1_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_pwm_in_pa11: tim1_ch4_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_in_pa11: tim1_ch4_remap1_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_in_pb0: tim1_ch2n_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_in_pb1: tim1_ch3n_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim11_ch1_pwm_in_pb9: tim11_ch1_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM11_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_pwm_in_pb13: tim1_ch1n_pwm_in_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_pwm_in_pb14: tim1_ch2n_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_pwm_in_pb15: tim1_ch3n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_in_pe8: tim1_ch1n_remap2_pwm_in_pe8 {
+				pinmux = <STM32F1_PINMUX('E', 8, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_in_pe9: tim1_ch1_remap2_pwm_in_pe9 {
+				pinmux = <STM32F1_PINMUX('E', 9, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_in_pe10: tim1_ch2n_remap2_pwm_in_pe10 {
+				pinmux = <STM32F1_PINMUX('E', 10, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_in_pe11: tim1_ch2_remap2_pwm_in_pe11 {
+				pinmux = <STM32F1_PINMUX('E', 11, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_in_pe12: tim1_ch3n_remap2_pwm_in_pe12 {
+				pinmux = <STM32F1_PINMUX('E', 12, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_in_pe13: tim1_ch3_remap2_pwm_in_pe13 {
+				pinmux = <STM32F1_PINMUX('E', 13, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_in_pe14: tim1_ch4_remap2_pwm_in_pe14 {
+				pinmux = <STM32F1_PINMUX('E', 14, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim12_ch1_pwm_in_pb14: tim12_ch1_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim12_ch2_pwm_in_pb15: tim12_ch2_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim13_ch1_pwm_in_pa6: tim13_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM13_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim14_ch1_pwm_in_pa7: tim14_ch1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM14_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_in_pd12: tim4_ch1_remap1_pwm_in_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_in_pd13: tim4_ch2_remap1_pwm_in_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_in_pd14: tim4_ch3_remap1_pwm_in_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_in_pd15: tim4_ch4_remap1_pwm_in_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch1_pwm_in_pa0: tim5_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pwm_in_pa1: tim5_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch3_pwm_in_pa2: tim5_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch4_pwm_in_pa3: tim5_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch1n_pwm_in_pa7: tim8_ch1n_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch2n_pwm_in_pb0: tim8_ch2n_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch3n_pwm_in_pb1: tim8_ch3n_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch1_pwm_in_pc6: tim8_ch1_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch2_pwm_in_pc7: tim8_ch2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch3_pwm_in_pc8: tim8_ch3_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch4_pwm_in_pc9: tim8_ch4_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim9_ch1_pwm_in_pa2: tim9_ch1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM9_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim9_ch2_pwm_in_pa3: tim9_ch2_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM9_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim9_ch1_remap1_pwm_in_pe5: tim9_ch1_remap1_pwm_in_pe5 {
+				pinmux = <STM32F1_PINMUX('E', 5, GPIO_IN, TIM9_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim9_ch2_remap1_pwm_in_pe6: tim9_ch2_remap1_pwm_in_pe6 {
+				pinmux = <STM32F1_PINMUX('E', 6, GPIO_IN, TIM9_REMAP1)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim10_ch1_pwm_out_pb8: tim10_ch1_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM10_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_out_pa7: tim1_ch1n_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_pwm_out_pa8: tim1_ch1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_out_pa8: tim1_ch1_remap1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_pwm_out_pa9: tim1_ch2_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_out_pa9: tim1_ch2_remap1_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_pwm_out_pa10: tim1_ch3_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_out_pa10: tim1_ch3_remap1_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_pwm_out_pa11: tim1_ch4_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_out_pa11: tim1_ch4_remap1_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_out_pb0: tim1_ch2n_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_out_pb1: tim1_ch3n_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			/omit-if-no-ref/ tim11_ch1_pwm_out_pb9: tim11_ch1_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM11_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			/omit-if-no-ref/ tim1_ch1n_pwm_out_pb13: tim1_ch1n_pwm_out_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			/omit-if-no-ref/ tim1_ch2n_pwm_out_pb14: tim1_ch2n_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			/omit-if-no-ref/ tim1_ch3n_pwm_out_pb15: tim1_ch3n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_pe8: tim1_ch1n_remap2_pwm_pe8 {
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_out_pe8: tim1_ch1n_remap2_pwm_out_pe8 {
 				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap2_pwm_pe9: tim1_ch1_remap2_pwm_pe9 {
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_out_pe9: tim1_ch1_remap2_pwm_out_pe9 {
 				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_pe10: tim1_ch2n_remap2_pwm_pe10 {
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_out_pe10: tim1_ch2n_remap2_pwm_out_pe10 {
 				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap2_pwm_pe11: tim1_ch2_remap2_pwm_pe11 {
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_out_pe11: tim1_ch2_remap2_pwm_out_pe11 {
 				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_pe12: tim1_ch3n_remap2_pwm_pe12 {
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_out_pe12: tim1_ch3n_remap2_pwm_out_pe12 {
 				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap2_pwm_pe13: tim1_ch3_remap2_pwm_pe13 {
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_out_pe13: tim1_ch3_remap2_pwm_out_pe13 {
 				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap2_pwm_pe14: tim1_ch4_remap2_pwm_pe14 {
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_out_pe14: tim1_ch4_remap2_pwm_out_pe14 {
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			/omit-if-no-ref/ tim12_ch1_pwm_out_pb14: tim12_ch1_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			/omit-if-no-ref/ tim12_ch2_pwm_out_pb15: tim12_ch2_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim13_ch1_pwm_out_pa6: tim13_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM13_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			/omit-if-no-ref/ tim14_ch1_pwm_out_pa7: tim14_ch1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM14_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_out_pd12: tim4_ch1_remap1_pwm_out_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_out_pd13: tim4_ch2_remap1_pwm_out_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_out_pd14: tim4_ch3_remap1_pwm_out_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_out_pd15: tim4_ch4_remap1_pwm_out_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim5_ch1_pwm_out_pa0: tim5_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim5_ch2_pwm_out_pa1: tim5_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim5_ch3_pwm_out_pa2: tim5_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim5_ch4_pwm_out_pa3: tim5_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim8_ch1n_pwm_out_pa7: tim8_ch1n_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim8_ch2n_pwm_out_pb0: tim8_ch2n_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim8_ch3n_pwm_out_pb1: tim8_ch3n_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim8_ch1_pwm_out_pc6: tim8_ch1_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim8_ch2_pwm_out_pc7: tim8_ch2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim8_ch3_pwm_out_pc8: tim8_ch3_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim8_ch4_pwm_out_pc9: tim8_ch4_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			/omit-if-no-ref/ tim9_ch1_pwm_out_pa2: tim9_ch1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM9_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			/omit-if-no-ref/ tim9_ch2_pwm_out_pa3: tim9_ch2_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM9_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim9_ch1_remap1_pwm_pe5: tim9_ch1_remap1_pwm_pe5 {
+			/omit-if-no-ref/ tim9_ch1_remap1_pwm_out_pe5: tim9_ch1_remap1_pwm_out_pe5 {
 				pinmux = <STM32F1_PINMUX('E', 5, ALTERNATE, TIM9_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim9_ch2_remap1_pwm_pe6: tim9_ch2_remap1_pwm_pe6 {
+			/omit-if-no-ref/ tim9_ch2_remap1_pwm_out_pe6: tim9_ch2_remap1_pwm_out_pe6 {
 				pinmux = <STM32F1_PINMUX('E', 6, ALTERNATE, TIM9_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f103vbix-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103vbix-pinctrl.dtsi
@@ -642,233 +642,463 @@
 				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, NO_REMAP)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_in_pa7: tim1_ch1n_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_pwm_in_pa8: tim1_ch1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_in_pa8: tim1_ch1_remap1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_pwm_in_pa9: tim1_ch2_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_in_pa9: tim1_ch2_remap1_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_pwm_in_pa10: tim1_ch3_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_in_pa10: tim1_ch3_remap1_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_pwm_in_pa11: tim1_ch4_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_in_pa11: tim1_ch4_remap1_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_in_pb0: tim1_ch2n_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_in_pb1: tim1_ch3n_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_pwm_in_pb13: tim1_ch1n_pwm_in_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_pwm_in_pb14: tim1_ch2n_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_pwm_in_pb15: tim1_ch3n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_in_pe8: tim1_ch1n_remap2_pwm_in_pe8 {
+				pinmux = <STM32F1_PINMUX('E', 8, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_in_pe9: tim1_ch1_remap2_pwm_in_pe9 {
+				pinmux = <STM32F1_PINMUX('E', 9, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_in_pe10: tim1_ch2n_remap2_pwm_in_pe10 {
+				pinmux = <STM32F1_PINMUX('E', 10, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_in_pe11: tim1_ch2_remap2_pwm_in_pe11 {
+				pinmux = <STM32F1_PINMUX('E', 11, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_in_pe12: tim1_ch3n_remap2_pwm_in_pe12 {
+				pinmux = <STM32F1_PINMUX('E', 12, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_in_pe13: tim1_ch3_remap2_pwm_in_pe13 {
+				pinmux = <STM32F1_PINMUX('E', 13, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_in_pe14: tim1_ch4_remap2_pwm_in_pe14 {
+				pinmux = <STM32F1_PINMUX('E', 14, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_in_pd12: tim4_ch1_remap1_pwm_in_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_in_pd13: tim4_ch2_remap1_pwm_in_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_in_pd14: tim4_ch3_remap1_pwm_in_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_in_pd15: tim4_ch4_remap1_pwm_in_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_out_pa7: tim1_ch1n_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_pwm_out_pa8: tim1_ch1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_out_pa8: tim1_ch1_remap1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_pwm_out_pa9: tim1_ch2_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_out_pa9: tim1_ch2_remap1_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_pwm_out_pa10: tim1_ch3_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_out_pa10: tim1_ch3_remap1_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_pwm_out_pa11: tim1_ch4_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_out_pa11: tim1_ch4_remap1_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_out_pb0: tim1_ch2n_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_out_pb1: tim1_ch3n_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			/omit-if-no-ref/ tim1_ch1n_pwm_out_pb13: tim1_ch1n_pwm_out_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			/omit-if-no-ref/ tim1_ch2n_pwm_out_pb14: tim1_ch2n_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			/omit-if-no-ref/ tim1_ch3n_pwm_out_pb15: tim1_ch3n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_pe8: tim1_ch1n_remap2_pwm_pe8 {
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_out_pe8: tim1_ch1n_remap2_pwm_out_pe8 {
 				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap2_pwm_pe9: tim1_ch1_remap2_pwm_pe9 {
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_out_pe9: tim1_ch1_remap2_pwm_out_pe9 {
 				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_pe10: tim1_ch2n_remap2_pwm_pe10 {
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_out_pe10: tim1_ch2n_remap2_pwm_out_pe10 {
 				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap2_pwm_pe11: tim1_ch2_remap2_pwm_pe11 {
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_out_pe11: tim1_ch2_remap2_pwm_out_pe11 {
 				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_pe12: tim1_ch3n_remap2_pwm_pe12 {
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_out_pe12: tim1_ch3n_remap2_pwm_out_pe12 {
 				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap2_pwm_pe13: tim1_ch3_remap2_pwm_pe13 {
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_out_pe13: tim1_ch3_remap2_pwm_out_pe13 {
 				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap2_pwm_pe14: tim1_ch4_remap2_pwm_pe14 {
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_out_pe14: tim1_ch4_remap2_pwm_out_pe14 {
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_out_pd12: tim4_ch1_remap1_pwm_out_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_out_pd13: tim4_ch2_remap1_pwm_out_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_out_pd14: tim4_ch3_remap1_pwm_out_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_out_pd15: tim4_ch4_remap1_pwm_out_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f103z(c-d-e)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(c-d-e)hx-pinctrl.dtsi
@@ -896,277 +896,551 @@
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_in_pa7: tim1_ch1n_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_pwm_in_pa8: tim1_ch1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_in_pa8: tim1_ch1_remap1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_pwm_in_pa9: tim1_ch2_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_in_pa9: tim1_ch2_remap1_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_pwm_in_pa10: tim1_ch3_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_in_pa10: tim1_ch3_remap1_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_pwm_in_pa11: tim1_ch4_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_in_pa11: tim1_ch4_remap1_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_in_pb0: tim1_ch2n_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_in_pb1: tim1_ch3n_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_pwm_in_pb13: tim1_ch1n_pwm_in_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_pwm_in_pb14: tim1_ch2n_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_pwm_in_pb15: tim1_ch3n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_in_pe8: tim1_ch1n_remap2_pwm_in_pe8 {
+				pinmux = <STM32F1_PINMUX('E', 8, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_in_pe9: tim1_ch1_remap2_pwm_in_pe9 {
+				pinmux = <STM32F1_PINMUX('E', 9, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_in_pe10: tim1_ch2n_remap2_pwm_in_pe10 {
+				pinmux = <STM32F1_PINMUX('E', 10, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_in_pe11: tim1_ch2_remap2_pwm_in_pe11 {
+				pinmux = <STM32F1_PINMUX('E', 11, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_in_pe12: tim1_ch3n_remap2_pwm_in_pe12 {
+				pinmux = <STM32F1_PINMUX('E', 12, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_in_pe13: tim1_ch3_remap2_pwm_in_pe13 {
+				pinmux = <STM32F1_PINMUX('E', 13, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_in_pe14: tim1_ch4_remap2_pwm_in_pe14 {
+				pinmux = <STM32F1_PINMUX('E', 14, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_in_pd12: tim4_ch1_remap1_pwm_in_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_in_pd13: tim4_ch2_remap1_pwm_in_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_in_pd14: tim4_ch3_remap1_pwm_in_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_in_pd15: tim4_ch4_remap1_pwm_in_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch1_pwm_in_pa0: tim5_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pwm_in_pa1: tim5_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch3_pwm_in_pa2: tim5_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch4_pwm_in_pa3: tim5_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch1n_pwm_in_pa7: tim8_ch1n_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch2n_pwm_in_pb0: tim8_ch2n_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch3n_pwm_in_pb1: tim8_ch3n_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch1_pwm_in_pc6: tim8_ch1_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch2_pwm_in_pc7: tim8_ch2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch3_pwm_in_pc8: tim8_ch3_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch4_pwm_in_pc9: tim8_ch4_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_out_pa7: tim1_ch1n_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_pwm_out_pa8: tim1_ch1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_out_pa8: tim1_ch1_remap1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_pwm_out_pa9: tim1_ch2_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_out_pa9: tim1_ch2_remap1_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_pwm_out_pa10: tim1_ch3_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_out_pa10: tim1_ch3_remap1_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_pwm_out_pa11: tim1_ch4_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_out_pa11: tim1_ch4_remap1_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_out_pb0: tim1_ch2n_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_out_pb1: tim1_ch3n_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			/omit-if-no-ref/ tim1_ch1n_pwm_out_pb13: tim1_ch1n_pwm_out_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			/omit-if-no-ref/ tim1_ch2n_pwm_out_pb14: tim1_ch2n_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			/omit-if-no-ref/ tim1_ch3n_pwm_out_pb15: tim1_ch3n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_pe8: tim1_ch1n_remap2_pwm_pe8 {
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_out_pe8: tim1_ch1n_remap2_pwm_out_pe8 {
 				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap2_pwm_pe9: tim1_ch1_remap2_pwm_pe9 {
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_out_pe9: tim1_ch1_remap2_pwm_out_pe9 {
 				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_pe10: tim1_ch2n_remap2_pwm_pe10 {
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_out_pe10: tim1_ch2n_remap2_pwm_out_pe10 {
 				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap2_pwm_pe11: tim1_ch2_remap2_pwm_pe11 {
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_out_pe11: tim1_ch2_remap2_pwm_out_pe11 {
 				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_pe12: tim1_ch3n_remap2_pwm_pe12 {
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_out_pe12: tim1_ch3n_remap2_pwm_out_pe12 {
 				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap2_pwm_pe13: tim1_ch3_remap2_pwm_pe13 {
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_out_pe13: tim1_ch3_remap2_pwm_out_pe13 {
 				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap2_pwm_pe14: tim1_ch4_remap2_pwm_pe14 {
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_out_pe14: tim1_ch4_remap2_pwm_out_pe14 {
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_out_pd12: tim4_ch1_remap1_pwm_out_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_out_pd13: tim4_ch2_remap1_pwm_out_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_out_pd14: tim4_ch3_remap1_pwm_out_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_out_pd15: tim4_ch4_remap1_pwm_out_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim5_ch1_pwm_out_pa0: tim5_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim5_ch2_pwm_out_pa1: tim5_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim5_ch3_pwm_out_pa2: tim5_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim5_ch4_pwm_out_pa3: tim5_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim8_ch1n_pwm_out_pa7: tim8_ch1n_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim8_ch2n_pwm_out_pb0: tim8_ch2n_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim8_ch3n_pwm_out_pb1: tim8_ch3n_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim8_ch1_pwm_out_pc6: tim8_ch1_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim8_ch2_pwm_out_pc7: tim8_ch2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim8_ch3_pwm_out_pc8: tim8_ch3_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim8_ch4_pwm_out_pc9: tim8_ch4_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, NO_REMAP)>;
 			};
 

--- a/dts/st/f1/stm32f103z(c-d-e)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(c-d-e)tx-pinctrl.dtsi
@@ -896,277 +896,551 @@
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_in_pa7: tim1_ch1n_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_pwm_in_pa8: tim1_ch1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_in_pa8: tim1_ch1_remap1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_pwm_in_pa9: tim1_ch2_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_in_pa9: tim1_ch2_remap1_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_pwm_in_pa10: tim1_ch3_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_in_pa10: tim1_ch3_remap1_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_pwm_in_pa11: tim1_ch4_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_in_pa11: tim1_ch4_remap1_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_in_pb0: tim1_ch2n_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_in_pb1: tim1_ch3n_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_pwm_in_pb13: tim1_ch1n_pwm_in_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_pwm_in_pb14: tim1_ch2n_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_pwm_in_pb15: tim1_ch3n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_in_pe8: tim1_ch1n_remap2_pwm_in_pe8 {
+				pinmux = <STM32F1_PINMUX('E', 8, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_in_pe9: tim1_ch1_remap2_pwm_in_pe9 {
+				pinmux = <STM32F1_PINMUX('E', 9, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_in_pe10: tim1_ch2n_remap2_pwm_in_pe10 {
+				pinmux = <STM32F1_PINMUX('E', 10, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_in_pe11: tim1_ch2_remap2_pwm_in_pe11 {
+				pinmux = <STM32F1_PINMUX('E', 11, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_in_pe12: tim1_ch3n_remap2_pwm_in_pe12 {
+				pinmux = <STM32F1_PINMUX('E', 12, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_in_pe13: tim1_ch3_remap2_pwm_in_pe13 {
+				pinmux = <STM32F1_PINMUX('E', 13, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_in_pe14: tim1_ch4_remap2_pwm_in_pe14 {
+				pinmux = <STM32F1_PINMUX('E', 14, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_in_pd12: tim4_ch1_remap1_pwm_in_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_in_pd13: tim4_ch2_remap1_pwm_in_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_in_pd14: tim4_ch3_remap1_pwm_in_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_in_pd15: tim4_ch4_remap1_pwm_in_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch1_pwm_in_pa0: tim5_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pwm_in_pa1: tim5_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch3_pwm_in_pa2: tim5_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch4_pwm_in_pa3: tim5_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch1n_pwm_in_pa7: tim8_ch1n_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch2n_pwm_in_pb0: tim8_ch2n_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch3n_pwm_in_pb1: tim8_ch3n_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch1_pwm_in_pc6: tim8_ch1_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch2_pwm_in_pc7: tim8_ch2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch3_pwm_in_pc8: tim8_ch3_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch4_pwm_in_pc9: tim8_ch4_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_out_pa7: tim1_ch1n_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_pwm_out_pa8: tim1_ch1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_out_pa8: tim1_ch1_remap1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_pwm_out_pa9: tim1_ch2_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_out_pa9: tim1_ch2_remap1_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_pwm_out_pa10: tim1_ch3_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_out_pa10: tim1_ch3_remap1_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_pwm_out_pa11: tim1_ch4_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_out_pa11: tim1_ch4_remap1_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_out_pb0: tim1_ch2n_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_out_pb1: tim1_ch3n_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			/omit-if-no-ref/ tim1_ch1n_pwm_out_pb13: tim1_ch1n_pwm_out_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			/omit-if-no-ref/ tim1_ch2n_pwm_out_pb14: tim1_ch2n_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			/omit-if-no-ref/ tim1_ch3n_pwm_out_pb15: tim1_ch3n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_pe8: tim1_ch1n_remap2_pwm_pe8 {
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_out_pe8: tim1_ch1n_remap2_pwm_out_pe8 {
 				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap2_pwm_pe9: tim1_ch1_remap2_pwm_pe9 {
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_out_pe9: tim1_ch1_remap2_pwm_out_pe9 {
 				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_pe10: tim1_ch2n_remap2_pwm_pe10 {
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_out_pe10: tim1_ch2n_remap2_pwm_out_pe10 {
 				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap2_pwm_pe11: tim1_ch2_remap2_pwm_pe11 {
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_out_pe11: tim1_ch2_remap2_pwm_out_pe11 {
 				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_pe12: tim1_ch3n_remap2_pwm_pe12 {
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_out_pe12: tim1_ch3n_remap2_pwm_out_pe12 {
 				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap2_pwm_pe13: tim1_ch3_remap2_pwm_pe13 {
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_out_pe13: tim1_ch3_remap2_pwm_out_pe13 {
 				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap2_pwm_pe14: tim1_ch4_remap2_pwm_pe14 {
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_out_pe14: tim1_ch4_remap2_pwm_out_pe14 {
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_out_pd12: tim4_ch1_remap1_pwm_out_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_out_pd13: tim4_ch2_remap1_pwm_out_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_out_pd14: tim4_ch3_remap1_pwm_out_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_out_pd15: tim4_ch4_remap1_pwm_out_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim5_ch1_pwm_out_pa0: tim5_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim5_ch2_pwm_out_pa1: tim5_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim5_ch3_pwm_out_pa2: tim5_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim5_ch4_pwm_out_pa3: tim5_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim8_ch1n_pwm_out_pa7: tim8_ch1n_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim8_ch2n_pwm_out_pb0: tim8_ch2n_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim8_ch3n_pwm_out_pb1: tim8_ch3n_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim8_ch1_pwm_out_pc6: tim8_ch1_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim8_ch2_pwm_out_pc7: tim8_ch2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim8_ch3_pwm_out_pc8: tim8_ch3_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim8_ch4_pwm_out_pc9: tim8_ch4_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, NO_REMAP)>;
 			};
 

--- a/dts/st/f1/stm32f103z(f-g)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(f-g)hx-pinctrl.dtsi
@@ -896,333 +896,663 @@
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			/omit-if-no-ref/ tim10_ch1_pwm_in_pb8: tim10_ch1_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM10_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim10_ch1_remap1_pwm_in_pf6: tim10_ch1_remap1_pwm_in_pf6 {
+				pinmux = <STM32F1_PINMUX('F', 6, GPIO_IN, TIM10_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_in_pa7: tim1_ch1n_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_pwm_in_pa8: tim1_ch1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_in_pa8: tim1_ch1_remap1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_pwm_in_pa9: tim1_ch2_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_in_pa9: tim1_ch2_remap1_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_pwm_in_pa10: tim1_ch3_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_in_pa10: tim1_ch3_remap1_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_pwm_in_pa11: tim1_ch4_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_in_pa11: tim1_ch4_remap1_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_in_pb0: tim1_ch2n_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_in_pb1: tim1_ch3n_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim11_ch1_pwm_in_pb9: tim11_ch1_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM11_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_pwm_in_pb13: tim1_ch1n_pwm_in_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_pwm_in_pb14: tim1_ch2n_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_pwm_in_pb15: tim1_ch3n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_in_pe8: tim1_ch1n_remap2_pwm_in_pe8 {
+				pinmux = <STM32F1_PINMUX('E', 8, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_in_pe9: tim1_ch1_remap2_pwm_in_pe9 {
+				pinmux = <STM32F1_PINMUX('E', 9, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_in_pe10: tim1_ch2n_remap2_pwm_in_pe10 {
+				pinmux = <STM32F1_PINMUX('E', 10, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_in_pe11: tim1_ch2_remap2_pwm_in_pe11 {
+				pinmux = <STM32F1_PINMUX('E', 11, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_in_pe12: tim1_ch3n_remap2_pwm_in_pe12 {
+				pinmux = <STM32F1_PINMUX('E', 12, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_in_pe13: tim1_ch3_remap2_pwm_in_pe13 {
+				pinmux = <STM32F1_PINMUX('E', 13, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_in_pe14: tim1_ch4_remap2_pwm_in_pe14 {
+				pinmux = <STM32F1_PINMUX('E', 14, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim11_ch1_remap1_pwm_in_pf7: tim11_ch1_remap1_pwm_in_pf7 {
+				pinmux = <STM32F1_PINMUX('F', 7, GPIO_IN, TIM11_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim12_ch1_pwm_in_pb14: tim12_ch1_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim12_ch2_pwm_in_pb15: tim12_ch2_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim13_ch1_pwm_in_pa6: tim13_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM13_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim13_ch1_remap1_pwm_in_pf8: tim13_ch1_remap1_pwm_in_pf8 {
+				pinmux = <STM32F1_PINMUX('F', 8, GPIO_IN, TIM13_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim14_ch1_pwm_in_pa7: tim14_ch1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM14_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_in_pd12: tim4_ch1_remap1_pwm_in_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_in_pd13: tim4_ch2_remap1_pwm_in_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_in_pd14: tim4_ch3_remap1_pwm_in_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_in_pd15: tim4_ch4_remap1_pwm_in_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim14_ch1_remap1_pwm_in_pf9: tim14_ch1_remap1_pwm_in_pf9 {
+				pinmux = <STM32F1_PINMUX('F', 9, GPIO_IN, TIM14_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch1_pwm_in_pa0: tim5_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pwm_in_pa1: tim5_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch3_pwm_in_pa2: tim5_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch4_pwm_in_pa3: tim5_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch1n_pwm_in_pa7: tim8_ch1n_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch2n_pwm_in_pb0: tim8_ch2n_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch3n_pwm_in_pb1: tim8_ch3n_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch1_pwm_in_pc6: tim8_ch1_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch2_pwm_in_pc7: tim8_ch2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch3_pwm_in_pc8: tim8_ch3_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch4_pwm_in_pc9: tim8_ch4_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim9_ch1_pwm_in_pa2: tim9_ch1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM9_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim9_ch2_pwm_in_pa3: tim9_ch2_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM9_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim9_ch1_remap1_pwm_in_pe5: tim9_ch1_remap1_pwm_in_pe5 {
+				pinmux = <STM32F1_PINMUX('E', 5, GPIO_IN, TIM9_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim9_ch2_remap1_pwm_in_pe6: tim9_ch2_remap1_pwm_in_pe6 {
+				pinmux = <STM32F1_PINMUX('E', 6, GPIO_IN, TIM9_REMAP1)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim10_ch1_pwm_out_pb8: tim10_ch1_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM10_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim10_ch1_remap1_pwm_pf6: tim10_ch1_remap1_pwm_pf6 {
+			/omit-if-no-ref/ tim10_ch1_remap1_pwm_out_pf6: tim10_ch1_remap1_pwm_out_pf6 {
 				pinmux = <STM32F1_PINMUX('F', 6, ALTERNATE, TIM10_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_out_pa7: tim1_ch1n_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_pwm_out_pa8: tim1_ch1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_out_pa8: tim1_ch1_remap1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_pwm_out_pa9: tim1_ch2_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_out_pa9: tim1_ch2_remap1_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_pwm_out_pa10: tim1_ch3_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_out_pa10: tim1_ch3_remap1_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_pwm_out_pa11: tim1_ch4_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_out_pa11: tim1_ch4_remap1_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_out_pb0: tim1_ch2n_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_out_pb1: tim1_ch3n_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			/omit-if-no-ref/ tim11_ch1_pwm_out_pb9: tim11_ch1_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM11_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			/omit-if-no-ref/ tim1_ch1n_pwm_out_pb13: tim1_ch1n_pwm_out_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			/omit-if-no-ref/ tim1_ch2n_pwm_out_pb14: tim1_ch2n_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			/omit-if-no-ref/ tim1_ch3n_pwm_out_pb15: tim1_ch3n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_pe8: tim1_ch1n_remap2_pwm_pe8 {
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_out_pe8: tim1_ch1n_remap2_pwm_out_pe8 {
 				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap2_pwm_pe9: tim1_ch1_remap2_pwm_pe9 {
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_out_pe9: tim1_ch1_remap2_pwm_out_pe9 {
 				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_pe10: tim1_ch2n_remap2_pwm_pe10 {
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_out_pe10: tim1_ch2n_remap2_pwm_out_pe10 {
 				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap2_pwm_pe11: tim1_ch2_remap2_pwm_pe11 {
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_out_pe11: tim1_ch2_remap2_pwm_out_pe11 {
 				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_pe12: tim1_ch3n_remap2_pwm_pe12 {
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_out_pe12: tim1_ch3n_remap2_pwm_out_pe12 {
 				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap2_pwm_pe13: tim1_ch3_remap2_pwm_pe13 {
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_out_pe13: tim1_ch3_remap2_pwm_out_pe13 {
 				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap2_pwm_pe14: tim1_ch4_remap2_pwm_pe14 {
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_out_pe14: tim1_ch4_remap2_pwm_out_pe14 {
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim11_ch1_remap1_pwm_pf7: tim11_ch1_remap1_pwm_pf7 {
+			/omit-if-no-ref/ tim11_ch1_remap1_pwm_out_pf7: tim11_ch1_remap1_pwm_out_pf7 {
 				pinmux = <STM32F1_PINMUX('F', 7, ALTERNATE, TIM11_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			/omit-if-no-ref/ tim12_ch1_pwm_out_pb14: tim12_ch1_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			/omit-if-no-ref/ tim12_ch2_pwm_out_pb15: tim12_ch2_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim13_ch1_pwm_out_pa6: tim13_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM13_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim13_ch1_remap1_pwm_pf8: tim13_ch1_remap1_pwm_pf8 {
+			/omit-if-no-ref/ tim13_ch1_remap1_pwm_out_pf8: tim13_ch1_remap1_pwm_out_pf8 {
 				pinmux = <STM32F1_PINMUX('F', 8, ALTERNATE, TIM13_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			/omit-if-no-ref/ tim14_ch1_pwm_out_pa7: tim14_ch1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM14_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_out_pd12: tim4_ch1_remap1_pwm_out_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_out_pd13: tim4_ch2_remap1_pwm_out_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_out_pd14: tim4_ch3_remap1_pwm_out_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_out_pd15: tim4_ch4_remap1_pwm_out_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim14_ch1_remap1_pwm_pf9: tim14_ch1_remap1_pwm_pf9 {
+			/omit-if-no-ref/ tim14_ch1_remap1_pwm_out_pf9: tim14_ch1_remap1_pwm_out_pf9 {
 				pinmux = <STM32F1_PINMUX('F', 9, ALTERNATE, TIM14_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim5_ch1_pwm_out_pa0: tim5_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim5_ch2_pwm_out_pa1: tim5_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim5_ch3_pwm_out_pa2: tim5_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim5_ch4_pwm_out_pa3: tim5_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim8_ch1n_pwm_out_pa7: tim8_ch1n_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim8_ch2n_pwm_out_pb0: tim8_ch2n_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim8_ch3n_pwm_out_pb1: tim8_ch3n_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim8_ch1_pwm_out_pc6: tim8_ch1_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim8_ch2_pwm_out_pc7: tim8_ch2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim8_ch3_pwm_out_pc8: tim8_ch3_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim8_ch4_pwm_out_pc9: tim8_ch4_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			/omit-if-no-ref/ tim9_ch1_pwm_out_pa2: tim9_ch1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM9_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			/omit-if-no-ref/ tim9_ch2_pwm_out_pa3: tim9_ch2_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM9_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim9_ch1_remap1_pwm_pe5: tim9_ch1_remap1_pwm_pe5 {
+			/omit-if-no-ref/ tim9_ch1_remap1_pwm_out_pe5: tim9_ch1_remap1_pwm_out_pe5 {
 				pinmux = <STM32F1_PINMUX('E', 5, ALTERNATE, TIM9_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim9_ch2_remap1_pwm_pe6: tim9_ch2_remap1_pwm_pe6 {
+			/omit-if-no-ref/ tim9_ch2_remap1_pwm_out_pe6: tim9_ch2_remap1_pwm_out_pe6 {
 				pinmux = <STM32F1_PINMUX('E', 6, ALTERNATE, TIM9_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f103z(f-g)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f103z(f-g)tx-pinctrl.dtsi
@@ -896,333 +896,663 @@
 				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, SPI3_REMAP0)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim10_ch1_pwm_pb8: tim10_ch1_pwm_pb8 {
+			/omit-if-no-ref/ tim10_ch1_pwm_in_pb8: tim10_ch1_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM10_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim10_ch1_remap1_pwm_in_pf6: tim10_ch1_remap1_pwm_in_pf6 {
+				pinmux = <STM32F1_PINMUX('F', 6, GPIO_IN, TIM10_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_in_pa7: tim1_ch1n_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_pwm_in_pa8: tim1_ch1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_in_pa8: tim1_ch1_remap1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_pwm_in_pa9: tim1_ch2_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_in_pa9: tim1_ch2_remap1_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_pwm_in_pa10: tim1_ch3_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_in_pa10: tim1_ch3_remap1_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_pwm_in_pa11: tim1_ch4_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_in_pa11: tim1_ch4_remap1_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_in_pb0: tim1_ch2n_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_in_pb1: tim1_ch3n_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim11_ch1_pwm_in_pb9: tim11_ch1_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM11_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_pwm_in_pb13: tim1_ch1n_pwm_in_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_pwm_in_pb14: tim1_ch2n_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_pwm_in_pb15: tim1_ch3n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_in_pe8: tim1_ch1n_remap2_pwm_in_pe8 {
+				pinmux = <STM32F1_PINMUX('E', 8, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_in_pe9: tim1_ch1_remap2_pwm_in_pe9 {
+				pinmux = <STM32F1_PINMUX('E', 9, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_in_pe10: tim1_ch2n_remap2_pwm_in_pe10 {
+				pinmux = <STM32F1_PINMUX('E', 10, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_in_pe11: tim1_ch2_remap2_pwm_in_pe11 {
+				pinmux = <STM32F1_PINMUX('E', 11, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_in_pe12: tim1_ch3n_remap2_pwm_in_pe12 {
+				pinmux = <STM32F1_PINMUX('E', 12, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_in_pe13: tim1_ch3_remap2_pwm_in_pe13 {
+				pinmux = <STM32F1_PINMUX('E', 13, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_in_pe14: tim1_ch4_remap2_pwm_in_pe14 {
+				pinmux = <STM32F1_PINMUX('E', 14, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim11_ch1_remap1_pwm_in_pf7: tim11_ch1_remap1_pwm_in_pf7 {
+				pinmux = <STM32F1_PINMUX('F', 7, GPIO_IN, TIM11_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim12_ch1_pwm_in_pb14: tim12_ch1_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim12_ch2_pwm_in_pb15: tim12_ch2_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim13_ch1_pwm_in_pa6: tim13_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM13_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim13_ch1_remap1_pwm_in_pf8: tim13_ch1_remap1_pwm_in_pf8 {
+				pinmux = <STM32F1_PINMUX('F', 8, GPIO_IN, TIM13_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim14_ch1_pwm_in_pa7: tim14_ch1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM14_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_in_pd12: tim4_ch1_remap1_pwm_in_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_in_pd13: tim4_ch2_remap1_pwm_in_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_in_pd14: tim4_ch3_remap1_pwm_in_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_in_pd15: tim4_ch4_remap1_pwm_in_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim14_ch1_remap1_pwm_in_pf9: tim14_ch1_remap1_pwm_in_pf9 {
+				pinmux = <STM32F1_PINMUX('F', 9, GPIO_IN, TIM14_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch1_pwm_in_pa0: tim5_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pwm_in_pa1: tim5_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch3_pwm_in_pa2: tim5_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch4_pwm_in_pa3: tim5_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch1n_pwm_in_pa7: tim8_ch1n_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch2n_pwm_in_pb0: tim8_ch2n_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch3n_pwm_in_pb1: tim8_ch3n_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch1_pwm_in_pc6: tim8_ch1_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch2_pwm_in_pc7: tim8_ch2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch3_pwm_in_pc8: tim8_ch3_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim8_ch4_pwm_in_pc9: tim8_ch4_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim9_ch1_pwm_in_pa2: tim9_ch1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM9_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim9_ch2_pwm_in_pa3: tim9_ch2_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM9_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim9_ch1_remap1_pwm_in_pe5: tim9_ch1_remap1_pwm_in_pe5 {
+				pinmux = <STM32F1_PINMUX('E', 5, GPIO_IN, TIM9_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim9_ch2_remap1_pwm_in_pe6: tim9_ch2_remap1_pwm_in_pe6 {
+				pinmux = <STM32F1_PINMUX('E', 6, GPIO_IN, TIM9_REMAP1)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim10_ch1_pwm_out_pb8: tim10_ch1_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM10_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim10_ch1_remap1_pwm_pf6: tim10_ch1_remap1_pwm_pf6 {
+			/omit-if-no-ref/ tim10_ch1_remap1_pwm_out_pf6: tim10_ch1_remap1_pwm_out_pf6 {
 				pinmux = <STM32F1_PINMUX('F', 6, ALTERNATE, TIM10_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_out_pa7: tim1_ch1n_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_pwm_out_pa8: tim1_ch1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_out_pa8: tim1_ch1_remap1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_pwm_out_pa9: tim1_ch2_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_out_pa9: tim1_ch2_remap1_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_pwm_out_pa10: tim1_ch3_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_out_pa10: tim1_ch3_remap1_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_pwm_out_pa11: tim1_ch4_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_out_pa11: tim1_ch4_remap1_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_out_pb0: tim1_ch2n_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_out_pb1: tim1_ch3n_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim11_ch1_pwm_pb9: tim11_ch1_pwm_pb9 {
+			/omit-if-no-ref/ tim11_ch1_pwm_out_pb9: tim11_ch1_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM11_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			/omit-if-no-ref/ tim1_ch1n_pwm_out_pb13: tim1_ch1n_pwm_out_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			/omit-if-no-ref/ tim1_ch2n_pwm_out_pb14: tim1_ch2n_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			/omit-if-no-ref/ tim1_ch3n_pwm_out_pb15: tim1_ch3n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_pe8: tim1_ch1n_remap2_pwm_pe8 {
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_out_pe8: tim1_ch1n_remap2_pwm_out_pe8 {
 				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap2_pwm_pe9: tim1_ch1_remap2_pwm_pe9 {
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_out_pe9: tim1_ch1_remap2_pwm_out_pe9 {
 				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_pe10: tim1_ch2n_remap2_pwm_pe10 {
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_out_pe10: tim1_ch2n_remap2_pwm_out_pe10 {
 				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap2_pwm_pe11: tim1_ch2_remap2_pwm_pe11 {
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_out_pe11: tim1_ch2_remap2_pwm_out_pe11 {
 				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_pe12: tim1_ch3n_remap2_pwm_pe12 {
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_out_pe12: tim1_ch3n_remap2_pwm_out_pe12 {
 				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap2_pwm_pe13: tim1_ch3_remap2_pwm_pe13 {
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_out_pe13: tim1_ch3_remap2_pwm_out_pe13 {
 				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap2_pwm_pe14: tim1_ch4_remap2_pwm_pe14 {
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_out_pe14: tim1_ch4_remap2_pwm_out_pe14 {
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim11_ch1_remap1_pwm_pf7: tim11_ch1_remap1_pwm_pf7 {
+			/omit-if-no-ref/ tim11_ch1_remap1_pwm_out_pf7: tim11_ch1_remap1_pwm_out_pf7 {
 				pinmux = <STM32F1_PINMUX('F', 7, ALTERNATE, TIM11_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim12_ch1_pwm_pb14: tim12_ch1_pwm_pb14 {
+			/omit-if-no-ref/ tim12_ch1_pwm_out_pb14: tim12_ch1_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim12_ch2_pwm_pb15: tim12_ch2_pwm_pb15 {
+			/omit-if-no-ref/ tim12_ch2_pwm_out_pb15: tim12_ch2_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim13_ch1_pwm_pa6: tim13_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim13_ch1_pwm_out_pa6: tim13_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM13_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim13_ch1_remap1_pwm_pf8: tim13_ch1_remap1_pwm_pf8 {
+			/omit-if-no-ref/ tim13_ch1_remap1_pwm_out_pf8: tim13_ch1_remap1_pwm_out_pf8 {
 				pinmux = <STM32F1_PINMUX('F', 8, ALTERNATE, TIM13_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim14_ch1_pwm_pa7: tim14_ch1_pwm_pa7 {
+			/omit-if-no-ref/ tim14_ch1_pwm_out_pa7: tim14_ch1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM14_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_out_pd12: tim4_ch1_remap1_pwm_out_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_out_pd13: tim4_ch2_remap1_pwm_out_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_out_pd14: tim4_ch3_remap1_pwm_out_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_out_pd15: tim4_ch4_remap1_pwm_out_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim14_ch1_remap1_pwm_pf9: tim14_ch1_remap1_pwm_pf9 {
+			/omit-if-no-ref/ tim14_ch1_remap1_pwm_out_pf9: tim14_ch1_remap1_pwm_out_pf9 {
 				pinmux = <STM32F1_PINMUX('F', 9, ALTERNATE, TIM14_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim5_ch1_pwm_out_pa0: tim5_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim5_ch2_pwm_out_pa1: tim5_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim5_ch3_pwm_out_pa2: tim5_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim5_ch4_pwm_out_pa3: tim5_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch1n_pwm_pa7: tim8_ch1n_pwm_pa7 {
+			/omit-if-no-ref/ tim8_ch1n_pwm_out_pa7: tim8_ch1n_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch2n_pwm_pb0: tim8_ch2n_pwm_pb0 {
+			/omit-if-no-ref/ tim8_ch2n_pwm_out_pb0: tim8_ch2n_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch3n_pwm_pb1: tim8_ch3n_pwm_pb1 {
+			/omit-if-no-ref/ tim8_ch3n_pwm_out_pb1: tim8_ch3n_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch1_pwm_pc6: tim8_ch1_pwm_pc6 {
+			/omit-if-no-ref/ tim8_ch1_pwm_out_pc6: tim8_ch1_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch2_pwm_pc7: tim8_ch2_pwm_pc7 {
+			/omit-if-no-ref/ tim8_ch2_pwm_out_pc7: tim8_ch2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch3_pwm_pc8: tim8_ch3_pwm_pc8 {
+			/omit-if-no-ref/ tim8_ch3_pwm_out_pc8: tim8_ch3_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim8_ch4_pwm_pc9: tim8_ch4_pwm_pc9 {
+			/omit-if-no-ref/ tim8_ch4_pwm_out_pc9: tim8_ch4_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim9_ch1_pwm_pa2: tim9_ch1_pwm_pa2 {
+			/omit-if-no-ref/ tim9_ch1_pwm_out_pa2: tim9_ch1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM9_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim9_ch2_pwm_pa3: tim9_ch2_pwm_pa3 {
+			/omit-if-no-ref/ tim9_ch2_pwm_out_pa3: tim9_ch2_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM9_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim9_ch1_remap1_pwm_pe5: tim9_ch1_remap1_pwm_pe5 {
+			/omit-if-no-ref/ tim9_ch1_remap1_pwm_out_pe5: tim9_ch1_remap1_pwm_out_pe5 {
 				pinmux = <STM32F1_PINMUX('E', 5, ALTERNATE, TIM9_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim9_ch2_remap1_pwm_pe6: tim9_ch2_remap1_pwm_pe6 {
+			/omit-if-no-ref/ tim9_ch2_remap1_pwm_out_pe6: tim9_ch2_remap1_pwm_out_pe6 {
 				pinmux = <STM32F1_PINMUX('E', 6, ALTERNATE, TIM9_REMAP1)>;
 			};
 

--- a/dts/st/f1/stm32f105r(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f105r(8-b-c)tx-pinctrl.dtsi
@@ -654,205 +654,407 @@
 				pinmux = <STM32F1_PINMUX('C', 10, GPIO_IN, SPI3_REMAP1)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_in_pa7: tim1_ch1n_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_pwm_in_pa8: tim1_ch1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_in_pa8: tim1_ch1_remap1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_pwm_in_pa9: tim1_ch2_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_in_pa9: tim1_ch2_remap1_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_pwm_in_pa10: tim1_ch3_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_in_pa10: tim1_ch3_remap1_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_pwm_in_pa11: tim1_ch4_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_in_pa11: tim1_ch4_remap1_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_in_pb0: tim1_ch2n_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_in_pb1: tim1_ch3n_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_pwm_in_pb13: tim1_ch1n_pwm_in_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_pwm_in_pb14: tim1_ch2n_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_pwm_in_pb15: tim1_ch3n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch1_pwm_in_pa0: tim5_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pwm_in_pa1: tim5_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch3_pwm_in_pa2: tim5_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch4_pwm_in_pa3: tim5_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_out_pa7: tim1_ch1n_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_pwm_out_pa8: tim1_ch1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_out_pa8: tim1_ch1_remap1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_pwm_out_pa9: tim1_ch2_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_out_pa9: tim1_ch2_remap1_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_pwm_out_pa10: tim1_ch3_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_out_pa10: tim1_ch3_remap1_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_pwm_out_pa11: tim1_ch4_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_out_pa11: tim1_ch4_remap1_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_out_pb0: tim1_ch2n_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_out_pb1: tim1_ch3n_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			/omit-if-no-ref/ tim1_ch1n_pwm_out_pb13: tim1_ch1n_pwm_out_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			/omit-if-no-ref/ tim1_ch2n_pwm_out_pb14: tim1_ch2n_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			/omit-if-no-ref/ tim1_ch3n_pwm_out_pb15: tim1_ch3n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim5_ch1_pwm_out_pa0: tim5_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim5_ch2_pwm_out_pa1: tim5_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim5_ch3_pwm_out_pa2: tim5_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim5_ch4_pwm_out_pa3: tim5_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
 			};
 

--- a/dts/st/f1/stm32f105v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f105v(8-b)hx-pinctrl.dtsi
@@ -778,249 +778,495 @@
 				pinmux = <STM32F1_PINMUX('C', 10, GPIO_IN, SPI3_REMAP1)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_in_pa7: tim1_ch1n_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_pwm_in_pa8: tim1_ch1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_in_pa8: tim1_ch1_remap1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_pwm_in_pa9: tim1_ch2_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_in_pa9: tim1_ch2_remap1_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_pwm_in_pa10: tim1_ch3_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_in_pa10: tim1_ch3_remap1_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_pwm_in_pa11: tim1_ch4_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_in_pa11: tim1_ch4_remap1_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_in_pb0: tim1_ch2n_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_in_pb1: tim1_ch3n_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_pwm_in_pb13: tim1_ch1n_pwm_in_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_pwm_in_pb14: tim1_ch2n_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_pwm_in_pb15: tim1_ch3n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_in_pe8: tim1_ch1n_remap2_pwm_in_pe8 {
+				pinmux = <STM32F1_PINMUX('E', 8, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_in_pe9: tim1_ch1_remap2_pwm_in_pe9 {
+				pinmux = <STM32F1_PINMUX('E', 9, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_in_pe10: tim1_ch2n_remap2_pwm_in_pe10 {
+				pinmux = <STM32F1_PINMUX('E', 10, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_in_pe11: tim1_ch2_remap2_pwm_in_pe11 {
+				pinmux = <STM32F1_PINMUX('E', 11, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_in_pe12: tim1_ch3n_remap2_pwm_in_pe12 {
+				pinmux = <STM32F1_PINMUX('E', 12, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_in_pe13: tim1_ch3_remap2_pwm_in_pe13 {
+				pinmux = <STM32F1_PINMUX('E', 13, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_in_pe14: tim1_ch4_remap2_pwm_in_pe14 {
+				pinmux = <STM32F1_PINMUX('E', 14, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_in_pd12: tim4_ch1_remap1_pwm_in_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_in_pd13: tim4_ch2_remap1_pwm_in_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_in_pd14: tim4_ch3_remap1_pwm_in_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_in_pd15: tim4_ch4_remap1_pwm_in_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch1_pwm_in_pa0: tim5_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pwm_in_pa1: tim5_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch3_pwm_in_pa2: tim5_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch4_pwm_in_pa3: tim5_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_out_pa7: tim1_ch1n_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_pwm_out_pa8: tim1_ch1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_out_pa8: tim1_ch1_remap1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_pwm_out_pa9: tim1_ch2_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_out_pa9: tim1_ch2_remap1_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_pwm_out_pa10: tim1_ch3_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_out_pa10: tim1_ch3_remap1_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_pwm_out_pa11: tim1_ch4_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_out_pa11: tim1_ch4_remap1_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_out_pb0: tim1_ch2n_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_out_pb1: tim1_ch3n_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			/omit-if-no-ref/ tim1_ch1n_pwm_out_pb13: tim1_ch1n_pwm_out_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			/omit-if-no-ref/ tim1_ch2n_pwm_out_pb14: tim1_ch2n_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			/omit-if-no-ref/ tim1_ch3n_pwm_out_pb15: tim1_ch3n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_pe8: tim1_ch1n_remap2_pwm_pe8 {
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_out_pe8: tim1_ch1n_remap2_pwm_out_pe8 {
 				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap2_pwm_pe9: tim1_ch1_remap2_pwm_pe9 {
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_out_pe9: tim1_ch1_remap2_pwm_out_pe9 {
 				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_pe10: tim1_ch2n_remap2_pwm_pe10 {
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_out_pe10: tim1_ch2n_remap2_pwm_out_pe10 {
 				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap2_pwm_pe11: tim1_ch2_remap2_pwm_pe11 {
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_out_pe11: tim1_ch2_remap2_pwm_out_pe11 {
 				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_pe12: tim1_ch3n_remap2_pwm_pe12 {
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_out_pe12: tim1_ch3n_remap2_pwm_out_pe12 {
 				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap2_pwm_pe13: tim1_ch3_remap2_pwm_pe13 {
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_out_pe13: tim1_ch3_remap2_pwm_out_pe13 {
 				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap2_pwm_pe14: tim1_ch4_remap2_pwm_pe14 {
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_out_pe14: tim1_ch4_remap2_pwm_out_pe14 {
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_out_pd12: tim4_ch1_remap1_pwm_out_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_out_pd13: tim4_ch2_remap1_pwm_out_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_out_pd14: tim4_ch3_remap1_pwm_out_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_out_pd15: tim4_ch4_remap1_pwm_out_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim5_ch1_pwm_out_pa0: tim5_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim5_ch2_pwm_out_pa1: tim5_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim5_ch3_pwm_out_pa2: tim5_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim5_ch4_pwm_out_pa3: tim5_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
 			};
 

--- a/dts/st/f1/stm32f105v(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f105v(8-b-c)tx-pinctrl.dtsi
@@ -778,249 +778,495 @@
 				pinmux = <STM32F1_PINMUX('C', 10, GPIO_IN, SPI3_REMAP1)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_in_pa7: tim1_ch1n_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_pwm_in_pa8: tim1_ch1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_in_pa8: tim1_ch1_remap1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_pwm_in_pa9: tim1_ch2_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_in_pa9: tim1_ch2_remap1_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_pwm_in_pa10: tim1_ch3_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_in_pa10: tim1_ch3_remap1_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_pwm_in_pa11: tim1_ch4_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_in_pa11: tim1_ch4_remap1_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_in_pb0: tim1_ch2n_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_in_pb1: tim1_ch3n_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_pwm_in_pb13: tim1_ch1n_pwm_in_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_pwm_in_pb14: tim1_ch2n_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_pwm_in_pb15: tim1_ch3n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_in_pe8: tim1_ch1n_remap2_pwm_in_pe8 {
+				pinmux = <STM32F1_PINMUX('E', 8, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_in_pe9: tim1_ch1_remap2_pwm_in_pe9 {
+				pinmux = <STM32F1_PINMUX('E', 9, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_in_pe10: tim1_ch2n_remap2_pwm_in_pe10 {
+				pinmux = <STM32F1_PINMUX('E', 10, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_in_pe11: tim1_ch2_remap2_pwm_in_pe11 {
+				pinmux = <STM32F1_PINMUX('E', 11, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_in_pe12: tim1_ch3n_remap2_pwm_in_pe12 {
+				pinmux = <STM32F1_PINMUX('E', 12, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_in_pe13: tim1_ch3_remap2_pwm_in_pe13 {
+				pinmux = <STM32F1_PINMUX('E', 13, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_in_pe14: tim1_ch4_remap2_pwm_in_pe14 {
+				pinmux = <STM32F1_PINMUX('E', 14, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_in_pd12: tim4_ch1_remap1_pwm_in_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_in_pd13: tim4_ch2_remap1_pwm_in_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_in_pd14: tim4_ch3_remap1_pwm_in_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_in_pd15: tim4_ch4_remap1_pwm_in_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch1_pwm_in_pa0: tim5_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pwm_in_pa1: tim5_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch3_pwm_in_pa2: tim5_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch4_pwm_in_pa3: tim5_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_out_pa7: tim1_ch1n_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_pwm_out_pa8: tim1_ch1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_out_pa8: tim1_ch1_remap1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_pwm_out_pa9: tim1_ch2_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_out_pa9: tim1_ch2_remap1_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_pwm_out_pa10: tim1_ch3_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_out_pa10: tim1_ch3_remap1_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_pwm_out_pa11: tim1_ch4_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_out_pa11: tim1_ch4_remap1_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_out_pb0: tim1_ch2n_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_out_pb1: tim1_ch3n_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			/omit-if-no-ref/ tim1_ch1n_pwm_out_pb13: tim1_ch1n_pwm_out_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			/omit-if-no-ref/ tim1_ch2n_pwm_out_pb14: tim1_ch2n_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			/omit-if-no-ref/ tim1_ch3n_pwm_out_pb15: tim1_ch3n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_pe8: tim1_ch1n_remap2_pwm_pe8 {
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_out_pe8: tim1_ch1n_remap2_pwm_out_pe8 {
 				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap2_pwm_pe9: tim1_ch1_remap2_pwm_pe9 {
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_out_pe9: tim1_ch1_remap2_pwm_out_pe9 {
 				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_pe10: tim1_ch2n_remap2_pwm_pe10 {
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_out_pe10: tim1_ch2n_remap2_pwm_out_pe10 {
 				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap2_pwm_pe11: tim1_ch2_remap2_pwm_pe11 {
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_out_pe11: tim1_ch2_remap2_pwm_out_pe11 {
 				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_pe12: tim1_ch3n_remap2_pwm_pe12 {
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_out_pe12: tim1_ch3n_remap2_pwm_out_pe12 {
 				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap2_pwm_pe13: tim1_ch3_remap2_pwm_pe13 {
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_out_pe13: tim1_ch3_remap2_pwm_out_pe13 {
 				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap2_pwm_pe14: tim1_ch4_remap2_pwm_pe14 {
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_out_pe14: tim1_ch4_remap2_pwm_out_pe14 {
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_out_pd12: tim4_ch1_remap1_pwm_out_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_out_pd13: tim4_ch2_remap1_pwm_out_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_out_pd14: tim4_ch3_remap1_pwm_out_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_out_pd15: tim4_ch4_remap1_pwm_out_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim5_ch1_pwm_out_pa0: tim5_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim5_ch2_pwm_out_pa1: tim5_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim5_ch3_pwm_out_pa2: tim5_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim5_ch4_pwm_out_pa3: tim5_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
 			};
 

--- a/dts/st/f1/stm32f107r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f107r(b-c)tx-pinctrl.dtsi
@@ -772,205 +772,407 @@
 				pinmux = <STM32F1_PINMUX('C', 10, GPIO_IN, SPI3_REMAP1)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_in_pa7: tim1_ch1n_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_pwm_in_pa8: tim1_ch1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_in_pa8: tim1_ch1_remap1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_pwm_in_pa9: tim1_ch2_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_in_pa9: tim1_ch2_remap1_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_pwm_in_pa10: tim1_ch3_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_in_pa10: tim1_ch3_remap1_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_pwm_in_pa11: tim1_ch4_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_in_pa11: tim1_ch4_remap1_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_in_pb0: tim1_ch2n_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_in_pb1: tim1_ch3n_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_pwm_in_pb13: tim1_ch1n_pwm_in_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_pwm_in_pb14: tim1_ch2n_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_pwm_in_pb15: tim1_ch3n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch1_pwm_in_pa0: tim5_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pwm_in_pa1: tim5_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch3_pwm_in_pa2: tim5_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch4_pwm_in_pa3: tim5_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_out_pa7: tim1_ch1n_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_pwm_out_pa8: tim1_ch1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_out_pa8: tim1_ch1_remap1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_pwm_out_pa9: tim1_ch2_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_out_pa9: tim1_ch2_remap1_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_pwm_out_pa10: tim1_ch3_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_out_pa10: tim1_ch3_remap1_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_pwm_out_pa11: tim1_ch4_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_out_pa11: tim1_ch4_remap1_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_out_pb0: tim1_ch2n_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_out_pb1: tim1_ch3n_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			/omit-if-no-ref/ tim1_ch1n_pwm_out_pb13: tim1_ch1n_pwm_out_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			/omit-if-no-ref/ tim1_ch2n_pwm_out_pb14: tim1_ch2n_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			/omit-if-no-ref/ tim1_ch3n_pwm_out_pb15: tim1_ch3n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim5_ch1_pwm_out_pa0: tim5_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim5_ch2_pwm_out_pa1: tim5_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim5_ch3_pwm_out_pa2: tim5_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim5_ch4_pwm_out_pa3: tim5_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
 			};
 

--- a/dts/st/f1/stm32f107v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f107v(b-c)tx-pinctrl.dtsi
@@ -920,249 +920,495 @@
 				pinmux = <STM32F1_PINMUX('C', 10, GPIO_IN, SPI3_REMAP1)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_in_pa7: tim1_ch1n_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_pwm_in_pa8: tim1_ch1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_in_pa8: tim1_ch1_remap1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_pwm_in_pa9: tim1_ch2_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_in_pa9: tim1_ch2_remap1_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_pwm_in_pa10: tim1_ch3_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_in_pa10: tim1_ch3_remap1_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_pwm_in_pa11: tim1_ch4_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_in_pa11: tim1_ch4_remap1_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_in_pb0: tim1_ch2n_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_in_pb1: tim1_ch3n_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_pwm_in_pb13: tim1_ch1n_pwm_in_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_pwm_in_pb14: tim1_ch2n_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_pwm_in_pb15: tim1_ch3n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_in_pe8: tim1_ch1n_remap2_pwm_in_pe8 {
+				pinmux = <STM32F1_PINMUX('E', 8, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_in_pe9: tim1_ch1_remap2_pwm_in_pe9 {
+				pinmux = <STM32F1_PINMUX('E', 9, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_in_pe10: tim1_ch2n_remap2_pwm_in_pe10 {
+				pinmux = <STM32F1_PINMUX('E', 10, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_in_pe11: tim1_ch2_remap2_pwm_in_pe11 {
+				pinmux = <STM32F1_PINMUX('E', 11, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_in_pe12: tim1_ch3n_remap2_pwm_in_pe12 {
+				pinmux = <STM32F1_PINMUX('E', 12, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_in_pe13: tim1_ch3_remap2_pwm_in_pe13 {
+				pinmux = <STM32F1_PINMUX('E', 13, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_in_pe14: tim1_ch4_remap2_pwm_in_pe14 {
+				pinmux = <STM32F1_PINMUX('E', 14, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_in_pd12: tim4_ch1_remap1_pwm_in_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_in_pd13: tim4_ch2_remap1_pwm_in_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_in_pd14: tim4_ch3_remap1_pwm_in_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_in_pd15: tim4_ch4_remap1_pwm_in_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch1_pwm_in_pa0: tim5_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pwm_in_pa1: tim5_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch3_pwm_in_pa2: tim5_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch4_pwm_in_pa3: tim5_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_out_pa7: tim1_ch1n_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_pwm_out_pa8: tim1_ch1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_out_pa8: tim1_ch1_remap1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_pwm_out_pa9: tim1_ch2_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_out_pa9: tim1_ch2_remap1_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_pwm_out_pa10: tim1_ch3_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_out_pa10: tim1_ch3_remap1_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_pwm_out_pa11: tim1_ch4_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_out_pa11: tim1_ch4_remap1_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_out_pb0: tim1_ch2n_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_out_pb1: tim1_ch3n_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			/omit-if-no-ref/ tim1_ch1n_pwm_out_pb13: tim1_ch1n_pwm_out_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			/omit-if-no-ref/ tim1_ch2n_pwm_out_pb14: tim1_ch2n_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			/omit-if-no-ref/ tim1_ch3n_pwm_out_pb15: tim1_ch3n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_pe8: tim1_ch1n_remap2_pwm_pe8 {
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_out_pe8: tim1_ch1n_remap2_pwm_out_pe8 {
 				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap2_pwm_pe9: tim1_ch1_remap2_pwm_pe9 {
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_out_pe9: tim1_ch1_remap2_pwm_out_pe9 {
 				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_pe10: tim1_ch2n_remap2_pwm_pe10 {
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_out_pe10: tim1_ch2n_remap2_pwm_out_pe10 {
 				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap2_pwm_pe11: tim1_ch2_remap2_pwm_pe11 {
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_out_pe11: tim1_ch2_remap2_pwm_out_pe11 {
 				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_pe12: tim1_ch3n_remap2_pwm_pe12 {
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_out_pe12: tim1_ch3n_remap2_pwm_out_pe12 {
 				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap2_pwm_pe13: tim1_ch3_remap2_pwm_pe13 {
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_out_pe13: tim1_ch3_remap2_pwm_out_pe13 {
 				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap2_pwm_pe14: tim1_ch4_remap2_pwm_pe14 {
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_out_pe14: tim1_ch4_remap2_pwm_out_pe14 {
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_out_pd12: tim4_ch1_remap1_pwm_out_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_out_pd13: tim4_ch2_remap1_pwm_out_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_out_pd14: tim4_ch3_remap1_pwm_out_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_out_pd15: tim4_ch4_remap1_pwm_out_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim5_ch1_pwm_out_pa0: tim5_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim5_ch2_pwm_out_pa1: tim5_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim5_ch3_pwm_out_pa2: tim5_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim5_ch4_pwm_out_pa3: tim5_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
 			};
 

--- a/dts/st/f1/stm32f107vchx-pinctrl.dtsi
+++ b/dts/st/f1/stm32f107vchx-pinctrl.dtsi
@@ -920,249 +920,495 @@
 				pinmux = <STM32F1_PINMUX('C', 10, GPIO_IN, SPI3_REMAP1)>;
 			};
 
-			/* TIM_CH_PWM / TIM_CHN_PWM */
+			/* TIM_CH_PWM_IN / TIM_CHN_PWM_IN */
 
-			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_pa7: tim1_ch1n_remap1_pwm_pa7 {
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_in_pa7: tim1_ch1n_remap1_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_pwm_in_pa8: tim1_ch1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_in_pa8: tim1_ch1_remap1_pwm_in_pa8 {
+				pinmux = <STM32F1_PINMUX('A', 8, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_pwm_in_pa9: tim1_ch2_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_in_pa9: tim1_ch2_remap1_pwm_in_pa9 {
+				pinmux = <STM32F1_PINMUX('A', 9, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_pwm_in_pa10: tim1_ch3_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_in_pa10: tim1_ch3_remap1_pwm_in_pa10 {
+				pinmux = <STM32F1_PINMUX('A', 10, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_pwm_in_pa11: tim1_ch4_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_in_pa11: tim1_ch4_remap1_pwm_in_pa11 {
+				pinmux = <STM32F1_PINMUX('A', 11, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_in_pb0: tim1_ch2n_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_in_pb1: tim1_ch3n_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM1_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_pwm_in_pb13: tim1_ch1n_pwm_in_pb13 {
+				pinmux = <STM32F1_PINMUX('B', 13, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_pwm_in_pb14: tim1_ch2n_pwm_in_pb14 {
+				pinmux = <STM32F1_PINMUX('B', 14, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_pwm_in_pb15: tim1_ch3n_pwm_in_pb15 {
+				pinmux = <STM32F1_PINMUX('B', 15, GPIO_IN, TIM1_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_in_pe8: tim1_ch1n_remap2_pwm_in_pe8 {
+				pinmux = <STM32F1_PINMUX('E', 8, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_in_pe9: tim1_ch1_remap2_pwm_in_pe9 {
+				pinmux = <STM32F1_PINMUX('E', 9, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_in_pe10: tim1_ch2n_remap2_pwm_in_pe10 {
+				pinmux = <STM32F1_PINMUX('E', 10, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_in_pe11: tim1_ch2_remap2_pwm_in_pe11 {
+				pinmux = <STM32F1_PINMUX('E', 11, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_in_pe12: tim1_ch3n_remap2_pwm_in_pe12 {
+				pinmux = <STM32F1_PINMUX('E', 12, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_in_pe13: tim1_ch3_remap2_pwm_in_pe13 {
+				pinmux = <STM32F1_PINMUX('E', 13, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_in_pe14: tim1_ch4_remap2_pwm_in_pe14 {
+				pinmux = <STM32F1_PINMUX('E', 14, GPIO_IN, TIM1_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_pwm_in_pa0: tim2_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_in_pa0: tim2_ch1_remap2_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_pwm_in_pa1: tim2_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_in_pa1: tim2_ch2_remap2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_pwm_in_pa2: tim2_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_in_pa2: tim2_ch3_remap1_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_pwm_in_pa3: tim2_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_in_pa3: tim2_ch4_remap1_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_in_pa15: tim2_ch1_remap1_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_in_pa15: tim2_ch1_remap3_pwm_in_pa15 {
+				pinmux = <STM32F1_PINMUX('A', 15, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_in_pb3: tim2_ch2_remap1_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_in_pb3: tim2_ch2_remap3_pwm_in_pb3 {
+				pinmux = <STM32F1_PINMUX('B', 3, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_in_pb10: tim2_ch3_remap2_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_in_pb10: tim2_ch3_remap3_pwm_in_pb10 {
+				pinmux = <STM32F1_PINMUX('B', 10, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_in_pb11: tim2_ch4_remap2_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_in_pb11: tim2_ch4_remap3_pwm_in_pb11 {
+				pinmux = <STM32F1_PINMUX('B', 11, GPIO_IN, TIM2_REMAP3)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_pwm_in_pa6: tim3_ch1_pwm_in_pa6 {
+				pinmux = <STM32F1_PINMUX('A', 6, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_pwm_in_pa7: tim3_ch2_pwm_in_pa7 {
+				pinmux = <STM32F1_PINMUX('A', 7, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_pwm_in_pb0: tim3_ch3_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_in_pb0: tim3_ch3_remap1_pwm_in_pb0 {
+				pinmux = <STM32F1_PINMUX('B', 0, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_pwm_in_pb1: tim3_ch4_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_in_pb1: tim3_ch4_remap1_pwm_in_pb1 {
+				pinmux = <STM32F1_PINMUX('B', 1, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_in_pb4: tim3_ch1_remap1_pwm_in_pb4 {
+				pinmux = <STM32F1_PINMUX('B', 4, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_in_pb5: tim3_ch2_remap1_pwm_in_pb5 {
+				pinmux = <STM32F1_PINMUX('B', 5, GPIO_IN, TIM3_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_in_pc6: tim3_ch1_remap2_pwm_in_pc6 {
+				pinmux = <STM32F1_PINMUX('C', 6, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_in_pc7: tim3_ch2_remap2_pwm_in_pc7 {
+				pinmux = <STM32F1_PINMUX('C', 7, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_in_pc8: tim3_ch3_remap2_pwm_in_pc8 {
+				pinmux = <STM32F1_PINMUX('C', 8, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_in_pc9: tim3_ch4_remap2_pwm_in_pc9 {
+				pinmux = <STM32F1_PINMUX('C', 9, GPIO_IN, TIM3_REMAP2)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_pwm_in_pb6: tim4_ch1_pwm_in_pb6 {
+				pinmux = <STM32F1_PINMUX('B', 6, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_pwm_in_pb7: tim4_ch2_pwm_in_pb7 {
+				pinmux = <STM32F1_PINMUX('B', 7, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_pwm_in_pb8: tim4_ch3_pwm_in_pb8 {
+				pinmux = <STM32F1_PINMUX('B', 8, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_pwm_in_pb9: tim4_ch4_pwm_in_pb9 {
+				pinmux = <STM32F1_PINMUX('B', 9, GPIO_IN, TIM4_REMAP0)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_in_pd12: tim4_ch1_remap1_pwm_in_pd12 {
+				pinmux = <STM32F1_PINMUX('D', 12, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_in_pd13: tim4_ch2_remap1_pwm_in_pd13 {
+				pinmux = <STM32F1_PINMUX('D', 13, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_in_pd14: tim4_ch3_remap1_pwm_in_pd14 {
+				pinmux = <STM32F1_PINMUX('D', 14, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_in_pd15: tim4_ch4_remap1_pwm_in_pd15 {
+				pinmux = <STM32F1_PINMUX('D', 15, GPIO_IN, TIM4_REMAP1)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch1_pwm_in_pa0: tim5_ch1_pwm_in_pa0 {
+				pinmux = <STM32F1_PINMUX('A', 0, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch2_pwm_in_pa1: tim5_ch2_pwm_in_pa1 {
+				pinmux = <STM32F1_PINMUX('A', 1, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch3_pwm_in_pa2: tim5_ch3_pwm_in_pa2 {
+				pinmux = <STM32F1_PINMUX('A', 2, GPIO_IN, NO_REMAP)>;
+			};
+
+			/omit-if-no-ref/ tim5_ch4_pwm_in_pa3: tim5_ch4_pwm_in_pa3 {
+				pinmux = <STM32F1_PINMUX('A', 3, GPIO_IN, NO_REMAP)>;
+			};
+
+			/* TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT */
+
+			/omit-if-no-ref/ tim1_ch1n_remap1_pwm_out_pa7: tim1_ch1n_remap1_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_pwm_pa8: tim1_ch1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_pwm_out_pa8: tim1_ch1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap1_pwm_pa8: tim1_ch1_remap1_pwm_pa8 {
+			/omit-if-no-ref/ tim1_ch1_remap1_pwm_out_pa8: tim1_ch1_remap1_pwm_out_pa8 {
 				pinmux = <STM32F1_PINMUX('A', 8, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_pwm_pa9: tim1_ch2_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_pwm_out_pa9: tim1_ch2_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap1_pwm_pa9: tim1_ch2_remap1_pwm_pa9 {
+			/omit-if-no-ref/ tim1_ch2_remap1_pwm_out_pa9: tim1_ch2_remap1_pwm_out_pa9 {
 				pinmux = <STM32F1_PINMUX('A', 9, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_pwm_pa10: tim1_ch3_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_pwm_out_pa10: tim1_ch3_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap1_pwm_pa10: tim1_ch3_remap1_pwm_pa10 {
+			/omit-if-no-ref/ tim1_ch3_remap1_pwm_out_pa10: tim1_ch3_remap1_pwm_out_pa10 {
 				pinmux = <STM32F1_PINMUX('A', 10, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_pwm_pa11: tim1_ch4_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_pwm_out_pa11: tim1_ch4_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap1_pwm_pa11: tim1_ch4_remap1_pwm_pa11 {
+			/omit-if-no-ref/ tim1_ch4_remap1_pwm_out_pa11: tim1_ch4_remap1_pwm_out_pa11 {
 				pinmux = <STM32F1_PINMUX('A', 11, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_pb0: tim1_ch2n_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim1_ch2n_remap1_pwm_out_pb0: tim1_ch2n_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_pb1: tim1_ch3n_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim1_ch3n_remap1_pwm_out_pb1: tim1_ch3n_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM1_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_pwm_pb13: tim1_ch1n_pwm_pb13 {
+			/omit-if-no-ref/ tim1_ch1n_pwm_out_pb13: tim1_ch1n_pwm_out_pb13 {
 				pinmux = <STM32F1_PINMUX('B', 13, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_pwm_pb14: tim1_ch2n_pwm_pb14 {
+			/omit-if-no-ref/ tim1_ch2n_pwm_out_pb14: tim1_ch2n_pwm_out_pb14 {
 				pinmux = <STM32F1_PINMUX('B', 14, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_pwm_pb15: tim1_ch3n_pwm_pb15 {
+			/omit-if-no-ref/ tim1_ch3n_pwm_out_pb15: tim1_ch3n_pwm_out_pb15 {
 				pinmux = <STM32F1_PINMUX('B', 15, ALTERNATE, TIM1_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_pe8: tim1_ch1n_remap2_pwm_pe8 {
+			/omit-if-no-ref/ tim1_ch1n_remap2_pwm_out_pe8: tim1_ch1n_remap2_pwm_out_pe8 {
 				pinmux = <STM32F1_PINMUX('E', 8, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch1_remap2_pwm_pe9: tim1_ch1_remap2_pwm_pe9 {
+			/omit-if-no-ref/ tim1_ch1_remap2_pwm_out_pe9: tim1_ch1_remap2_pwm_out_pe9 {
 				pinmux = <STM32F1_PINMUX('E', 9, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_pe10: tim1_ch2n_remap2_pwm_pe10 {
+			/omit-if-no-ref/ tim1_ch2n_remap2_pwm_out_pe10: tim1_ch2n_remap2_pwm_out_pe10 {
 				pinmux = <STM32F1_PINMUX('E', 10, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch2_remap2_pwm_pe11: tim1_ch2_remap2_pwm_pe11 {
+			/omit-if-no-ref/ tim1_ch2_remap2_pwm_out_pe11: tim1_ch2_remap2_pwm_out_pe11 {
 				pinmux = <STM32F1_PINMUX('E', 11, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_pe12: tim1_ch3n_remap2_pwm_pe12 {
+			/omit-if-no-ref/ tim1_ch3n_remap2_pwm_out_pe12: tim1_ch3n_remap2_pwm_out_pe12 {
 				pinmux = <STM32F1_PINMUX('E', 12, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch3_remap2_pwm_pe13: tim1_ch3_remap2_pwm_pe13 {
+			/omit-if-no-ref/ tim1_ch3_remap2_pwm_out_pe13: tim1_ch3_remap2_pwm_out_pe13 {
 				pinmux = <STM32F1_PINMUX('E', 13, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim1_ch4_remap2_pwm_pe14: tim1_ch4_remap2_pwm_pe14 {
+			/omit-if-no-ref/ tim1_ch4_remap2_pwm_out_pe14: tim1_ch4_remap2_pwm_out_pe14 {
 				pinmux = <STM32F1_PINMUX('E', 14, ALTERNATE, TIM1_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_pwm_pa0: tim2_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_pwm_out_pa0: tim2_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap2_pwm_pa0: tim2_ch1_remap2_pwm_pa0 {
+			/omit-if-no-ref/ tim2_ch1_remap2_pwm_out_pa0: tim2_ch1_remap2_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_pwm_pa1: tim2_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_pwm_out_pa1: tim2_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap2_pwm_pa1: tim2_ch2_remap2_pwm_pa1 {
+			/omit-if-no-ref/ tim2_ch2_remap2_pwm_out_pa1: tim2_ch2_remap2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_pwm_pa2: tim2_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_pwm_out_pa2: tim2_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap1_pwm_pa2: tim2_ch3_remap1_pwm_pa2 {
+			/omit-if-no-ref/ tim2_ch3_remap1_pwm_out_pa2: tim2_ch3_remap1_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_pwm_pa3: tim2_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_pwm_out_pa3: tim2_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap1_pwm_pa3: tim2_ch4_remap1_pwm_pa3 {
+			/omit-if-no-ref/ tim2_ch4_remap1_pwm_out_pa3: tim2_ch4_remap1_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap1_pwm_pa15: tim2_ch1_remap1_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap1_pwm_out_pa15: tim2_ch1_remap1_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch1_remap3_pwm_pa15: tim2_ch1_remap3_pwm_pa15 {
+			/omit-if-no-ref/ tim2_ch1_remap3_pwm_out_pa15: tim2_ch1_remap3_pwm_out_pa15 {
 				pinmux = <STM32F1_PINMUX('A', 15, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap1_pwm_pb3: tim2_ch2_remap1_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap1_pwm_out_pb3: tim2_ch2_remap1_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch2_remap3_pwm_pb3: tim2_ch2_remap3_pwm_pb3 {
+			/omit-if-no-ref/ tim2_ch2_remap3_pwm_out_pb3: tim2_ch2_remap3_pwm_out_pb3 {
 				pinmux = <STM32F1_PINMUX('B', 3, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap2_pwm_pb10: tim2_ch3_remap2_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap2_pwm_out_pb10: tim2_ch3_remap2_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch3_remap3_pwm_pb10: tim2_ch3_remap3_pwm_pb10 {
+			/omit-if-no-ref/ tim2_ch3_remap3_pwm_out_pb10: tim2_ch3_remap3_pwm_out_pb10 {
 				pinmux = <STM32F1_PINMUX('B', 10, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap2_pwm_pb11: tim2_ch4_remap2_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap2_pwm_out_pb11: tim2_ch4_remap2_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim2_ch4_remap3_pwm_pb11: tim2_ch4_remap3_pwm_pb11 {
+			/omit-if-no-ref/ tim2_ch4_remap3_pwm_out_pb11: tim2_ch4_remap3_pwm_out_pb11 {
 				pinmux = <STM32F1_PINMUX('B', 11, ALTERNATE, TIM2_REMAP3)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_pwm_pa6: tim3_ch1_pwm_pa6 {
+			/omit-if-no-ref/ tim3_ch1_pwm_out_pa6: tim3_ch1_pwm_out_pa6 {
 				pinmux = <STM32F1_PINMUX('A', 6, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_pwm_pa7: tim3_ch2_pwm_pa7 {
+			/omit-if-no-ref/ tim3_ch2_pwm_out_pa7: tim3_ch2_pwm_out_pa7 {
 				pinmux = <STM32F1_PINMUX('A', 7, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_pwm_pb0: tim3_ch3_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_pwm_out_pb0: tim3_ch3_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap1_pwm_pb0: tim3_ch3_remap1_pwm_pb0 {
+			/omit-if-no-ref/ tim3_ch3_remap1_pwm_out_pb0: tim3_ch3_remap1_pwm_out_pb0 {
 				pinmux = <STM32F1_PINMUX('B', 0, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_pwm_pb1: tim3_ch4_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_pwm_out_pb1: tim3_ch4_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap1_pwm_pb1: tim3_ch4_remap1_pwm_pb1 {
+			/omit-if-no-ref/ tim3_ch4_remap1_pwm_out_pb1: tim3_ch4_remap1_pwm_out_pb1 {
 				pinmux = <STM32F1_PINMUX('B', 1, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap1_pwm_pb4: tim3_ch1_remap1_pwm_pb4 {
+			/omit-if-no-ref/ tim3_ch1_remap1_pwm_out_pb4: tim3_ch1_remap1_pwm_out_pb4 {
 				pinmux = <STM32F1_PINMUX('B', 4, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap1_pwm_pb5: tim3_ch2_remap1_pwm_pb5 {
+			/omit-if-no-ref/ tim3_ch2_remap1_pwm_out_pb5: tim3_ch2_remap1_pwm_out_pb5 {
 				pinmux = <STM32F1_PINMUX('B', 5, ALTERNATE, TIM3_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch1_remap2_pwm_pc6: tim3_ch1_remap2_pwm_pc6 {
+			/omit-if-no-ref/ tim3_ch1_remap2_pwm_out_pc6: tim3_ch1_remap2_pwm_out_pc6 {
 				pinmux = <STM32F1_PINMUX('C', 6, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch2_remap2_pwm_pc7: tim3_ch2_remap2_pwm_pc7 {
+			/omit-if-no-ref/ tim3_ch2_remap2_pwm_out_pc7: tim3_ch2_remap2_pwm_out_pc7 {
 				pinmux = <STM32F1_PINMUX('C', 7, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch3_remap2_pwm_pc8: tim3_ch3_remap2_pwm_pc8 {
+			/omit-if-no-ref/ tim3_ch3_remap2_pwm_out_pc8: tim3_ch3_remap2_pwm_out_pc8 {
 				pinmux = <STM32F1_PINMUX('C', 8, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim3_ch4_remap2_pwm_pc9: tim3_ch4_remap2_pwm_pc9 {
+			/omit-if-no-ref/ tim3_ch4_remap2_pwm_out_pc9: tim3_ch4_remap2_pwm_out_pc9 {
 				pinmux = <STM32F1_PINMUX('C', 9, ALTERNATE, TIM3_REMAP2)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_pwm_pb6: tim4_ch1_pwm_pb6 {
+			/omit-if-no-ref/ tim4_ch1_pwm_out_pb6: tim4_ch1_pwm_out_pb6 {
 				pinmux = <STM32F1_PINMUX('B', 6, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_pwm_pb7: tim4_ch2_pwm_pb7 {
+			/omit-if-no-ref/ tim4_ch2_pwm_out_pb7: tim4_ch2_pwm_out_pb7 {
 				pinmux = <STM32F1_PINMUX('B', 7, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_pwm_pb8: tim4_ch3_pwm_pb8 {
+			/omit-if-no-ref/ tim4_ch3_pwm_out_pb8: tim4_ch3_pwm_out_pb8 {
 				pinmux = <STM32F1_PINMUX('B', 8, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_pwm_pb9: tim4_ch4_pwm_pb9 {
+			/omit-if-no-ref/ tim4_ch4_pwm_out_pb9: tim4_ch4_pwm_out_pb9 {
 				pinmux = <STM32F1_PINMUX('B', 9, ALTERNATE, TIM4_REMAP0)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch1_remap1_pwm_pd12: tim4_ch1_remap1_pwm_pd12 {
+			/omit-if-no-ref/ tim4_ch1_remap1_pwm_out_pd12: tim4_ch1_remap1_pwm_out_pd12 {
 				pinmux = <STM32F1_PINMUX('D', 12, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch2_remap1_pwm_pd13: tim4_ch2_remap1_pwm_pd13 {
+			/omit-if-no-ref/ tim4_ch2_remap1_pwm_out_pd13: tim4_ch2_remap1_pwm_out_pd13 {
 				pinmux = <STM32F1_PINMUX('D', 13, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch3_remap1_pwm_pd14: tim4_ch3_remap1_pwm_pd14 {
+			/omit-if-no-ref/ tim4_ch3_remap1_pwm_out_pd14: tim4_ch3_remap1_pwm_out_pd14 {
 				pinmux = <STM32F1_PINMUX('D', 14, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim4_ch4_remap1_pwm_pd15: tim4_ch4_remap1_pwm_pd15 {
+			/omit-if-no-ref/ tim4_ch4_remap1_pwm_out_pd15: tim4_ch4_remap1_pwm_out_pd15 {
 				pinmux = <STM32F1_PINMUX('D', 15, ALTERNATE, TIM4_REMAP1)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch1_pwm_pa0: tim5_ch1_pwm_pa0 {
+			/omit-if-no-ref/ tim5_ch1_pwm_out_pa0: tim5_ch1_pwm_out_pa0 {
 				pinmux = <STM32F1_PINMUX('A', 0, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch2_pwm_pa1: tim5_ch2_pwm_pa1 {
+			/omit-if-no-ref/ tim5_ch2_pwm_out_pa1: tim5_ch2_pwm_out_pa1 {
 				pinmux = <STM32F1_PINMUX('A', 1, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch3_pwm_pa2: tim5_ch3_pwm_pa2 {
+			/omit-if-no-ref/ tim5_ch3_pwm_out_pa2: tim5_ch3_pwm_out_pa2 {
 				pinmux = <STM32F1_PINMUX('A', 2, ALTERNATE, NO_REMAP)>;
 			};
 
-			/omit-if-no-ref/ tim5_ch4_pwm_pa3: tim5_ch4_pwm_pa3 {
+			/omit-if-no-ref/ tim5_ch4_pwm_out_pa3: tim5_ch4_pwm_out_pa3 {
 				pinmux = <STM32F1_PINMUX('A', 3, ALTERNATE, NO_REMAP)>;
 			};
 

--- a/scripts/genpinctrl/stm32f1-pinctrl-config.yaml
+++ b/scripts/genpinctrl/stm32f1-pinctrl-config.yaml
@@ -208,10 +208,15 @@
   mode: input
   variant: slave
 
-- name: TIM_CH_PWM / TIM_CHN_PWM
+- name: TIM_CH_PWM_OUT / TIM_CHN_PWM_OUT
   match: "^TIM\\d+_CH\\d+N?$"
   mode: alternate
-  variant: pwm
+  variant: pwm_out
+
+- name: TIM_CH_PWM_IN / TIM_CHN_PWM_IN
+  match: "^TIM\\d+_CH\\d+N?$"
+  mode: input
+  variant: pwm_in
 
 - name: UART_CTS / USART_CTS
   match: "^US?ART\\d+_CTS$"


### PR DESCRIPTION
On STM32F1xx, pins used for PWM input must be configured as input, and not as alternate.
This PR adds all PWM inputs, in addition to the already present (though renamed) PWM outputs.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/53584