### PR TITLE
scripts: genpinctrl: add support for FSMC pins

### DIFF
--- a/scripts/genpinctrl/stm32-pinctrl-config.yaml
+++ b/scripts/genpinctrl/stm32-pinctrl-config.yaml
@@ -139,7 +139,7 @@
   match: "^FDCAN\\d+_TX$"
 
 - name: FMC
-  match: "^FMC_(?:NL|NADV|CLK|NBL[0-3]|A\\d+|D\\d+|NE[1-4]|NOE|NWE|NWAIT|NCE|INT|SDCLK|SDNWE|SDCKE[0-1]|SDNE[0-1]|SDNRAS|SDNCAS)$"
+  match: "^FS?MC_(?:NL|NADV|CLK|NBL[0-3]|A\\d+|D\\d+|NE[1-4]|NOE|NWE|NWAIT|NCE|INT|SDCLK|SDNWE|SDCKE[0-1]|SDNE[0-1]|SDNRAS|SDNCAS)$"
   bias: pull-up
   slew-rate: very-high-speed
 


### PR DESCRIPTION
FSMC and FMC are very similar, but FSMC pins in STM32_open_pin_data are identified  as FSMC_xxx, so they are not included in generated pinctrl dts files.

This just modify the regex in the stm32-pinctrl-config.yaml file to match "FSMC" in addition to "FMC".

If accepted, dtsi files will have to be regenerated in a following PR.