### PR TITLE
dts: st: Regenerate all ST dtsi files

### DIFF
--- a/dts/st/f0/stm32f031c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f031c(4-6)tx-pinctrl.dtsi
@@ -286,6 +286,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f031e6yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f031e6yx-pinctrl.dtsi
@@ -169,6 +169,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f031f(4-6)px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f031f(4-6)px-pinctrl.dtsi
@@ -133,6 +133,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f031g(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f031g(4-6)ux-pinctrl.dtsi
@@ -186,6 +186,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f031k(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f031k(4-6)ux-pinctrl.dtsi
@@ -208,6 +208,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f031k6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f031k6tx-pinctrl.dtsi
@@ -194,6 +194,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f038c6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f038c6tx-pinctrl.dtsi
@@ -282,6 +282,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f038e6yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f038e6yx-pinctrl.dtsi
@@ -169,6 +169,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f038f6px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f038f6px-pinctrl.dtsi
@@ -125,6 +125,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f038g6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f038g6ux-pinctrl.dtsi
@@ -178,6 +178,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f038k6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f038k6ux-pinctrl.dtsi
@@ -204,6 +204,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f042c(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042c(4-6)tx-pinctrl.dtsi
@@ -328,6 +328,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f042c(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042c(4-6)ux-pinctrl.dtsi
@@ -328,6 +328,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f042f4px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042f4px-pinctrl.dtsi
@@ -187,6 +187,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f042f6px-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042f6px-pinctrl.dtsi
@@ -187,6 +187,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f042g(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042g(4-6)ux-pinctrl.dtsi
@@ -236,6 +236,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f042k(4-6)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042k(4-6)tx-pinctrl.dtsi
@@ -246,6 +246,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f042k(4-6)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042k(4-6)ux-pinctrl.dtsi
@@ -254,6 +254,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f042t6yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f042t6yx-pinctrl.dtsi
@@ -262,6 +262,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f048c6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f048c6ux-pinctrl.dtsi
@@ -302,6 +302,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f048g6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f048g6ux-pinctrl.dtsi
@@ -210,6 +210,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f048t6yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f048t6yx-pinctrl.dtsi
@@ -240,6 +240,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f051c4tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051c4tx-pinctrl.dtsi
@@ -256,6 +256,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f051c4ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051c4ux-pinctrl.dtsi
@@ -256,6 +256,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f051c6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051c6tx-pinctrl.dtsi
@@ -256,6 +256,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f051c6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051c6ux-pinctrl.dtsi
@@ -256,6 +256,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f051c8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051c8tx-pinctrl.dtsi
@@ -280,6 +280,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f051c8ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051c8ux-pinctrl.dtsi
@@ -280,6 +280,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f051k4tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051k4tx-pinctrl.dtsi
@@ -188,6 +188,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f051k4ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051k4ux-pinctrl.dtsi
@@ -202,6 +202,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f051k6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051k6tx-pinctrl.dtsi
@@ -188,6 +188,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f051k6ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051k6ux-pinctrl.dtsi
@@ -202,6 +202,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f051k8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051k8tx-pinctrl.dtsi
@@ -188,6 +188,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f051k8ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051k8ux-pinctrl.dtsi
@@ -202,6 +202,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f051r4tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051r4tx-pinctrl.dtsi
@@ -344,6 +344,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f051r6tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051r6tx-pinctrl.dtsi
@@ -344,6 +344,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f051r8hx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051r8hx-pinctrl.dtsi
@@ -368,6 +368,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f051r8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051r8tx-pinctrl.dtsi
@@ -368,6 +368,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f051t8yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f051t8yx-pinctrl.dtsi
@@ -204,6 +204,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f058c8ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f058c8ux-pinctrl.dtsi
@@ -276,6 +276,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f058r8hx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f058r8hx-pinctrl.dtsi
@@ -364,6 +364,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f058r8tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f058r8tx-pinctrl.dtsi
@@ -364,6 +364,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f058t8yx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f058t8yx-pinctrl.dtsi
@@ -200,6 +200,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f071c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f071c(8-b)tx-pinctrl.dtsi
@@ -286,6 +286,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f071c(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f071c(8-b)ux-pinctrl.dtsi
@@ -286,6 +286,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f071cbyx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f071cbyx-pinctrl.dtsi
@@ -286,6 +286,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f071rbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f071rbtx-pinctrl.dtsi
@@ -366,6 +366,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f071v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f071v(8-b)hx-pinctrl.dtsi
@@ -520,6 +520,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pe14: i2s1_mck_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f071v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f071v(8-b)tx-pinctrl.dtsi
@@ -520,6 +520,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pe14: i2s1_mck_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f072c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072c(8-b)tx-pinctrl.dtsi
@@ -308,6 +308,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f072c(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072c(8-b)ux-pinctrl.dtsi
@@ -308,6 +308,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f072cbyx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072cbyx-pinctrl.dtsi
@@ -308,6 +308,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f072r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072r(8-b)tx-pinctrl.dtsi
@@ -388,6 +388,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f072rbhx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072rbhx-pinctrl.dtsi
@@ -388,6 +388,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f072rbix-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072rbix-pinctrl.dtsi
@@ -388,6 +388,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f072v(8-b)hx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072v(8-b)hx-pinctrl.dtsi
@@ -551,6 +551,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pe14: i2s1_mck_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f072v(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f072v(8-b)tx-pinctrl.dtsi
@@ -551,6 +551,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pe14: i2s1_mck_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f078cbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078cbtx-pinctrl.dtsi
@@ -282,6 +282,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f078cbux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078cbux-pinctrl.dtsi
@@ -282,6 +282,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f078cbyx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078cbyx-pinctrl.dtsi
@@ -282,6 +282,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f078rbhx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078rbhx-pinctrl.dtsi
@@ -362,6 +362,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f078rbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078rbtx-pinctrl.dtsi
@@ -362,6 +362,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f078vbhx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078vbhx-pinctrl.dtsi
@@ -516,6 +516,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pe14: i2s1_mck_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f078vbtx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f078vbtx-pinctrl.dtsi
@@ -516,6 +516,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pe14: i2s1_mck_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f091c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091c(b-c)tx-pinctrl.dtsi
@@ -348,6 +348,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f091c(b-c)ux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091c(b-c)ux-pinctrl.dtsi
@@ -348,6 +348,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f091r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091r(b-c)tx-pinctrl.dtsi
@@ -428,6 +428,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f091rchx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091rchx-pinctrl.dtsi
@@ -428,6 +428,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f091rcyx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091rcyx-pinctrl.dtsi
@@ -428,6 +428,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f091v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091v(b-c)tx-pinctrl.dtsi
@@ -591,6 +591,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pe14: i2s1_mck_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f091vchx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f091vchx-pinctrl.dtsi
@@ -591,6 +591,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pe14: i2s1_mck_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f098cctx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098cctx-pinctrl.dtsi
@@ -344,6 +344,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f098ccux-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098ccux-pinctrl.dtsi
@@ -344,6 +344,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f098rchx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098rchx-pinctrl.dtsi
@@ -424,6 +424,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f098rctx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098rctx-pinctrl.dtsi
@@ -424,6 +424,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f098rcyx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098rcyx-pinctrl.dtsi
@@ -424,6 +424,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f098vchx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098vchx-pinctrl.dtsi
@@ -587,6 +587,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pe14: i2s1_mck_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f0/stm32f098vctx-pinctrl.dtsi
+++ b/dts/st/f0/stm32f098vctx-pinctrl.dtsi
@@ -587,6 +587,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pe14: i2s1_mck_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f2/stm32f205r(b-c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205r(b-c-e-f-g)tx-pinctrl.dtsi
@@ -480,6 +480,18 @@
 				drive-open-drain;
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f2/stm32f205r(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205r(e-g)yx-pinctrl.dtsi
@@ -480,6 +480,18 @@
 				drive-open-drain;
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f2/stm32f205rgex-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205rgex-pinctrl.dtsi
@@ -480,6 +480,18 @@
 				drive-open-drain;
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f2/stm32f205v(b-c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205v(b-c-e-f-g)tx-pinctrl.dtsi
@@ -613,6 +613,18 @@
 				drive-open-drain;
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f2/stm32f205z(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f205z(c-e-f-g)tx-pinctrl.dtsi
@@ -785,6 +785,18 @@
 				drive-open-drain;
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f2/stm32f207i(c-e-f-g)hx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207i(c-e-f-g)hx-pinctrl.dtsi
@@ -1112,6 +1112,18 @@
 				drive-open-drain;
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f2/stm32f207i(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207i(c-e-f-g)tx-pinctrl.dtsi
@@ -1112,6 +1112,18 @@
 				drive-open-drain;
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f2/stm32f207v(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207v(c-e-f-g)tx-pinctrl.dtsi
@@ -758,6 +758,18 @@
 				drive-open-drain;
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f2/stm32f207z(c-e-f-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f207z(c-e-f-g)tx-pinctrl.dtsi
@@ -950,6 +950,18 @@
 				drive-open-drain;
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f2/stm32f215r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f215r(e-g)tx-pinctrl.dtsi
@@ -480,6 +480,18 @@
 				drive-open-drain;
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f2/stm32f215v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f215v(e-g)tx-pinctrl.dtsi
@@ -613,6 +613,18 @@
 				drive-open-drain;
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f2/stm32f215z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f215z(e-g)tx-pinctrl.dtsi
@@ -785,6 +785,18 @@
 				drive-open-drain;
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f2/stm32f217i(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217i(e-g)hx-pinctrl.dtsi
@@ -1112,6 +1112,18 @@
 				drive-open-drain;
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f2/stm32f217i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217i(e-g)tx-pinctrl.dtsi
@@ -1112,6 +1112,18 @@
 				drive-open-drain;
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f2/stm32f217v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217v(e-g)tx-pinctrl.dtsi
@@ -758,6 +758,18 @@
 				drive-open-drain;
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f2/stm32f217z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f2/stm32f217z(e-g)tx-pinctrl.dtsi
@@ -950,6 +950,18 @@
 				drive-open-drain;
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f3/stm32f301c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f301c(6-8)tx-pinctrl.dtsi
@@ -305,6 +305,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/f3/stm32f301c8yx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f301c8yx-pinctrl.dtsi
@@ -305,6 +305,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/f3/stm32f301k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f301k(6-8)tx-pinctrl.dtsi
@@ -232,6 +232,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/f3/stm32f301k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/f3/stm32f301k(6-8)ux-pinctrl.dtsi
@@ -224,6 +224,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/f3/stm32f301r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f301r(6-8)tx-pinctrl.dtsi
@@ -388,6 +388,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/f3/stm32f302c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302c(6-8)tx-pinctrl.dtsi
@@ -327,6 +327,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/f3/stm32f302c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302c(b-c)tx-pinctrl.dtsi
@@ -302,6 +302,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f3/stm32f302c8yx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302c8yx-pinctrl.dtsi
@@ -327,6 +327,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/f3/stm32f302k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302k(6-8)ux-pinctrl.dtsi
@@ -237,6 +237,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/f3/stm32f302r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302r(6-8)tx-pinctrl.dtsi
@@ -410,6 +410,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/f3/stm32f302r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302r(b-c)tx-pinctrl.dtsi
@@ -411,6 +411,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f3/stm32f302r(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302r(d-e)tx-pinctrl.dtsi
@@ -434,6 +434,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/f3/stm32f302v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302v(b-c)tx-pinctrl.dtsi
@@ -574,6 +574,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f3/stm32f302v(d-e)hx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302v(d-e)hx-pinctrl.dtsi
@@ -797,6 +797,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/f3/stm32f302v(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302v(d-e)tx-pinctrl.dtsi
@@ -797,6 +797,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/f3/stm32f302vcyx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302vcyx-pinctrl.dtsi
@@ -534,6 +534,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f3/stm32f302z(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302z(d-e)tx-pinctrl.dtsi
@@ -1037,6 +1037,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/f3/stm32f303c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303c(b-c)tx-pinctrl.dtsi
@@ -330,6 +330,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f3/stm32f303r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303r(b-c)tx-pinctrl.dtsi
@@ -439,6 +439,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f3/stm32f303r(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303r(d-e)tx-pinctrl.dtsi
@@ -462,6 +462,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/f3/stm32f303v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303v(b-c)tx-pinctrl.dtsi
@@ -690,6 +690,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f3/stm32f303v(d-e)hx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303v(d-e)hx-pinctrl.dtsi
@@ -913,6 +913,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/f3/stm32f303v(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303v(d-e)tx-pinctrl.dtsi
@@ -913,6 +913,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/f3/stm32f303vcyx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303vcyx-pinctrl.dtsi
@@ -626,6 +626,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f3/stm32f303veyx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303veyx-pinctrl.dtsi
@@ -657,6 +657,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/f3/stm32f303z(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303z(d-e)tx-pinctrl.dtsi
@@ -1153,6 +1153,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/f3/stm32f318c8tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f318c8tx-pinctrl.dtsi
@@ -301,6 +301,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/f3/stm32f318c8yx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f318c8yx-pinctrl.dtsi
@@ -301,6 +301,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/f3/stm32f318k8ux-pinctrl.dtsi
+++ b/dts/st/f3/stm32f318k8ux-pinctrl.dtsi
@@ -214,6 +214,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/f3/stm32f358cctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f358cctx-pinctrl.dtsi
@@ -322,6 +322,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f3/stm32f358rctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f358rctx-pinctrl.dtsi
@@ -431,6 +431,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f3/stm32f358vctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f358vctx-pinctrl.dtsi
@@ -682,6 +682,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f3/stm32f373c(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f373c(8-b-c)tx-pinctrl.dtsi
@@ -352,6 +352,43 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa13: i2s1_mck_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa2: i2s3_mck_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pb4: i2s3_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pb0: i2s1_sd_pb0 {

--- a/dts/st/f3/stm32f373r(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f373r(8-b-c)tx-pinctrl.dtsi
@@ -450,6 +450,58 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa13: i2s1_mck_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pc8: i2s1_mck_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa2: i2s3_mck_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pb4: i2s3_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc11: i2s3_mck_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f3/stm32f373v(8-b-c)hx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f373v(8-b-c)hx-pinctrl.dtsi
@@ -591,6 +591,63 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa13: i2s1_mck_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pc8: i2s1_mck_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa2: i2s3_mck_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pb4: i2s3_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc11: i2s3_mck_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f3/stm32f373v(8-b-c)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f373v(8-b-c)tx-pinctrl.dtsi
@@ -591,6 +591,63 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa13: i2s1_mck_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pc8: i2s1_mck_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa2: i2s3_mck_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pb4: i2s3_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc11: i2s3_mck_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f3/stm32f378cctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378cctx-pinctrl.dtsi
@@ -348,6 +348,43 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa13: i2s1_mck_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa2: i2s3_mck_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pb4: i2s3_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pb0: i2s1_sd_pb0 {

--- a/dts/st/f3/stm32f378rctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378rctx-pinctrl.dtsi
@@ -446,6 +446,58 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa13: i2s1_mck_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pc8: i2s1_mck_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa2: i2s3_mck_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pb4: i2s3_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc11: i2s3_mck_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f3/stm32f378rcyx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378rcyx-pinctrl.dtsi
@@ -446,6 +446,58 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa13: i2s1_mck_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pc8: i2s1_mck_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa2: i2s3_mck_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pb4: i2s3_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc11: i2s3_mck_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f3/stm32f378vchx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378vchx-pinctrl.dtsi
@@ -587,6 +587,63 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa13: i2s1_mck_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pc8: i2s1_mck_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa2: i2s3_mck_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pb4: i2s3_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc11: i2s3_mck_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f3/stm32f378vctx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f378vctx-pinctrl.dtsi
@@ -587,6 +587,63 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa13: i2s1_mck_pa13 {
+				pinmux = <STM32_PINMUX('A', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pc8: i2s1_mck_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa2: i2s3_mck_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pb4: i2s3_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc11: i2s3_mck_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f3/stm32f398vetx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f398vetx-pinctrl.dtsi
@@ -905,6 +905,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/f4/stm32f401r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401r(b-c)tx-pinctrl.dtsi
@@ -358,6 +358,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f401r(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401r(d-e)tx-pinctrl.dtsi
@@ -358,6 +358,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f401v(b-c)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401v(b-c)hx-pinctrl.dtsi
@@ -493,6 +493,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f401v(b-c)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401v(b-c)tx-pinctrl.dtsi
@@ -487,6 +487,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f401v(d-e)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401v(d-e)hx-pinctrl.dtsi
@@ -493,6 +493,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f401v(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f401v(d-e)tx-pinctrl.dtsi
@@ -487,6 +487,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f405o(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405o(e-g)yx-pinctrl.dtsi
@@ -572,6 +572,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f405rgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405rgtx-pinctrl.dtsi
@@ -502,6 +502,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f405vgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405vgtx-pinctrl.dtsi
@@ -635,6 +635,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f405zgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f405zgtx-pinctrl.dtsi
@@ -807,6 +807,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f407i(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407i(e-g)hx-pinctrl.dtsi
@@ -1139,6 +1139,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f407i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407i(e-g)tx-pinctrl.dtsi
@@ -1139,6 +1139,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f407v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407v(e-g)tx-pinctrl.dtsi
@@ -780,6 +780,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f407z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f407z(e-g)tx-pinctrl.dtsi
@@ -972,6 +972,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f410c(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f410c(8-b)tx-pinctrl.dtsi
@@ -261,6 +261,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pb10: i2s1_mck_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa6: i2s2_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f4/stm32f410c(8-b)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f410c(8-b)ux-pinctrl.dtsi
@@ -277,6 +277,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pb10: i2s1_mck_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa6: i2s2_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f4/stm32f410r(8-b)ix-pinctrl.dtsi
+++ b/dts/st/f4/stm32f410r(8-b)ix-pinctrl.dtsi
@@ -368,6 +368,33 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pb10: i2s1_mck_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pc7: i2s1_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa6: i2s2_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f4/stm32f410r(8-b)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f410r(8-b)tx-pinctrl.dtsi
@@ -368,6 +368,33 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pb10: i2s1_mck_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pc7: i2s1_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa6: i2s2_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f4/stm32f410t(8-b)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f410t(8-b)yx-pinctrl.dtsi
@@ -174,6 +174,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pb10: i2s1_mck_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pb5: i2s1_sd_pb5 {

--- a/dts/st/f4/stm32f411c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411c(c-e)ux-pinctrl.dtsi
@@ -304,6 +304,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa6: i2s2_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pb10: i2s3_mck_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f4/stm32f411c(c-e)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411c(c-e)yx-pinctrl.dtsi
@@ -304,6 +304,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa6: i2s2_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pb10: i2s3_mck_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f4/stm32f411r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411r(c-e)tx-pinctrl.dtsi
@@ -400,6 +400,33 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa6: i2s2_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pb10: i2s3_mck_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f4/stm32f411v(c-e)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411v(c-e)hx-pinctrl.dtsi
@@ -555,6 +555,33 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa6: i2s2_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pb10: i2s3_mck_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f4/stm32f411v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f411v(c-e)tx-pinctrl.dtsi
@@ -549,6 +549,33 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa6: i2s2_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pb10: i2s3_mck_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f4/stm32f412c(e-g)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412c(e-g)ux-pinctrl.dtsi
@@ -344,6 +344,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa6: i2s2_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pb10: i2s3_mck_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f4/stm32f412r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412r(e-g)tx-pinctrl.dtsi
@@ -440,6 +440,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa6: i2s2_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pb10: i2s3_mck_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f4/stm32f412r(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412r(e-g)yx-pinctrl.dtsi
@@ -440,6 +440,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa6: i2s2_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pb10: i2s3_mck_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f4/stm32f412r(e-g)yxp-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412r(e-g)yxp-pinctrl.dtsi
@@ -440,6 +440,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa6: i2s2_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pb10: i2s3_mck_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f4/stm32f412v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412v(e-g)hx-pinctrl.dtsi
@@ -604,6 +604,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa6: i2s2_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pb10: i2s3_mck_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f4/stm32f412v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412v(e-g)tx-pinctrl.dtsi
@@ -598,6 +598,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa6: i2s2_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pb10: i2s3_mck_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f4/stm32f412z(e-g)jx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412z(e-g)jx-pinctrl.dtsi
@@ -766,6 +766,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa6: i2s2_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pb10: i2s3_mck_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f4/stm32f412z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412z(e-g)tx-pinctrl.dtsi
@@ -766,6 +766,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa6: i2s2_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pb10: i2s3_mck_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f4/stm32f413c(g-h)ux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413c(g-h)ux-pinctrl.dtsi
@@ -377,6 +377,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa6: i2s2_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pb10: i2s3_mck_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f4/stm32f413m(g-h)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413m(g-h)yx-pinctrl.dtsi
@@ -528,6 +528,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa6: i2s2_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pb10: i2s3_mck_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f4/stm32f413r(g-h)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413r(g-h)tx-pinctrl.dtsi
@@ -473,6 +473,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa6: i2s2_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pb10: i2s3_mck_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f4/stm32f413v(g-h)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413v(g-h)hx-pinctrl.dtsi
@@ -637,6 +637,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa6: i2s2_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pb10: i2s3_mck_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f4/stm32f413v(g-h)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413v(g-h)tx-pinctrl.dtsi
@@ -631,6 +631,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa6: i2s2_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pb10: i2s3_mck_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f4/stm32f413z(g-h)jx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413z(g-h)jx-pinctrl.dtsi
@@ -799,6 +799,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa6: i2s2_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pb10: i2s3_mck_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f4/stm32f413z(g-h)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413z(g-h)tx-pinctrl.dtsi
@@ -799,6 +799,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa6: i2s2_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pb10: i2s3_mck_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f4/stm32f415ogyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415ogyx-pinctrl.dtsi
@@ -572,6 +572,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f415rgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415rgtx-pinctrl.dtsi
@@ -502,6 +502,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f415vgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415vgtx-pinctrl.dtsi
@@ -635,6 +635,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f415zgtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f415zgtx-pinctrl.dtsi
@@ -807,6 +807,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f417i(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417i(e-g)hx-pinctrl.dtsi
@@ -1139,6 +1139,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f417i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417i(e-g)tx-pinctrl.dtsi
@@ -1139,6 +1139,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f417v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417v(e-g)tx-pinctrl.dtsi
@@ -780,6 +780,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f417z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f417z(e-g)tx-pinctrl.dtsi
@@ -972,6 +972,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f423chux-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423chux-pinctrl.dtsi
@@ -377,6 +377,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa6: i2s2_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pb10: i2s3_mck_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f4/stm32f423mhyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423mhyx-pinctrl.dtsi
@@ -528,6 +528,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa6: i2s2_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pb10: i2s3_mck_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f4/stm32f423rhtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423rhtx-pinctrl.dtsi
@@ -473,6 +473,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa6: i2s2_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pb10: i2s3_mck_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f4/stm32f423vhhx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423vhhx-pinctrl.dtsi
@@ -637,6 +637,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa6: i2s2_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pb10: i2s3_mck_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f4/stm32f423vhtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423vhtx-pinctrl.dtsi
@@ -631,6 +631,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa6: i2s2_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pb10: i2s3_mck_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f4/stm32f423zhjx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423zhjx-pinctrl.dtsi
@@ -799,6 +799,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa6: i2s2_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pb10: i2s3_mck_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f4/stm32f423zhtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423zhtx-pinctrl.dtsi
@@ -799,6 +799,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa6: i2s2_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pb10: i2s3_mck_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f4/stm32f427a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427a(g-i)hx-pinctrl.dtsi
@@ -1560,6 +1560,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f427i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427i(g-i)hx-pinctrl.dtsi
@@ -1650,6 +1650,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f427i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427i(g-i)tx-pinctrl.dtsi
@@ -1650,6 +1650,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f427v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427v(g-i)tx-pinctrl.dtsi
@@ -1009,6 +1009,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f427z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427z(g-i)tx-pinctrl.dtsi
@@ -1345,6 +1345,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f429a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429a(g-i)hx-pinctrl.dtsi
@@ -1560,6 +1560,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f429b(e-g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429b(e-g-i)tx-pinctrl.dtsi
@@ -1762,6 +1762,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f429i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429i(e-g)tx-pinctrl.dtsi
@@ -1650,6 +1650,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f429i(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429i(e-g-i)hx-pinctrl.dtsi
@@ -1650,6 +1650,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f429iitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429iitx-pinctrl.dtsi
@@ -1650,6 +1650,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f429n(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429n(e-g)hx-pinctrl.dtsi
@@ -1762,6 +1762,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f429nihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429nihx-pinctrl.dtsi
@@ -1762,6 +1762,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f429v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429v(e-g)tx-pinctrl.dtsi
@@ -979,6 +979,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f429vitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429vitx-pinctrl.dtsi
@@ -979,6 +979,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f429z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429z(e-g)tx-pinctrl.dtsi
@@ -1345,6 +1345,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f429zgyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429zgyx-pinctrl.dtsi
@@ -1345,6 +1345,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f429zitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429zitx-pinctrl.dtsi
@@ -1345,6 +1345,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f429ziyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429ziyx-pinctrl.dtsi
@@ -1345,6 +1345,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f437aihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437aihx-pinctrl.dtsi
@@ -1560,6 +1560,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f437i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437i(g-i)hx-pinctrl.dtsi
@@ -1650,6 +1650,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f437i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437i(g-i)tx-pinctrl.dtsi
@@ -1650,6 +1650,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f437v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437v(g-i)tx-pinctrl.dtsi
@@ -1009,6 +1009,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f437z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437z(g-i)tx-pinctrl.dtsi
@@ -1345,6 +1345,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f439aihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439aihx-pinctrl.dtsi
@@ -1560,6 +1560,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f439b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439b(g-i)tx-pinctrl.dtsi
@@ -1762,6 +1762,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f439i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439i(g-i)hx-pinctrl.dtsi
@@ -1650,6 +1650,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f439i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439i(g-i)tx-pinctrl.dtsi
@@ -1650,6 +1650,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f439n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439n(g-i)hx-pinctrl.dtsi
@@ -1762,6 +1762,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f439v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439v(g-i)tx-pinctrl.dtsi
@@ -979,6 +979,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f439z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439z(g-i)tx-pinctrl.dtsi
@@ -1345,6 +1345,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f439z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439z(g-i)yx-pinctrl.dtsi
@@ -1345,6 +1345,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f446m(c-e)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446m(c-e)yx-pinctrl.dtsi
@@ -571,6 +571,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa6: i2s2_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f4/stm32f446r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446r(c-e)tx-pinctrl.dtsi
@@ -530,6 +530,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa6: i2s2_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f4/stm32f446v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446v(c-e)tx-pinctrl.dtsi
@@ -910,6 +910,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa6: i2s2_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f4/stm32f446z(c-e)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)hx-pinctrl.dtsi
@@ -1236,6 +1236,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa6: i2s2_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f4/stm32f446z(c-e)jx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)jx-pinctrl.dtsi
@@ -1236,6 +1236,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa6: i2s2_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f4/stm32f446z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)tx-pinctrl.dtsi
@@ -1236,6 +1236,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa6: i2s2_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f4/stm32f469a(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469a(e-g-i)hx-pinctrl.dtsi
@@ -1337,6 +1337,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f469a(e-g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469a(e-g-i)yx-pinctrl.dtsi
@@ -1337,6 +1337,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f469b(e-g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469b(e-g-i)tx-pinctrl.dtsi
@@ -1755,6 +1755,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f469i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469i(e-g)tx-pinctrl.dtsi
@@ -1579,6 +1579,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f469i(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469i(e-g-i)hx-pinctrl.dtsi
@@ -1579,6 +1579,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f469iitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469iitx-pinctrl.dtsi
@@ -1579,6 +1579,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f469n(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469n(e-g)hx-pinctrl.dtsi
@@ -1755,6 +1755,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f469nihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469nihx-pinctrl.dtsi
@@ -1755,6 +1755,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f469v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469v(e-g)tx-pinctrl.dtsi
@@ -755,6 +755,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f469vitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469vitx-pinctrl.dtsi
@@ -755,6 +755,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f469z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469z(e-g)tx-pinctrl.dtsi
@@ -1137,6 +1137,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f469zitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469zitx-pinctrl.dtsi
@@ -1137,6 +1137,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f479a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479a(g-i)hx-pinctrl.dtsi
@@ -1337,6 +1337,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f479a(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479a(g-i)yx-pinctrl.dtsi
@@ -1337,6 +1337,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f479b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479b(g-i)tx-pinctrl.dtsi
@@ -1755,6 +1755,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f479i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479i(g-i)hx-pinctrl.dtsi
@@ -1579,6 +1579,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f479i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479i(g-i)tx-pinctrl.dtsi
@@ -1579,6 +1579,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f479n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479n(g-i)hx-pinctrl.dtsi
@@ -1755,6 +1755,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f479v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479v(g-i)tx-pinctrl.dtsi
@@ -755,6 +755,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f4/stm32f479z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479z(g-i)tx-pinctrl.dtsi
@@ -1137,6 +1137,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/f7/stm32f722i(c-e)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722i(c-e)kx-pinctrl.dtsi
@@ -1498,6 +1498,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f722i(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722i(c-e)tx-pinctrl.dtsi
@@ -1498,6 +1498,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f722r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722r(c-e)tx-pinctrl.dtsi
@@ -487,6 +487,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f722v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722v(c-e)tx-pinctrl.dtsi
@@ -879,6 +879,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f722z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722z(c-e)tx-pinctrl.dtsi
@@ -1213,6 +1213,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f723i(c-e)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723i(c-e)kx-pinctrl.dtsi
@@ -1484,6 +1484,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f723i(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723i(c-e)tx-pinctrl.dtsi
@@ -1484,6 +1484,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f723v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723v(c-e)tx-pinctrl.dtsi
@@ -849,6 +849,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f723v(c-e)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723v(c-e)yx-pinctrl.dtsi
@@ -849,6 +849,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f723z(c-e)ix-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723z(c-e)ix-pinctrl.dtsi
@@ -1199,6 +1199,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f723z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723z(c-e)tx-pinctrl.dtsi
@@ -1199,6 +1199,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f730i8kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730i8kx-pinctrl.dtsi
@@ -1484,6 +1484,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f730r8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730r8tx-pinctrl.dtsi
@@ -487,6 +487,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f730v8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730v8tx-pinctrl.dtsi
@@ -879,6 +879,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f730z8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730z8tx-pinctrl.dtsi
@@ -1199,6 +1199,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f732iekx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732iekx-pinctrl.dtsi
@@ -1498,6 +1498,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f732ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732ietx-pinctrl.dtsi
@@ -1498,6 +1498,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f732retx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732retx-pinctrl.dtsi
@@ -487,6 +487,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f732vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732vetx-pinctrl.dtsi
@@ -879,6 +879,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f732zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732zetx-pinctrl.dtsi
@@ -1213,6 +1213,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f733iekx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733iekx-pinctrl.dtsi
@@ -1484,6 +1484,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f733ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733ietx-pinctrl.dtsi
@@ -1484,6 +1484,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f733vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733vetx-pinctrl.dtsi
@@ -849,6 +849,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f733veyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733veyx-pinctrl.dtsi
@@ -849,6 +849,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f733zeix-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733zeix-pinctrl.dtsi
@@ -1199,6 +1199,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f733zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733zetx-pinctrl.dtsi
@@ -1199,6 +1199,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f745i(e-g)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745i(e-g)kx-pinctrl.dtsi
@@ -1731,6 +1731,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f745i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745i(e-g)tx-pinctrl.dtsi
@@ -1731,6 +1731,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f745v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745v(e-g)hx-pinctrl.dtsi
@@ -1054,6 +1054,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f745v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745v(e-g)tx-pinctrl.dtsi
@@ -1054,6 +1054,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f745z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745z(e-g)tx-pinctrl.dtsi
@@ -1414,6 +1414,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f746b(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746b(e-g)tx-pinctrl.dtsi
@@ -1843,6 +1843,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f746i(e-g)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746i(e-g)kx-pinctrl.dtsi
@@ -1731,6 +1731,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f746ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746ietx-pinctrl.dtsi
@@ -1731,6 +1731,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f746igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746igtx-pinctrl.dtsi
@@ -1731,6 +1731,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f746nehx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746nehx-pinctrl.dtsi
@@ -1843,6 +1843,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f746nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746nghx-pinctrl.dtsi
@@ -1843,6 +1843,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f746v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746v(e-g)hx-pinctrl.dtsi
@@ -1054,6 +1054,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f746vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746vetx-pinctrl.dtsi
@@ -1054,6 +1054,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f746vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746vgtx-pinctrl.dtsi
@@ -1054,6 +1054,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f746z(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746z(e-g)yx-pinctrl.dtsi
@@ -1414,6 +1414,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f746zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746zetx-pinctrl.dtsi
@@ -1414,6 +1414,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f746zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746zgtx-pinctrl.dtsi
@@ -1414,6 +1414,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f750n8hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750n8hx-pinctrl.dtsi
@@ -1843,6 +1843,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f750v8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750v8tx-pinctrl.dtsi
@@ -1054,6 +1054,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f750z8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750z8tx-pinctrl.dtsi
@@ -1414,6 +1414,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f756bgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756bgtx-pinctrl.dtsi
@@ -1843,6 +1843,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f756igkx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756igkx-pinctrl.dtsi
@@ -1731,6 +1731,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f756igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756igtx-pinctrl.dtsi
@@ -1731,6 +1731,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f756nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756nghx-pinctrl.dtsi
@@ -1843,6 +1843,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f756vghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756vghx-pinctrl.dtsi
@@ -1054,6 +1054,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f756vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756vgtx-pinctrl.dtsi
@@ -1054,6 +1054,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f756zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756zgtx-pinctrl.dtsi
@@ -1414,6 +1414,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f756zgyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756zgyx-pinctrl.dtsi
@@ -1414,6 +1414,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f765b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765b(g-i)tx-pinctrl.dtsi
@@ -1930,6 +1930,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f765i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765i(g-i)kx-pinctrl.dtsi
@@ -1818,6 +1818,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f765i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765i(g-i)tx-pinctrl.dtsi
@@ -1818,6 +1818,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f765n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765n(g-i)hx-pinctrl.dtsi
@@ -1930,6 +1930,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f765v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765v(g-i)hx-pinctrl.dtsi
@@ -1125,6 +1125,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f765v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765v(g-i)tx-pinctrl.dtsi
@@ -1125,6 +1125,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f765z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765z(g-i)tx-pinctrl.dtsi
@@ -1496,6 +1496,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f767b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767b(g-i)tx-pinctrl.dtsi
@@ -1930,6 +1930,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f767i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767i(g-i)kx-pinctrl.dtsi
@@ -1818,6 +1818,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f767i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767i(g-i)tx-pinctrl.dtsi
@@ -1818,6 +1818,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f767n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767n(g-i)hx-pinctrl.dtsi
@@ -1930,6 +1930,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f767vghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vghx-pinctrl.dtsi
@@ -1125,6 +1125,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f767vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vgtx-pinctrl.dtsi
@@ -1125,6 +1125,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f767vihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vihx-pinctrl.dtsi
@@ -1125,6 +1125,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f767vitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vitx-pinctrl.dtsi
@@ -1125,6 +1125,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f767zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767zgtx-pinctrl.dtsi
@@ -1496,6 +1496,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f767zitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767zitx-pinctrl.dtsi
@@ -1496,6 +1496,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f768aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f768aiyx-pinctrl.dtsi
@@ -1476,6 +1476,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f769a(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769a(g-i)yx-pinctrl.dtsi
@@ -1476,6 +1476,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f769b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769b(g-i)tx-pinctrl.dtsi
@@ -1894,6 +1894,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f769igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769igtx-pinctrl.dtsi
@@ -1701,6 +1701,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f769iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769iitx-pinctrl.dtsi
@@ -1701,6 +1701,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f769nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769nghx-pinctrl.dtsi
@@ -1894,6 +1894,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f769nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769nihx-pinctrl.dtsi
@@ -1894,6 +1894,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f777bitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777bitx-pinctrl.dtsi
@@ -1930,6 +1930,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f777iikx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777iikx-pinctrl.dtsi
@@ -1818,6 +1818,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f777iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777iitx-pinctrl.dtsi
@@ -1818,6 +1818,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f777nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777nihx-pinctrl.dtsi
@@ -1930,6 +1930,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f777vihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777vihx-pinctrl.dtsi
@@ -1125,6 +1125,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f777vitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777vitx-pinctrl.dtsi
@@ -1125,6 +1125,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f777zitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777zitx-pinctrl.dtsi
@@ -1496,6 +1496,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f778aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f778aiyx-pinctrl.dtsi
@@ -1476,6 +1476,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f779aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779aiyx-pinctrl.dtsi
@@ -1476,6 +1476,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f779bitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779bitx-pinctrl.dtsi
@@ -1894,6 +1894,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f779iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779iitx-pinctrl.dtsi
@@ -1701,6 +1701,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/f7/stm32f779nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779nihx-pinctrl.dtsi
@@ -1894,6 +1894,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa7: i2s1_sd_pa7 {

--- a/dts/st/g0/stm32g030c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g030c(6-8)tx-pinctrl.dtsi
@@ -343,6 +343,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g030f6px-pinctrl.dtsi
+++ b/dts/st/g0/stm32g030f6px-pinctrl.dtsi
@@ -259,6 +259,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g030j6mx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g030j6mx-pinctrl.dtsi
@@ -189,6 +189,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g030k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g030k(6-8)tx-pinctrl.dtsi
@@ -263,6 +263,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g031c(4-6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031c(4-6-8)tx-pinctrl.dtsi
@@ -347,6 +347,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g031c(4-6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031c(4-6-8)ux-pinctrl.dtsi
@@ -347,6 +347,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g031f(4-6-8)px-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031f(4-6-8)px-pinctrl.dtsi
@@ -263,6 +263,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g031g(4-6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031g(4-6-8)ux-pinctrl.dtsi
@@ -249,6 +249,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g031j(4-6)mx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031j(4-6)mx-pinctrl.dtsi
@@ -193,6 +193,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g031k(4-6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031k(4-6-8)tx-pinctrl.dtsi
@@ -267,6 +267,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g031k(4-6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031k(4-6-8)ux-pinctrl.dtsi
@@ -267,6 +267,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g031y8yx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g031y8yx-pinctrl.dtsi
@@ -263,6 +263,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g041c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041c(6-8)tx-pinctrl.dtsi
@@ -347,6 +347,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g041c(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041c(6-8)ux-pinctrl.dtsi
@@ -347,6 +347,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g041f(6-8)px-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041f(6-8)px-pinctrl.dtsi
@@ -263,6 +263,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g041g(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041g(6-8)ux-pinctrl.dtsi
@@ -249,6 +249,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g041j6mx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041j6mx-pinctrl.dtsi
@@ -193,6 +193,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g041k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041k(6-8)tx-pinctrl.dtsi
@@ -267,6 +267,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g041k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041k(6-8)ux-pinctrl.dtsi
@@ -267,6 +267,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g041y8yx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g041y8yx-pinctrl.dtsi
@@ -263,6 +263,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g050c6tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g050c6tx-pinctrl.dtsi
@@ -359,6 +359,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g050c8tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g050c8tx-pinctrl.dtsi
@@ -359,6 +359,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g050f6px-pinctrl.dtsi
+++ b/dts/st/g0/stm32g050f6px-pinctrl.dtsi
@@ -263,6 +263,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g050k6tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g050k6tx-pinctrl.dtsi
@@ -267,6 +267,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g050k8tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g050k8tx-pinctrl.dtsi
@@ -267,6 +267,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g051c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g051c(6-8)tx-pinctrl.dtsi
@@ -369,6 +369,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g051c(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g051c(6-8)ux-pinctrl.dtsi
@@ -369,6 +369,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g051f(6-8)px-pinctrl.dtsi
+++ b/dts/st/g0/stm32g051f(6-8)px-pinctrl.dtsi
@@ -273,6 +273,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g051f8yx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g051f8yx-pinctrl.dtsi
@@ -273,6 +273,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g051g(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g051g(6-8)ux-pinctrl.dtsi
@@ -259,6 +259,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g051k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g051k(6-8)tx-pinctrl.dtsi
@@ -277,6 +277,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g051k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g051k(6-8)ux-pinctrl.dtsi
@@ -277,6 +277,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g061c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g061c(6-8)tx-pinctrl.dtsi
@@ -369,6 +369,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g061c(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g061c(6-8)ux-pinctrl.dtsi
@@ -369,6 +369,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g061f(6-8)px-pinctrl.dtsi
+++ b/dts/st/g0/stm32g061f(6-8)px-pinctrl.dtsi
@@ -273,6 +273,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g061f8yx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g061f8yx-pinctrl.dtsi
@@ -273,6 +273,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g061g(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g061g(6-8)ux-pinctrl.dtsi
@@ -259,6 +259,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g061k(6-8)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g061k(6-8)tx-pinctrl.dtsi
@@ -277,6 +277,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g061k(6-8)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g061k(6-8)ux-pinctrl.dtsi
@@ -277,6 +277,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g070cbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g070cbtx-pinctrl.dtsi
@@ -335,6 +335,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g070kbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g070kbtx-pinctrl.dtsi
@@ -243,6 +243,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g070rbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g070rbtx-pinctrl.dtsi
@@ -412,6 +412,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pd5: i2s1_mck_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g071c(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071c(6-8-b)tx-pinctrl.dtsi
@@ -349,6 +349,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g071c(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071c(6-8-b)ux-pinctrl.dtsi
@@ -349,6 +349,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g071ebyx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071ebyx-pinctrl.dtsi
@@ -222,6 +222,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g071g(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071g(6-8-b)ux-pinctrl.dtsi
@@ -239,6 +239,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g071g(8-b)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071g(8-b)uxn-pinctrl.dtsi
@@ -230,6 +230,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g071k(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071k(6-8-b)tx-pinctrl.dtsi
@@ -257,6 +257,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g071k(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071k(6-8-b)ux-pinctrl.dtsi
@@ -257,6 +257,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g071k(8-b)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071k(8-b)txn-pinctrl.dtsi
@@ -248,6 +248,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g071k(8-b)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071k(8-b)uxn-pinctrl.dtsi
@@ -248,6 +248,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g071r(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071r(6-8-b)tx-pinctrl.dtsi
@@ -426,6 +426,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pd5: i2s1_mck_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g071rbix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g071rbix-pinctrl.dtsi
@@ -426,6 +426,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pd5: i2s1_mck_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g081cbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081cbtx-pinctrl.dtsi
@@ -349,6 +349,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g081cbux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081cbux-pinctrl.dtsi
@@ -349,6 +349,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g081ebyx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081ebyx-pinctrl.dtsi
@@ -222,6 +222,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g081gbux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081gbux-pinctrl.dtsi
@@ -239,6 +239,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g081gbuxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081gbuxn-pinctrl.dtsi
@@ -230,6 +230,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g081kbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081kbtx-pinctrl.dtsi
@@ -257,6 +257,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g081kbtxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081kbtxn-pinctrl.dtsi
@@ -248,6 +248,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g081kbux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081kbux-pinctrl.dtsi
@@ -257,6 +257,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g081kbuxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081kbuxn-pinctrl.dtsi
@@ -248,6 +248,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g081rbix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081rbix-pinctrl.dtsi
@@ -426,6 +426,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pd5: i2s1_mck_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g081rbtx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g081rbtx-pinctrl.dtsi
@@ -426,6 +426,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pd5: i2s1_mck_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g0b0cetx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b0cetx-pinctrl.dtsi
@@ -424,6 +424,53 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb2: i2s2_mck_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb6: i2s2_mck_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g0b0ketx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b0ketx-pinctrl.dtsi
@@ -317,6 +317,43 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb2: i2s2_mck_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb6: i2s2_mck_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g0b0retx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b0retx-pinctrl.dtsi
@@ -513,6 +513,63 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pd5: i2s1_mck_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb2: i2s2_mck_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb6: i2s2_mck_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g0b0vetx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b0vetx-pinctrl.dtsi
@@ -654,6 +654,68 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pd5: i2s1_mck_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pe14: i2s1_mck_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb2: i2s2_mck_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb6: i2s2_mck_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g0b1c(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1c(b-c-e)tx-pinctrl.dtsi
@@ -486,6 +486,53 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb2: i2s2_mck_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb6: i2s2_mck_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g0b1c(b-c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1c(b-c-e)txn-pinctrl.dtsi
@@ -478,6 +478,53 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb2: i2s2_mck_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb6: i2s2_mck_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g0b1c(b-c-e)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1c(b-c-e)ux-pinctrl.dtsi
@@ -486,6 +486,53 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb2: i2s2_mck_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb6: i2s2_mck_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g0b1c(b-c-e)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1c(b-c-e)uxn-pinctrl.dtsi
@@ -478,6 +478,53 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb2: i2s2_mck_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb6: i2s2_mck_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g0b1k(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1k(b-c-e)tx-pinctrl.dtsi
@@ -363,6 +363,43 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb2: i2s2_mck_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb6: i2s2_mck_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g0b1k(b-c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1k(b-c-e)txn-pinctrl.dtsi
@@ -335,6 +335,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb6: i2s2_mck_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g0b1k(b-c-e)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1k(b-c-e)ux-pinctrl.dtsi
@@ -363,6 +363,43 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb2: i2s2_mck_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb6: i2s2_mck_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g0b1k(b-c-e)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1k(b-c-e)uxn-pinctrl.dtsi
@@ -335,6 +335,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb6: i2s2_mck_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g0b1m(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1m(b-c-e)tx-pinctrl.dtsi
@@ -663,6 +663,63 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pd5: i2s1_mck_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb2: i2s2_mck_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb6: i2s2_mck_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g0b1neyx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1neyx-pinctrl.dtsi
@@ -510,6 +510,53 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb2: i2s2_mck_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb6: i2s2_mck_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g0b1r(b-c-e)ixn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1r(b-c-e)ixn-pinctrl.dtsi
@@ -578,6 +578,63 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pd5: i2s1_mck_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb2: i2s2_mck_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb6: i2s2_mck_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g0b1r(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1r(b-c-e)tx-pinctrl.dtsi
@@ -591,6 +591,63 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pd5: i2s1_mck_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb2: i2s2_mck_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb6: i2s2_mck_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g0b1r(b-c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1r(b-c-e)txn-pinctrl.dtsi
@@ -578,6 +578,63 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pd5: i2s1_mck_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb2: i2s2_mck_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb6: i2s2_mck_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g0b1v(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1v(b-c-e)ix-pinctrl.dtsi
@@ -748,6 +748,68 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pd5: i2s1_mck_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pe14: i2s1_mck_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb2: i2s2_mck_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb6: i2s2_mck_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g0b1v(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0b1v(b-c-e)tx-pinctrl.dtsi
@@ -748,6 +748,68 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pd5: i2s1_mck_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pe14: i2s1_mck_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb2: i2s2_mck_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb6: i2s2_mck_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g0c1c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1c(c-e)tx-pinctrl.dtsi
@@ -486,6 +486,53 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb2: i2s2_mck_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb6: i2s2_mck_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g0c1c(c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1c(c-e)txn-pinctrl.dtsi
@@ -478,6 +478,53 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb2: i2s2_mck_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb6: i2s2_mck_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g0c1c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1c(c-e)ux-pinctrl.dtsi
@@ -486,6 +486,53 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb2: i2s2_mck_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb6: i2s2_mck_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g0c1c(c-e)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1c(c-e)uxn-pinctrl.dtsi
@@ -478,6 +478,53 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb2: i2s2_mck_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb6: i2s2_mck_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g0c1k(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1k(c-e)tx-pinctrl.dtsi
@@ -363,6 +363,43 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb2: i2s2_mck_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb6: i2s2_mck_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g0c1k(c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1k(c-e)txn-pinctrl.dtsi
@@ -335,6 +335,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb6: i2s2_mck_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g0c1k(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1k(c-e)ux-pinctrl.dtsi
@@ -363,6 +363,43 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb2: i2s2_mck_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb6: i2s2_mck_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g0c1k(c-e)uxn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1k(c-e)uxn-pinctrl.dtsi
@@ -335,6 +335,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb6: i2s2_mck_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g0c1m(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1m(c-e)tx-pinctrl.dtsi
@@ -663,6 +663,63 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pd5: i2s1_mck_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb2: i2s2_mck_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb6: i2s2_mck_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g0c1neyx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1neyx-pinctrl.dtsi
@@ -510,6 +510,53 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb2: i2s2_mck_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb6: i2s2_mck_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g0c1r(c-e)ixn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1r(c-e)ixn-pinctrl.dtsi
@@ -578,6 +578,63 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pd5: i2s1_mck_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb2: i2s2_mck_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb6: i2s2_mck_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g0c1r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1r(c-e)tx-pinctrl.dtsi
@@ -591,6 +591,63 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pd5: i2s1_mck_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb2: i2s2_mck_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb6: i2s2_mck_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g0c1r(c-e)txn-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1r(c-e)txn-pinctrl.dtsi
@@ -578,6 +578,63 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pd5: i2s1_mck_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb2: i2s2_mck_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb6: i2s2_mck_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g0c1v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1v(c-e)ix-pinctrl.dtsi
@@ -748,6 +748,68 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pd5: i2s1_mck_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pe14: i2s1_mck_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb2: i2s2_mck_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb6: i2s2_mck_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g0/stm32g0c1v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g0/stm32g0c1v(c-e)tx-pinctrl.dtsi
@@ -748,6 +748,68 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pa6: i2s1_mck_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pa11: i2s1_mck_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pb4: i2s1_mck_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pd5: i2s1_mck_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pe14: i2s1_mck_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pa9: i2s2_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb2: i2s2_mck_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb6: i2s2_mck_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF4)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF1)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s1_sd_pa2: i2s1_sd_pa2 {

--- a/dts/st/g4/stm32g431c(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431c(6-8-b)tx-pinctrl.dtsi
@@ -363,6 +363,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g431c(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431c(6-8-b)ux-pinctrl.dtsi
@@ -400,6 +400,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g431cbyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431cbyx-pinctrl.dtsi
@@ -391,6 +391,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g431k(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431k(6-8-b)tx-pinctrl.dtsi
@@ -272,6 +272,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g431k(6-8-b)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431k(6-8-b)ux-pinctrl.dtsi
@@ -272,6 +272,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g431m(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431m(6-8-b)tx-pinctrl.dtsi
@@ -552,6 +552,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g431r(6-8-b)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431r(6-8-b)ix-pinctrl.dtsi
@@ -488,6 +488,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g431r(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431r(6-8-b)tx-pinctrl.dtsi
@@ -488,6 +488,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g431v(6-8-b)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g431v(6-8-b)tx-pinctrl.dtsi
@@ -632,6 +632,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g441cbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441cbtx-pinctrl.dtsi
@@ -363,6 +363,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g441cbux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441cbux-pinctrl.dtsi
@@ -400,6 +400,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g441cbyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441cbyx-pinctrl.dtsi
@@ -391,6 +391,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g441kbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441kbtx-pinctrl.dtsi
@@ -272,6 +272,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g441kbux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441kbux-pinctrl.dtsi
@@ -272,6 +272,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g441mbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441mbtx-pinctrl.dtsi
@@ -552,6 +552,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g441rbix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441rbix-pinctrl.dtsi
@@ -488,6 +488,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g441rbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441rbtx-pinctrl.dtsi
@@ -488,6 +488,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g441vbtx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g441vbtx-pinctrl.dtsi
@@ -632,6 +632,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g471c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471c(c-e)tx-pinctrl.dtsi
@@ -403,6 +403,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g471c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471c(c-e)ux-pinctrl.dtsi
@@ -446,6 +446,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g471m(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471m(c-e)tx-pinctrl.dtsi
@@ -636,6 +636,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g471meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471meyx-pinctrl.dtsi
@@ -644,6 +644,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g471q(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471q(c-e)tx-pinctrl.dtsi
@@ -870,6 +870,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g471r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471r(c-e)tx-pinctrl.dtsi
@@ -540,6 +540,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g471v(c-e)hx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471v(c-e)hx-pinctrl.dtsi
@@ -732,6 +732,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g471v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471v(c-e)ix-pinctrl.dtsi
@@ -732,6 +732,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g471v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g471v(c-e)tx-pinctrl.dtsi
@@ -732,6 +732,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g473c(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473c(b-c-e)tx-pinctrl.dtsi
@@ -443,6 +443,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g473c(b-c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473c(b-c-e)ux-pinctrl.dtsi
@@ -486,6 +486,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g473m(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473m(b-c-e)tx-pinctrl.dtsi
@@ -740,6 +740,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g473meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473meyx-pinctrl.dtsi
@@ -756,6 +756,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g473p(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473p(b-c-e)ix-pinctrl.dtsi
@@ -1282,6 +1282,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g473q(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473q(b-c-e)tx-pinctrl.dtsi
@@ -1350,6 +1350,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g473r(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473r(b-c-e)tx-pinctrl.dtsi
@@ -580,6 +580,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g473v(b-c-e)hx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473v(b-c-e)hx-pinctrl.dtsi
@@ -1086,6 +1086,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g473v(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473v(b-c-e)tx-pinctrl.dtsi
@@ -1086,6 +1086,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g474c(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474c(b-c-e)tx-pinctrl.dtsi
@@ -525,6 +525,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g474c(b-c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474c(b-c-e)ux-pinctrl.dtsi
@@ -580,6 +580,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g474m(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474m(b-c-e)tx-pinctrl.dtsi
@@ -854,6 +854,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g474meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474meyx-pinctrl.dtsi
@@ -870,6 +870,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g474p(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474p(b-c-e)ix-pinctrl.dtsi
@@ -1396,6 +1396,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g474q(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474q(b-c-e)tx-pinctrl.dtsi
@@ -1464,6 +1464,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g474r(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474r(b-c-e)tx-pinctrl.dtsi
@@ -694,6 +694,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g474v(b-c-e)hx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474v(b-c-e)hx-pinctrl.dtsi
@@ -1200,6 +1200,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g474v(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474v(b-c-e)tx-pinctrl.dtsi
@@ -1200,6 +1200,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g483cetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483cetx-pinctrl.dtsi
@@ -443,6 +443,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g483ceux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483ceux-pinctrl.dtsi
@@ -486,6 +486,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g483metx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483metx-pinctrl.dtsi
@@ -740,6 +740,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g483meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483meyx-pinctrl.dtsi
@@ -756,6 +756,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g483peix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483peix-pinctrl.dtsi
@@ -1282,6 +1282,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g483qetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483qetx-pinctrl.dtsi
@@ -1350,6 +1350,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g483retx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483retx-pinctrl.dtsi
@@ -580,6 +580,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g483vehx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483vehx-pinctrl.dtsi
@@ -1086,6 +1086,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g483vetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483vetx-pinctrl.dtsi
@@ -1086,6 +1086,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g484cetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484cetx-pinctrl.dtsi
@@ -525,6 +525,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g484ceux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484ceux-pinctrl.dtsi
@@ -580,6 +580,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g484metx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484metx-pinctrl.dtsi
@@ -854,6 +854,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g484meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484meyx-pinctrl.dtsi
@@ -870,6 +870,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g484peix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484peix-pinctrl.dtsi
@@ -1396,6 +1396,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g484qetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484qetx-pinctrl.dtsi
@@ -1464,6 +1464,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g484retx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484retx-pinctrl.dtsi
@@ -694,6 +694,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g484vehx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484vehx-pinctrl.dtsi
@@ -1200,6 +1200,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g484vetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484vetx-pinctrl.dtsi
@@ -1200,6 +1200,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g491c(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491c(c-e)tx-pinctrl.dtsi
@@ -391,6 +391,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g491c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491c(c-e)ux-pinctrl.dtsi
@@ -428,6 +428,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g491k(c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491k(c-e)ux-pinctrl.dtsi
@@ -284,6 +284,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g491m(c-e)sx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491m(c-e)sx-pinctrl.dtsi
@@ -612,6 +612,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g491m(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491m(c-e)tx-pinctrl.dtsi
@@ -612,6 +612,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g491r(c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491r(c-e)ix-pinctrl.dtsi
@@ -516,6 +516,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g491r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491r(c-e)tx-pinctrl.dtsi
@@ -516,6 +516,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g491reyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491reyx-pinctrl.dtsi
@@ -516,6 +516,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g491v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g491v(c-e)tx-pinctrl.dtsi
@@ -708,6 +708,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g4a1cetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1cetx-pinctrl.dtsi
@@ -391,6 +391,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g4a1ceux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1ceux-pinctrl.dtsi
@@ -428,6 +428,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g4a1keux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1keux-pinctrl.dtsi
@@ -284,6 +284,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g4a1mesx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1mesx-pinctrl.dtsi
@@ -612,6 +612,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g4a1metx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1metx-pinctrl.dtsi
@@ -612,6 +612,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g4a1reix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1reix-pinctrl.dtsi
@@ -516,6 +516,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g4a1retx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1retx-pinctrl.dtsi
@@ -516,6 +516,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g4a1reyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1reyx-pinctrl.dtsi
@@ -516,6 +516,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/g4/stm32g4a1vetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g4a1vetx-pinctrl.dtsi
@@ -708,6 +708,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa8: i2s2_mck_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pa9: i2s3_mck_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa11: i2s2_sd_pa11 {

--- a/dts/st/h7/stm32h723vehx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vehx-pinctrl.dtsi
@@ -1227,6 +1227,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h723vetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vetx-pinctrl.dtsi
@@ -1227,6 +1227,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h723vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vghx-pinctrl.dtsi
@@ -1227,6 +1227,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h723vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723vgtx-pinctrl.dtsi
@@ -1227,6 +1227,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h723zeix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zeix-pinctrl.dtsi
@@ -1704,6 +1704,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h723zetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zetx-pinctrl.dtsi
@@ -1676,6 +1676,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h723zgix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zgix-pinctrl.dtsi
@@ -1704,6 +1704,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h723zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h723zgtx-pinctrl.dtsi
@@ -1676,6 +1676,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h725aeix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725aeix-pinctrl.dtsi
@@ -1911,6 +1911,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h725agix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725agix-pinctrl.dtsi
@@ -1911,6 +1911,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h725iekx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725iekx-pinctrl.dtsi
@@ -2025,6 +2025,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h725ietx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725ietx-pinctrl.dtsi
@@ -1704,6 +1704,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h725igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725igkx-pinctrl.dtsi
@@ -2025,6 +2025,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h725igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725igtx-pinctrl.dtsi
@@ -1704,6 +1704,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h725revx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725revx-pinctrl.dtsi
@@ -531,6 +531,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h725rgvx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725rgvx-pinctrl.dtsi
@@ -531,6 +531,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h725vehx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vehx-pinctrl.dtsi
@@ -1177,6 +1177,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h725vetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vetx-pinctrl.dtsi
@@ -1097,6 +1097,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h725vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vghx-pinctrl.dtsi
@@ -1177,6 +1177,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h725vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vgtx-pinctrl.dtsi
@@ -1097,6 +1097,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h725vgyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725vgyx-pinctrl.dtsi
@@ -1051,6 +1051,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h725zetx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725zetx-pinctrl.dtsi
@@ -1474,6 +1474,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h725zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h725zgtx-pinctrl.dtsi
@@ -1474,6 +1474,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h730abixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730abixq-pinctrl.dtsi
@@ -1911,6 +1911,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h730ibkxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730ibkxq-pinctrl.dtsi
@@ -2025,6 +2025,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h730ibtxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730ibtxq-pinctrl.dtsi
@@ -1704,6 +1704,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h730vbhx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730vbhx-pinctrl.dtsi
@@ -1227,6 +1227,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h730vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730vbtx-pinctrl.dtsi
@@ -1227,6 +1227,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h730zbix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730zbix-pinctrl.dtsi
@@ -1704,6 +1704,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h730zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h730zbtx-pinctrl.dtsi
@@ -1676,6 +1676,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h733vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733vghx-pinctrl.dtsi
@@ -1227,6 +1227,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h733vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733vgtx-pinctrl.dtsi
@@ -1227,6 +1227,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h733zgix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733zgix-pinctrl.dtsi
@@ -1704,6 +1704,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h733zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h733zgtx-pinctrl.dtsi
@@ -1676,6 +1676,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h735agix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735agix-pinctrl.dtsi
@@ -1911,6 +1911,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h735igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735igkx-pinctrl.dtsi
@@ -2025,6 +2025,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h735igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735igtx-pinctrl.dtsi
@@ -1704,6 +1704,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h735rgvx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735rgvx-pinctrl.dtsi
@@ -531,6 +531,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h735vghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vghx-pinctrl.dtsi
@@ -1177,6 +1177,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h735vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vgtx-pinctrl.dtsi
@@ -1097,6 +1097,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h735vgyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735vgyx-pinctrl.dtsi
@@ -1051,6 +1051,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h735zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h735zgtx-pinctrl.dtsi
@@ -1474,6 +1474,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
@@ -1741,6 +1741,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
@@ -1990,6 +1990,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
@@ -1878,6 +1878,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
@@ -1878,6 +1878,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
@@ -1114,6 +1114,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
@@ -1114,6 +1114,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
@@ -2107,6 +2107,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
@@ -1530,6 +1530,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
@@ -1741,6 +1741,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
@@ -1990,6 +1990,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h743bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bitx-pinctrl.dtsi
@@ -1990,6 +1990,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h743igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igkx-pinctrl.dtsi
@@ -1878,6 +1878,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h743igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igtx-pinctrl.dtsi
@@ -1878,6 +1878,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h743iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iikx-pinctrl.dtsi
@@ -1878,6 +1878,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h743iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iitx-pinctrl.dtsi
@@ -1878,6 +1878,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
@@ -1114,6 +1114,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
@@ -1114,6 +1114,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h743vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vitx-pinctrl.dtsi
@@ -1114,6 +1114,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h743xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xghx-pinctrl.dtsi
@@ -2107,6 +2107,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h743xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xihx-pinctrl.dtsi
@@ -2107,6 +2107,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
@@ -1530,6 +1530,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h743zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zitx-pinctrl.dtsi
@@ -1530,6 +1530,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
@@ -1918,6 +1918,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h745bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bitx-pinctrl.dtsi
@@ -1918,6 +1918,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h745igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igkx-pinctrl.dtsi
@@ -1873,6 +1873,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h745igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igtx-pinctrl.dtsi
@@ -1558,6 +1558,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h745iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iikx-pinctrl.dtsi
@@ -1873,6 +1873,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h745iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iitx-pinctrl.dtsi
@@ -1558,6 +1558,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h745xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xghx-pinctrl.dtsi
@@ -2107,6 +2107,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h745xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xihx-pinctrl.dtsi
@@ -2107,6 +2107,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
@@ -1336,6 +1336,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h745zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zitx-pinctrl.dtsi
@@ -1336,6 +1336,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
@@ -1530,6 +1530,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
@@ -1882,6 +1882,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h747bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bitx-pinctrl.dtsi
@@ -1882,6 +1882,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h747igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747igtx-pinctrl.dtsi
@@ -1530,6 +1530,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h747iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747iitx-pinctrl.dtsi
@@ -1530,6 +1530,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h747xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xghx-pinctrl.dtsi
@@ -2107,6 +2107,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h747xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xihx-pinctrl.dtsi
@@ -2107,6 +2107,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
@@ -1373,6 +1373,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
@@ -1878,6 +1878,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
@@ -1878,6 +1878,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
@@ -1114,6 +1114,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
@@ -2107,6 +2107,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
@@ -1530,6 +1530,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h753aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753aiix-pinctrl.dtsi
@@ -1741,6 +1741,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h753bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753bitx-pinctrl.dtsi
@@ -1990,6 +1990,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h753iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iikx-pinctrl.dtsi
@@ -1878,6 +1878,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h753iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iitx-pinctrl.dtsi
@@ -1878,6 +1878,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h753vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vihx-pinctrl.dtsi
@@ -1114,6 +1114,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h753vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vitx-pinctrl.dtsi
@@ -1114,6 +1114,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h753xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753xihx-pinctrl.dtsi
@@ -2107,6 +2107,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h753zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753zitx-pinctrl.dtsi
@@ -1530,6 +1530,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h755bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755bitx-pinctrl.dtsi
@@ -1918,6 +1918,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h755iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iikx-pinctrl.dtsi
@@ -1873,6 +1873,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h755iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iitx-pinctrl.dtsi
@@ -1558,6 +1558,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h755xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755xihx-pinctrl.dtsi
@@ -2107,6 +2107,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h755zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755zitx-pinctrl.dtsi
@@ -1336,6 +1336,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h757aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757aiix-pinctrl.dtsi
@@ -1530,6 +1530,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h757bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757bitx-pinctrl.dtsi
@@ -1882,6 +1882,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h757iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757iitx-pinctrl.dtsi
@@ -1530,6 +1530,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h757xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757xihx-pinctrl.dtsi
@@ -2107,6 +2107,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
@@ -1373,6 +1373,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
@@ -1478,6 +1478,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
@@ -1611,6 +1611,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
@@ -1566,6 +1566,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
@@ -1611,6 +1611,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
@@ -1344,6 +1344,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
@@ -1795,6 +1795,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
@@ -1723,6 +1723,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h7a3qiyxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3qiyxq-pinctrl.dtsi
@@ -1050,6 +1050,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h7a3r(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3r(g-i)tx-pinctrl.dtsi
@@ -541,6 +541,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h7a3v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)hx-pinctrl.dtsi
@@ -968,6 +968,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h7a3v(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)hxq-pinctrl.dtsi
@@ -918,6 +918,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h7a3v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)tx-pinctrl.dtsi
@@ -968,6 +968,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h7a3v(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)txq-pinctrl.dtsi
@@ -848,6 +848,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
@@ -1316,6 +1316,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h7a3z(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)txq-pinctrl.dtsi
@@ -1142,6 +1142,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
@@ -1478,6 +1478,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
@@ -1566,6 +1566,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
@@ -1611,6 +1611,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h7b0rbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0rbtx-pinctrl.dtsi
@@ -541,6 +541,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h7b0vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0vbtx-pinctrl.dtsi
@@ -968,6 +968,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
@@ -1316,6 +1316,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
@@ -1478,6 +1478,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
@@ -1611,6 +1611,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
@@ -1566,6 +1566,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
@@ -1611,6 +1611,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
@@ -1344,6 +1344,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
@@ -1795,6 +1795,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
@@ -1723,6 +1723,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h7b3qiyxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3qiyxq-pinctrl.dtsi
@@ -1050,6 +1050,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h7b3ritx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3ritx-pinctrl.dtsi
@@ -541,6 +541,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h7b3vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vihx-pinctrl.dtsi
@@ -968,6 +968,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h7b3vihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vihxq-pinctrl.dtsi
@@ -918,6 +918,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h7b3vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vitx-pinctrl.dtsi
@@ -968,6 +968,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h7b3vitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vitxq-pinctrl.dtsi
@@ -848,6 +848,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
@@ -1316,6 +1316,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/h7/stm32h7b3zitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitxq-pinctrl.dtsi
@@ -1142,6 +1142,28 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s6_mck_pa3: i2s6_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/l0/stm32l051c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l051c(6-8)tx-pinctrl.dtsi
@@ -261,6 +261,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l051c(6-8)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l051c(6-8)ux-pinctrl.dtsi
@@ -261,6 +261,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l051r(6-8)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l051r(6-8)hx-pinctrl.dtsi
@@ -333,6 +333,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l051r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l051r(6-8)tx-pinctrl.dtsi
@@ -341,6 +341,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l052c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052c(6-8)tx-pinctrl.dtsi
@@ -267,6 +267,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l052c(6-8)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052c(6-8)ux-pinctrl.dtsi
@@ -267,6 +267,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l052r(6-8)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052r(6-8)hx-pinctrl.dtsi
@@ -339,6 +339,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l052r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l052r(6-8)tx-pinctrl.dtsi
@@ -347,6 +347,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l053c(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l053c(6-8)tx-pinctrl.dtsi
@@ -267,6 +267,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l053c(6-8)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l053c(6-8)ux-pinctrl.dtsi
@@ -267,6 +267,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l053r(6-8)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l053r(6-8)hx-pinctrl.dtsi
@@ -339,6 +339,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l053r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l053r(6-8)tx-pinctrl.dtsi
@@ -347,6 +347,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l062c8ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l062c8ux-pinctrl.dtsi
@@ -267,6 +267,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l063c8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l063c8tx-pinctrl.dtsi
@@ -267,6 +267,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l063c8ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l063c8ux-pinctrl.dtsi
@@ -267,6 +267,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l063r8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l063r8tx-pinctrl.dtsi
@@ -347,6 +347,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l071c(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071c(b-z)tx-pinctrl.dtsi
@@ -285,6 +285,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l071c(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071c(b-z)ux-pinctrl.dtsi
@@ -285,6 +285,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l071c(b-z)yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071c(b-z)yx-pinctrl.dtsi
@@ -321,6 +321,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l071c8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071c8tx-pinctrl.dtsi
@@ -285,6 +285,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l071c8ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071c8ux-pinctrl.dtsi
@@ -285,6 +285,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l071r(b-z)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071r(b-z)hx-pinctrl.dtsi
@@ -375,6 +375,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l071r(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071r(b-z)tx-pinctrl.dtsi
@@ -383,6 +383,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l071v(b-z)ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071v(b-z)ix-pinctrl.dtsi
@@ -520,6 +520,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l071v(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071v(b-z)tx-pinctrl.dtsi
@@ -520,6 +520,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l071v8ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071v8ix-pinctrl.dtsi
@@ -520,6 +520,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l071v8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l071v8tx-pinctrl.dtsi
@@ -520,6 +520,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l072c(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072c(b-z)tx-pinctrl.dtsi
@@ -295,6 +295,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l072c(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072c(b-z)ux-pinctrl.dtsi
@@ -295,6 +295,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l072c(b-z)yx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072c(b-z)yx-pinctrl.dtsi
@@ -331,6 +331,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l072czex-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072czex-pinctrl.dtsi
@@ -331,6 +331,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l072r(b-z)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072r(b-z)hx-pinctrl.dtsi
@@ -385,6 +385,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l072r(b-z)ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072r(b-z)ix-pinctrl.dtsi
@@ -385,6 +385,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l072r(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072r(b-z)tx-pinctrl.dtsi
@@ -393,6 +393,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l072v(b-z)ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072v(b-z)ix-pinctrl.dtsi
@@ -530,6 +530,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l072v(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072v(b-z)tx-pinctrl.dtsi
@@ -530,6 +530,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l072v8ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072v8ix-pinctrl.dtsi
@@ -530,6 +530,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l072v8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l072v8tx-pinctrl.dtsi
@@ -530,6 +530,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l073c(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073c(b-z)tx-pinctrl.dtsi
@@ -295,6 +295,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l073c(b-z)ux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073c(b-z)ux-pinctrl.dtsi
@@ -295,6 +295,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l073czyx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073czyx-pinctrl.dtsi
@@ -331,6 +331,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l073r(b-z)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073r(b-z)hx-pinctrl.dtsi
@@ -385,6 +385,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l073r(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073r(b-z)tx-pinctrl.dtsi
@@ -393,6 +393,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l073rzix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073rzix-pinctrl.dtsi
@@ -385,6 +385,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l073v(b-z)ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073v(b-z)ix-pinctrl.dtsi
@@ -530,6 +530,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l073v(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073v(b-z)tx-pinctrl.dtsi
@@ -530,6 +530,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l073v8ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073v8ix-pinctrl.dtsi
@@ -530,6 +530,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l073v8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l073v8tx-pinctrl.dtsi
@@ -530,6 +530,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l081c(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l081c(b-z)tx-pinctrl.dtsi
@@ -285,6 +285,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l081czux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l081czux-pinctrl.dtsi
@@ -285,6 +285,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l082czux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l082czux-pinctrl.dtsi
@@ -295,6 +295,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l082czyx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l082czyx-pinctrl.dtsi
@@ -331,6 +331,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l083c(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083c(b-z)tx-pinctrl.dtsi
@@ -295,6 +295,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l083czux-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083czux-pinctrl.dtsi
@@ -295,6 +295,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l083r(b-z)hx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083r(b-z)hx-pinctrl.dtsi
@@ -385,6 +385,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l083r(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083r(b-z)tx-pinctrl.dtsi
@@ -393,6 +393,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l083v(b-z)ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083v(b-z)ix-pinctrl.dtsi
@@ -530,6 +530,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l083v(b-z)tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083v(b-z)tx-pinctrl.dtsi
@@ -530,6 +530,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l083v8ix-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083v8ix-pinctrl.dtsi
@@ -530,6 +530,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l0/stm32l083v8tx-pinctrl.dtsi
+++ b/dts/st/l0/stm32l083v8tx-pinctrl.dtsi
@@ -530,6 +530,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF0)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc2: i2s2_mck_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pd3: i2s2_mck_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF2)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l100rctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l100rctx-pinctrl.dtsi
@@ -365,6 +365,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l151qchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151qchx-pinctrl.dtsi
@@ -634,6 +634,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l151qdhx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151qdhx-pinctrl.dtsi
@@ -634,6 +634,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l151qehx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151qehx-pinctrl.dtsi
@@ -634,6 +634,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l151rctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151rctx-pinctrl.dtsi
@@ -365,6 +365,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l151rctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151rctxa-pinctrl.dtsi
@@ -365,6 +365,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l151rcyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151rcyx-pinctrl.dtsi
@@ -365,6 +365,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l151rdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151rdtx-pinctrl.dtsi
@@ -365,6 +365,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l151rdyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151rdyx-pinctrl.dtsi
@@ -365,6 +365,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l151retx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151retx-pinctrl.dtsi
@@ -365,6 +365,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l151ucyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151ucyx-pinctrl.dtsi
@@ -365,6 +365,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l151vchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vchx-pinctrl.dtsi
@@ -514,6 +514,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l151vctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vctx-pinctrl.dtsi
@@ -514,6 +514,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l151vctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vctxa-pinctrl.dtsi
@@ -514,6 +514,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l151vdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vdtx-pinctrl.dtsi
@@ -514,6 +514,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l151vdtxx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vdtxx-pinctrl.dtsi
@@ -514,6 +514,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l151vdyxx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vdyxx-pinctrl.dtsi
@@ -514,6 +514,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l151vetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151vetx-pinctrl.dtsi
@@ -514,6 +514,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l151veyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151veyx-pinctrl.dtsi
@@ -514,6 +514,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l151zctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151zctx-pinctrl.dtsi
@@ -662,6 +662,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l151zdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151zdtx-pinctrl.dtsi
@@ -662,6 +662,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l151zetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l151zetx-pinctrl.dtsi
@@ -662,6 +662,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l152qchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152qchx-pinctrl.dtsi
@@ -634,6 +634,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l152qdhx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152qdhx-pinctrl.dtsi
@@ -634,6 +634,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l152qehx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152qehx-pinctrl.dtsi
@@ -634,6 +634,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l152rctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152rctx-pinctrl.dtsi
@@ -365,6 +365,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l152rctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152rctxa-pinctrl.dtsi
@@ -365,6 +365,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l152rdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152rdtx-pinctrl.dtsi
@@ -365,6 +365,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l152rdyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152rdyx-pinctrl.dtsi
@@ -365,6 +365,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l152retx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152retx-pinctrl.dtsi
@@ -365,6 +365,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l152ucyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152ucyx-pinctrl.dtsi
@@ -365,6 +365,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l152vchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vchx-pinctrl.dtsi
@@ -514,6 +514,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l152vctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vctx-pinctrl.dtsi
@@ -514,6 +514,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l152vctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vctxa-pinctrl.dtsi
@@ -514,6 +514,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l152vdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vdtx-pinctrl.dtsi
@@ -514,6 +514,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l152vdtxx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vdtxx-pinctrl.dtsi
@@ -514,6 +514,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l152vetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152vetx-pinctrl.dtsi
@@ -514,6 +514,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l152veyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152veyx-pinctrl.dtsi
@@ -514,6 +514,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l152zctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152zctx-pinctrl.dtsi
@@ -662,6 +662,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l152zdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152zdtx-pinctrl.dtsi
@@ -662,6 +662,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l152zetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l152zetx-pinctrl.dtsi
@@ -662,6 +662,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l162qchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162qchx-pinctrl.dtsi
@@ -634,6 +634,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l162qdhx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162qdhx-pinctrl.dtsi
@@ -634,6 +634,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l162rctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162rctx-pinctrl.dtsi
@@ -365,6 +365,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l162rctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162rctxa-pinctrl.dtsi
@@ -365,6 +365,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l162rdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162rdtx-pinctrl.dtsi
@@ -365,6 +365,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l162rdyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162rdyx-pinctrl.dtsi
@@ -365,6 +365,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l162retx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162retx-pinctrl.dtsi
@@ -365,6 +365,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l162vchx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vchx-pinctrl.dtsi
@@ -514,6 +514,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l162vctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vctx-pinctrl.dtsi
@@ -514,6 +514,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l162vctxa-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vctxa-pinctrl.dtsi
@@ -514,6 +514,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l162vdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vdtx-pinctrl.dtsi
@@ -514,6 +514,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l162vdyxx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vdyxx-pinctrl.dtsi
@@ -514,6 +514,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l162vetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162vetx-pinctrl.dtsi
@@ -514,6 +514,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l162veyx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162veyx-pinctrl.dtsi
@@ -514,6 +514,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l162zctx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162zctx-pinctrl.dtsi
@@ -662,6 +662,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l162zdtx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162zdtx-pinctrl.dtsi
@@ -662,6 +662,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/l1/stm32l162zetx-pinctrl.dtsi
+++ b/dts/st/l1/stm32l162zetx-pinctrl.dtsi
@@ -662,6 +662,18 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pb15: i2s2_sd_pb15 {

--- a/dts/st/mp1/stm32mp151aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aaax-pinctrl.dtsi
@@ -1685,6 +1685,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pz6: i2s1_mck_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp151aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aabx-pinctrl.dtsi
@@ -1019,6 +1019,33 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp151aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aacx-pinctrl.dtsi
@@ -1573,6 +1573,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pz6: i2s1_mck_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp151aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aadx-pinctrl.dtsi
@@ -1019,6 +1019,33 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp151caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151caax-pinctrl.dtsi
@@ -1685,6 +1685,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pz6: i2s1_mck_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp151cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cabx-pinctrl.dtsi
@@ -1019,6 +1019,33 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp151cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cacx-pinctrl.dtsi
@@ -1573,6 +1573,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pz6: i2s1_mck_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp151cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cadx-pinctrl.dtsi
@@ -1019,6 +1019,33 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp151daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151daax-pinctrl.dtsi
@@ -1685,6 +1685,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pz6: i2s1_mck_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp151dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dabx-pinctrl.dtsi
@@ -1019,6 +1019,33 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp151dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dacx-pinctrl.dtsi
@@ -1573,6 +1573,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pz6: i2s1_mck_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp151dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dadx-pinctrl.dtsi
@@ -1019,6 +1019,33 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp151faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151faax-pinctrl.dtsi
@@ -1685,6 +1685,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pz6: i2s1_mck_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp151fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151fabx-pinctrl.dtsi
@@ -1019,6 +1019,33 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp151facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151facx-pinctrl.dtsi
@@ -1573,6 +1573,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pz6: i2s1_mck_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp151fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151fadx-pinctrl.dtsi
@@ -1019,6 +1019,33 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp153aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aaax-pinctrl.dtsi
@@ -1741,6 +1741,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pz6: i2s1_mck_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp153aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aabx-pinctrl.dtsi
@@ -1063,6 +1063,33 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp153aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aacx-pinctrl.dtsi
@@ -1629,6 +1629,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pz6: i2s1_mck_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp153aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aadx-pinctrl.dtsi
@@ -1063,6 +1063,33 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp153caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153caax-pinctrl.dtsi
@@ -1741,6 +1741,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pz6: i2s1_mck_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp153cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cabx-pinctrl.dtsi
@@ -1063,6 +1063,33 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp153cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cacx-pinctrl.dtsi
@@ -1629,6 +1629,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pz6: i2s1_mck_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp153cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cadx-pinctrl.dtsi
@@ -1063,6 +1063,33 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp153daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153daax-pinctrl.dtsi
@@ -1741,6 +1741,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pz6: i2s1_mck_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp153dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dabx-pinctrl.dtsi
@@ -1063,6 +1063,33 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp153dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dacx-pinctrl.dtsi
@@ -1629,6 +1629,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pz6: i2s1_mck_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp153dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dadx-pinctrl.dtsi
@@ -1063,6 +1063,33 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp153faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153faax-pinctrl.dtsi
@@ -1741,6 +1741,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pz6: i2s1_mck_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp153fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153fabx-pinctrl.dtsi
@@ -1063,6 +1063,33 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp153facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153facx-pinctrl.dtsi
@@ -1629,6 +1629,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pz6: i2s1_mck_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp153fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153fadx-pinctrl.dtsi
@@ -1063,6 +1063,33 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp157aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aaax-pinctrl.dtsi
@@ -1741,6 +1741,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pz6: i2s1_mck_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp157aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aabx-pinctrl.dtsi
@@ -1063,6 +1063,33 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp157aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aacx-pinctrl.dtsi
@@ -1629,6 +1629,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pz6: i2s1_mck_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp157aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aadx-pinctrl.dtsi
@@ -1063,6 +1063,33 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp157caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157caax-pinctrl.dtsi
@@ -1741,6 +1741,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pz6: i2s1_mck_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp157cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cabx-pinctrl.dtsi
@@ -1063,6 +1063,33 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp157cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cacx-pinctrl.dtsi
@@ -1629,6 +1629,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pz6: i2s1_mck_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp157cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cadx-pinctrl.dtsi
@@ -1063,6 +1063,33 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp157daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157daax-pinctrl.dtsi
@@ -1741,6 +1741,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pz6: i2s1_mck_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp157dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dabx-pinctrl.dtsi
@@ -1063,6 +1063,33 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp157dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dacx-pinctrl.dtsi
@@ -1629,6 +1629,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pz6: i2s1_mck_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp157dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dadx-pinctrl.dtsi
@@ -1063,6 +1063,33 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp157faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157faax-pinctrl.dtsi
@@ -1741,6 +1741,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pz6: i2s1_mck_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp157fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157fabx-pinctrl.dtsi
@@ -1063,6 +1063,33 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp157facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157facx-pinctrl.dtsi
@@ -1629,6 +1629,38 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s1_mck_pz6: i2s1_mck_pz6 {
+				pinmux = <STM32_PINMUX('Z', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/mp1/stm32mp157fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157fadx-pinctrl.dtsi
@@ -1063,6 +1063,33 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s1_mck_pc4: i2s1_mck_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pe1: i2s2_mck_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pc7: i2s3_mck_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s3_mck_pd13: i2s3_mck_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF6)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_WS */
 
 			/omit-if-no-ref/ i2s1_ws_pa4: i2s1_ws_pa4 {

--- a/dts/st/wl/stm32wl54ccux-pinctrl.dtsi
+++ b/dts/st/wl/stm32wl54ccux-pinctrl.dtsi
@@ -248,6 +248,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {

--- a/dts/st/wl/stm32wl54jcix-pinctrl.dtsi
+++ b/dts/st/wl/stm32wl54jcix-pinctrl.dtsi
@@ -374,6 +374,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {

--- a/dts/st/wl/stm32wl55ccux-pinctrl.dtsi
+++ b/dts/st/wl/stm32wl55ccux-pinctrl.dtsi
@@ -248,6 +248,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {

--- a/dts/st/wl/stm32wl55jcix-pinctrl.dtsi
+++ b/dts/st/wl/stm32wl55jcix-pinctrl.dtsi
@@ -374,6 +374,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {

--- a/dts/st/wl/stm32wle4c8ux-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle4c8ux-pinctrl.dtsi
@@ -248,6 +248,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {

--- a/dts/st/wl/stm32wle4cbux-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle4cbux-pinctrl.dtsi
@@ -248,6 +248,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {

--- a/dts/st/wl/stm32wle4ccux-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle4ccux-pinctrl.dtsi
@@ -248,6 +248,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {

--- a/dts/st/wl/stm32wle4j8ix-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle4j8ix-pinctrl.dtsi
@@ -374,6 +374,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {

--- a/dts/st/wl/stm32wle4jbix-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle4jbix-pinctrl.dtsi
@@ -374,6 +374,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {

--- a/dts/st/wl/stm32wle4jcix-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle4jcix-pinctrl.dtsi
@@ -374,6 +374,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {

--- a/dts/st/wl/stm32wle5c8ux-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle5c8ux-pinctrl.dtsi
@@ -248,6 +248,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {

--- a/dts/st/wl/stm32wle5cbux-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle5cbux-pinctrl.dtsi
@@ -248,6 +248,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {

--- a/dts/st/wl/stm32wle5ccux-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle5ccux-pinctrl.dtsi
@@ -248,6 +248,13 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {

--- a/dts/st/wl/stm32wle5j8ix-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle5j8ix-pinctrl.dtsi
@@ -374,6 +374,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {

--- a/dts/st/wl/stm32wle5jbix-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle5jbix-pinctrl.dtsi
@@ -374,6 +374,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {

--- a/dts/st/wl/stm32wle5jcix-pinctrl.dtsi
+++ b/dts/st/wl/stm32wle5jcix-pinctrl.dtsi
@@ -374,6 +374,23 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* I2S_MCK */
+
+			/omit-if-no-ref/ i2s2_mck_pa3: i2s2_mck_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pb14: i2s2_mck_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			/omit-if-no-ref/ i2s2_mck_pc6: i2s2_mck_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2S_SD */
 
 			/omit-if-no-ref/ i2s2_sd_pa10: i2s2_sd_pa10 {


### PR DESCRIPTION
Regenerate all of the ST dtsi files to incorporate the support of the available I2S MCK pins.

Depends on https://github.com/zephyrproject-rtos/hal_stm32/pull/162 and enables https://github.com/zephyrproject-rtos/zephyr/issues/54841