### PR TITLE
Stm32h503  does not enable the driver if instance is not present

### DIFF
--- a/stm32cube/stm32h5xx/README
+++ b/stm32cube/stm32h5xx/README
@@ -54,7 +54,7 @@ Patch List:
        drivers/include/stm32h5xx_ll_spi.h
       ST internal bug : 147754
 
- *fix to the V2 HAL API to get PTP to work
+   *fix to the V2 HAL API to get PTP to work
      impacted file : stm32h5xx_hal_eth.c
      In the HAL_ETH_ReadData function where it checks for the last descriptor, 
      we added a checked if the TSA bit was set in DESC1
@@ -62,5 +62,15 @@ Patch List:
      after the last descriptor
      If the CTXT bit is set in the context descriptor then extract the timestamps
      ST internal bug : 161504
+
+   *fix compilation error when instance does not exist on stm32h50x devices
+    - Include the stm32h5xx_ll_dlyb.h only if the stm32h5 device has a SDMMC BLYB or OCTOSPI BLYB
+    - Include the stm32h5xx_hal_dcache.h only if the stm32h5 device has a DCACHE
+    - Include the stm32h5xx_hal_sai.h only if the stm32h5 device has a SAI block A or B
+      Impacted files:
+       drivers/include/stm32h5xx_ll_dlyb.h
+       drivers/include/stm32h5xx_hal_dcache.h
+       drivers/include/stm32h5xx_hal_sai.h
+      ST internal bug : 166551 166552 166553
 
    See release_note.html from STM32Cube

--- a/stm32cube/stm32h5xx/drivers/include/stm32h5xx_hal_dcache.h
+++ b/stm32cube/stm32h5xx/drivers/include/stm32h5xx_hal_dcache.h
@@ -31,6 +31,8 @@ extern "C" {
   * @{
   */
 
+#if defined (DCACHE1)
+
 /** @addtogroup DCACHE
   * @{
   */
@@ -317,6 +319,8 @@ uint32_t HAL_DCACHE_GetError(DCACHE_HandleTypeDef *hdcache);
 /**
   * @}
   */
+
+#endif /* DCACHE1 */
 
 /**
   * @}

--- a/stm32cube/stm32h5xx/drivers/include/stm32h5xx_hal_sai.h
+++ b/stm32cube/stm32h5xx/drivers/include/stm32h5xx_hal_sai.h
@@ -31,6 +31,8 @@ extern "C" {
   * @{
   */
 
+#if defined(SAI1_Block_A) || defined(SAI1_Block_B)
+
 /** @addtogroup SAI
   * @{
   */
@@ -956,6 +958,8 @@ uint32_t HAL_SAI_GetError(const SAI_HandleTypeDef *hsai);
 /**
   * @}
   */
+
+#endif /* SAI1_Block_A || SAI1_Block_B */
 
 /**
   * @}

--- a/stm32cube/stm32h5xx/drivers/include/stm32h5xx_ll_dlyb.h
+++ b/stm32cube/stm32h5xx/drivers/include/stm32h5xx_ll_dlyb.h
@@ -31,7 +31,7 @@ extern "C" {
   * @{
   */
 
-#if defined(HAL_SD_MODULE_ENABLED) || defined(HAL_OSPI_MODULE_ENABLED) || defined(HAL_XSPI_MODULE_ENABLED)
+#if defined(DLYB_SDMMC1) || defined(DLYB_SDMMC2) || defined(DLYB_OCTOSPI1) || defined(DLYB_OCTOSPI2)
 
 /* Exported types ------------------------------------------------------------*/
 /** @defgroup DLYB_LL DLYB
@@ -128,7 +128,7 @@ uint32_t LL_DLYB_GetClockPeriod(DLYB_TypeDef *DLYBx, LL_DLYB_CfgTypeDef *pdlyb_c
   * @}
   */
 
-#endif /* HAL_SD_MODULE_ENABLED || HAL_OSPI_MODULE_ENABLED || HAL_XSPI_MODULE_ENABLED */
+#endif /* DLYB_SDMMC1 || DLYB_SDMMC2 || DLYB_OCTOSPI1 || DLYB_OCTOSPI2 */
 
 /**
   * @}


### PR DESCRIPTION
The stm32h503 soc does not embed delayblock (DLYB) or SAI block or DCACHE instances.
Consequently the corresponding drivers should be included.


