### PR TITLE
Revert "scripts: serie_update: fetch submodules"

### DIFF
--- a/scripts/serie_update.py
+++ b/scripts/serie_update.py
@@ -192,22 +192,14 @@ class Stm32SerieUpdate:
             # if already exists, then just clean and fetch
             self.os_cmd(("git", "clean", "-fdx"), cwd=self.stm32cube_serie_path)
             self.os_cmd(("git", "fetch"), cwd=self.stm32cube_serie_path)
-            # this is useful when HAL drivers submodules are not aleardy
-            # present locally, otherwise "git fetch" is sufficient
-            self.os_cmd(("git", "submodule", "update", "--init"),
-                        cwd=self.stm32cube_serie_path)
             branch = self.major_branch()
             self.os_cmd(
                 ("git", "reset", "--hard", branch),
                 cwd=self.stm32cube_serie_path,
             )
         else:
-            # HAL drivers are now included as git submodules in upstream
-            # STM32Cube repositories
-            # So, we need to add --recursive or --recurse-submodules to
-            # "git clone" to fetch them
             self.os_cmd(
-                ("git", "clone", "--recursive", repo_name),
+                ("git", "clone", repo_name),
                 cwd=self.stm32cube_repo_path,
             )
             branch = self.major_branch()


### PR DESCRIPTION
This reverts commit 818cef7f16ea0a2cb211ae3de06ea8a1e0d0da1a.
Changes introduced in this commit (PR #182) are not enough to update Cube packages correctly following the introduction of submodules in the upstream STM32Cube repos.