### PR TITLE
drivers: STM32U5 : ADC_LL : fix : fixed ADC4 single channel sampling

### DIFF
--- a/stm32cube/stm32u5xx/drivers/include/stm32u5xx_ll_adc.h
+++ b/stm32cube/stm32u5xx/drivers/include/stm32u5xx_ll_adc.h
@@ -4595,7 +4595,7 @@ __STATIC_INLINE void LL_ADC_REG_SetSequencerLength(ADC_TypeDef *ADCx, uint32_t S
   }
   else
   {
-    MODIFY_REG(ADCx->CHSELR, ADC_CHSELR_CHSEL,SequencerNbRanks);
+    MODIFY_REG(ADCx->CHSELR, ADC_CHSELR_CHSEL, SequencerNbRanks);
   }
 }
 

--- a/stm32cube/stm32u5xx/drivers/include/stm32u5xx_ll_adc.h
+++ b/stm32cube/stm32u5xx/drivers/include/stm32u5xx_ll_adc.h
@@ -4595,7 +4595,7 @@ __STATIC_INLINE void LL_ADC_REG_SetSequencerLength(ADC_TypeDef *ADCx, uint32_t S
   }
   else
   {
-    SET_BIT(ADCx->CHSELR, SequencerNbRanks);
+    MODIFY_REG(ADCx->CHSELR, ADC_CHSELR_CHSEL,SequencerNbRanks);
   }
 }
 


### PR DESCRIPTION
If read 2 different channels in turn, CHSELR register will content two channels. need erase register before write a new channel