### PR TITLE
stm32cubec0xx: Correct patch list in readme

### DIFF
--- a/stm32cube/stm32c0xx/README
+++ b/stm32cube/stm32c0xx/README
@@ -37,8 +37,8 @@ License Link:
 Patch List:
 
    *Provision to enable hal & ll asserts added
-    -Added stm32cube/stm32g0xx/drivers/include/stm32_assert.h
-    -Removed unused stm32cube/stm32g0xx/drivers/include/stm32_assert_template.h
+    -Added stm32cube/stm32c0xx/drivers/include/stm32_assert.h
+    -Removed unused stm32cube/stm32c0xx/drivers/include/stm32_assert_template.h
 
    *Add missing LL function for setting flash latency
      This will allow the C0 series to use the STM32 common


### PR DESCRIPTION
Not that significant but I made a copy-paste misstake when fixing the last comment of [# 161](https://github.com/zephyrproject-rtos/hal_stm32/pull/161).