### PR TITLE
stm32 hal driver has a function to check the memorymapped mode of a NOR flash

### DIFF
--- a/stm32cube/stm32h7xx/drivers/include/stm32h7xx_hal_ospi.h
+++ b/stm32cube/stm32h7xx/drivers/include/stm32h7xx_hal_ospi.h
@@ -826,6 +826,7 @@ HAL_StatusTypeDef     HAL_OSPI_AutoPolling_IT(OSPI_HandleTypeDef *hospi, OSPI_Au
 
 /* OSPI memory-mapped mode functions */
 HAL_StatusTypeDef     HAL_OSPI_MemoryMapped         (OSPI_HandleTypeDef *hospi, OSPI_MemoryMappedTypeDef *cfg);
+uint32_t HAL_OSPI_IsMemoryMapped(OSPI_HandleTypeDef *hospi);
 
 /* Callback functions in non-blocking modes ***********************************/
 void                  HAL_OSPI_ErrorCallback        (OSPI_HandleTypeDef *hospi);

--- a/stm32cube/stm32h7xx/drivers/include/stm32h7xx_hal_qspi.h
+++ b/stm32cube/stm32h7xx/drivers/include/stm32h7xx_hal_qspi.h
@@ -587,6 +587,7 @@ HAL_StatusTypeDef     HAL_QSPI_AutoPolling_IT(QSPI_HandleTypeDef *hqspi, QSPI_Co
 
 /* QSPI memory-mapped mode */
 HAL_StatusTypeDef     HAL_QSPI_MemoryMapped(QSPI_HandleTypeDef *hqspi, QSPI_CommandTypeDef *cmd, QSPI_MemoryMappedTypeDef *cfg);
+uint32_t HAL_QSPI_IsMemoryMapped(QSPI_HandleTypeDef *hqspi);
 
 /* Callback functions in non-blocking modes ***********************************/
 void                  HAL_QSPI_ErrorCallback        (QSPI_HandleTypeDef *hqspi);

--- a/stm32cube/stm32h7xx/drivers/src/stm32h7xx_hal_ospi.c
+++ b/stm32cube/stm32h7xx/drivers/src/stm32h7xx_hal_ospi.c
@@ -794,6 +794,16 @@ void HAL_OSPI_IRQHandler(OSPI_HandleTypeDef *hospi)
 }
 
 /**
+  * @brief  Check whether the flash is in MemoryMap or not.
+  * @param  hospi   : OSPI handle
+  * @retval Status (0: disabled, 1: enabled)
+  */
+uint32_t HAL_OSPI_IsMemoryMapped(OSPI_HandleTypeDef *hospi)
+{
+  return ((READ_BIT(hospi->Instance->CR, OCTOSPI_CR_FMODE) == OCTOSPI_CR_FMODE) ? 1UL : 0UL);
+}
+
+/**
   * @brief  Set the command configuration.
   * @param  hospi   : OSPI handle
   * @param  cmd     : structure that contains the command configuration information

--- a/stm32cube/stm32h7xx/drivers/src/stm32h7xx_hal_qspi.c
+++ b/stm32cube/stm32h7xx/drivers/src/stm32h7xx_hal_qspi.c
@@ -1778,6 +1778,16 @@ HAL_StatusTypeDef HAL_QSPI_MemoryMapped(QSPI_HandleTypeDef *hqspi, QSPI_CommandT
 }
 
 /**
+  * @brief  Check whether the flash is in MemoryMap or not.
+  * @param  hqspi   : QSPI handle
+  * @retval Status (0: disabled, 1: enabled)
+  */
+uint32_t HAL_QSPI_IsMemoryMapped(QSPI_HandleTypeDef *hqspi)
+{
+  return ((READ_BIT(hqspi->Instance->CCR, QUADSPI_CCR_FMODE) == QUADSPI_CCR_FMODE) ? 1UL : 0UL);
+}
+
+/**
   * @brief  Transfer Error callback.
   * @param  hqspi QSPI handle
   * @retval None

--- a/stm32cube/stm32l4xx/drivers/include/stm32l4xx_hal_ospi.h
+++ b/stm32cube/stm32l4xx/drivers/include/stm32l4xx_hal_ospi.h
@@ -807,6 +807,7 @@ HAL_StatusTypeDef     HAL_OSPI_AutoPolling_IT(OSPI_HandleTypeDef *hospi, OSPI_Au
 
 /* OSPI memory-mapped mode functions */
 HAL_StatusTypeDef     HAL_OSPI_MemoryMapped         (OSPI_HandleTypeDef *hospi, OSPI_MemoryMappedTypeDef *cfg);
+uint32_t HAL_OSPI_IsMemoryMapped(OSPI_HandleTypeDef *hospi);
 
 /* Callback functions in non-blocking modes ***********************************/
 void                  HAL_OSPI_ErrorCallback        (OSPI_HandleTypeDef *hospi);

--- a/stm32cube/stm32l4xx/drivers/include/stm32l4xx_hal_qspi.h
+++ b/stm32cube/stm32l4xx/drivers/include/stm32l4xx_hal_qspi.h
@@ -598,6 +598,7 @@ HAL_StatusTypeDef     HAL_QSPI_AutoPolling_IT(QSPI_HandleTypeDef *hqspi, QSPI_Co
 
 /* QSPI memory-mapped mode */
 HAL_StatusTypeDef     HAL_QSPI_MemoryMapped(QSPI_HandleTypeDef *hqspi, QSPI_CommandTypeDef *cmd, QSPI_MemoryMappedTypeDef *cfg);
+uint32_t HAL_QSPI_IsMemoryMapped(QSPI_HandleTypeDef *hqspi);
 
 /* Callback functions in non-blocking modes ***********************************/
 void                  HAL_QSPI_ErrorCallback        (QSPI_HandleTypeDef *hqspi);

--- a/stm32cube/stm32l4xx/drivers/src/stm32l4xx_hal_ospi.c
+++ b/stm32cube/stm32l4xx/drivers/src/stm32l4xx_hal_ospi.c
@@ -1861,6 +1861,16 @@ HAL_StatusTypeDef HAL_OSPI_MemoryMapped(OSPI_HandleTypeDef *hospi, OSPI_MemoryMa
 }
 
 /**
+  * @brief  Check whether the flash is in MemoryMap or not
+  * @param  hospi   : OSPI handle
+  * @retval Status (0: disabled, 1: enabled)
+  */
+uint32_t HAL_OSPI_IsMemoryMapped(OSPI_HandleTypeDef *hospi)
+{
+  return ((READ_BIT(hospi->Instance->CR, OCTOSPI_CR_FMODE) == OCTOSPI_CR_FMODE) ? 1UL : 0UL);
+}
+
+/**
   * @brief  Transfer Error callback.
   * @param  hospi : OSPI handle
   * @retval None

--- a/stm32cube/stm32l4xx/drivers/src/stm32l4xx_hal_qspi.c
+++ b/stm32cube/stm32l4xx/drivers/src/stm32l4xx_hal_qspi.c
@@ -1858,6 +1858,16 @@ HAL_StatusTypeDef HAL_QSPI_MemoryMapped(QSPI_HandleTypeDef *hqspi, QSPI_CommandT
 }
 
 /**
+  * @brief  Check whether the flash is in MemoryMap or not
+  * @param  hqspi   : QSPI handle
+  * @retval Status (0: disabled, 1: enabled)
+  */
+uint32_t HAL_QSPI_IsMemoryMapped(QSPI_HandleTypeDef *hqspi)
+{
+  return ((READ_BIT(hqspi->Instance->CCR, QUADSPI_CCR_FMODE) == QUADSPI_CCR_FMODE) ? 1UL : 0UL);
+}
+
+/**
   * @brief  Transfer Error callback.
   * @param  hqspi QSPI handle
   * @retval None

--- a/stm32cube/stm32l5xx/drivers/include/stm32l5xx_hal_ospi.h
+++ b/stm32cube/stm32l5xx/drivers/include/stm32l5xx_hal_ospi.h
@@ -780,6 +780,7 @@ HAL_StatusTypeDef     HAL_OSPI_AutoPolling_IT(OSPI_HandleTypeDef *hospi, OSPI_Au
 
 /* OSPI memory-mapped mode functions */
 HAL_StatusTypeDef     HAL_OSPI_MemoryMapped         (OSPI_HandleTypeDef *hospi, OSPI_MemoryMappedTypeDef *cfg);
+uint32_t HAL_OSPI_IsMemoryMapped(OSPI_HandleTypeDef *hospi);
 
 /* Callback functions in non-blocking modes ***********************************/
 void                  HAL_OSPI_ErrorCallback        (OSPI_HandleTypeDef *hospi);

--- a/stm32cube/stm32l5xx/drivers/src/stm32l5xx_hal_ospi.c
+++ b/stm32cube/stm32l5xx/drivers/src/stm32l5xx_hal_ospi.c
@@ -1848,6 +1848,16 @@ HAL_StatusTypeDef HAL_OSPI_MemoryMapped(OSPI_HandleTypeDef *hospi, OSPI_MemoryMa
 }
 
 /**
+  * @brief  Check whether the flash is in MemoryMap or not.
+  * @param  hospi   : OSPI handle
+  * @retval Status (0: disabled, 1: enabled)
+  */
+uint32_t HAL_OSPI_IsMemoryMapped(OSPI_HandleTypeDef *hospi)
+{
+  return ((READ_BIT(hospi->Instance->CR, OCTOSPI_CR_FMODE) == OCTOSPI_CR_FMODE) ? 1UL : 0UL);
+}
+
+/**
   * @brief  Transfer Error callback.
   * @param  hospi : OSPI handle
   * @retval None

--- a/stm32cube/stm32u5xx/drivers/include/stm32u5xx_hal_ospi.h
+++ b/stm32cube/stm32u5xx/drivers/include/stm32u5xx_hal_ospi.h
@@ -832,6 +832,7 @@ HAL_StatusTypeDef     HAL_OSPI_AutoPolling_IT(OSPI_HandleTypeDef *hospi, OSPI_Au
 
 /* OSPI memory-mapped mode functions */
 HAL_StatusTypeDef     HAL_OSPI_MemoryMapped(OSPI_HandleTypeDef *hospi, OSPI_MemoryMappedTypeDef *cfg);
+uint32_t HAL_OSPI_IsMemoryMapped(OSPI_HandleTypeDef *hospi);
 
 /* Callback functions in non-blocking modes ***********************************/
 void                  HAL_OSPI_ErrorCallback(OSPI_HandleTypeDef *hospi);

--- a/stm32cube/stm32u5xx/drivers/src/stm32u5xx_hal_ospi.c
+++ b/stm32cube/stm32u5xx/drivers/src/stm32u5xx_hal_ospi.c
@@ -1979,6 +1979,16 @@ HAL_StatusTypeDef HAL_OSPI_MemoryMapped(OSPI_HandleTypeDef *hospi, OSPI_MemoryMa
 }
 
 /**
+  * @brief  Check whether the flash is in MemoryMap or not.
+  * @param  hospi   : OSPI handle
+  * @retval Status (0: disabled, 1: enabled)
+  */
+uint32_t HAL_OSPI_IsMemoryMapped(OSPI_HandleTypeDef *hospi)
+{
+  return ((READ_BIT(hospi->Instance->CR, OCTOSPI_CR_FMODE) == OCTOSPI_CR_FMODE) ? 1UL : 0UL);
+}
+
+/**
   * @brief  Transfer Error callback.
   * @param  hospi : OSPI handle
   * @retval None


### PR DESCRIPTION
Add a function to check if the Quad or Octo NOR flash is in memoryMapped mode to the series:
 stm23U5x serie
 stm32H7x serie 
 stm23L5x serie
 stm23L4x serie  

