### PR TITLE
scripts: serie_update: add Git commands to fetch HAL Drivers Git submodules

### DIFF
--- a/scripts/serie_update.py
+++ b/scripts/serie_update.py
@@ -192,14 +192,22 @@ class Stm32SerieUpdate:
             # if already exists, then just clean and fetch
             self.os_cmd(("git", "clean", "-fdx"), cwd=self.stm32cube_serie_path)
             self.os_cmd(("git", "fetch"), cwd=self.stm32cube_serie_path)
+            # this is useful when HAL drivers submodules are not aleardy
+            # present locally, otherwise "git fetch" is sufficient
+            self.os_cmd(("git", "submodule", "update", "--init"),
+                        cwd=self.stm32cube_serie_path)
             branch = self.major_branch()
             self.os_cmd(
                 ("git", "reset", "--hard", branch),
                 cwd=self.stm32cube_serie_path,
             )
         else:
+            # HAL drivers are now included as git submodules in upstream
+            # STM32Cube repositories
+            # So, we need to add --recursive or --recurse-submodules to
+            # "git clone" to fetch them
             self.os_cmd(
-                ("git", "clone", repo_name),
+                ("git", "clone", "--recursive", repo_name),
                 cwd=self.stm32cube_repo_path,
             )
             branch = self.major_branch()


### PR DESCRIPTION
STM32Cube HAL drivers are now included as Git submodules in the upstream STM32Cube repositories. So we need additional commands to fetch them.
For "git clone", we need to add --recursive or "--recurse-submodules".
For "git fetch", if it's the 1st time the local Cube directories are updated after the change in the upstream repositories, "git submodule update --init" is needed to specifically fetch the HAL Drivers submodules.