### PR TITLE
stm32cube: ll_spi: enhance interrupt register handling for stm32h5xx, h7xx, mp1xx, u5xx, wbaxx

### DIFF
--- a/stm32cube/stm32h5xx/drivers/include/stm32h5xx_ll_spi.h
+++ b/stm32cube/stm32h5xx/drivers/include/stm32h5xx_ll_spi.h
@@ -1795,6 +1795,17 @@ __STATIC_INLINE uint32_t LL_SPI_GetRxFIFOPackingLevel(const SPI_TypeDef *SPIx)
 }
 
 /**
+  * @brief  Clear interrupt/status flag by setting corresponding bit in IFCR register
+  * @param  SPIx SPI Instance
+  * @param  ClearBits Clear bits
+  * @retval None
+  */
+__STATIC_INLINE void LL_SPI_ClearFlag(SPI_TypeDef *SPIx, uint32_t ClearBits)
+{
+  WRITE_REG(SPIx->IFCR, ClearBits);
+}
+
+/**
   * @brief  Clear End Of Transfer flag
   * @rmtoll IFCR         EOTC          LL_SPI_ClearFlag_EOT
   * @param  SPIx SPI Instance

--- a/stm32cube/stm32h5xx/drivers/include/stm32h5xx_ll_spi.h
+++ b/stm32cube/stm32h5xx/drivers/include/stm32h5xx_ll_spi.h
@@ -1802,7 +1802,7 @@ __STATIC_INLINE uint32_t LL_SPI_GetRxFIFOPackingLevel(const SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_EOT(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_EOTC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_EOTC);
 }
 
 /**
@@ -1813,7 +1813,7 @@ __STATIC_INLINE void LL_SPI_ClearFlag_EOT(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_TXTF(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_TXTFC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_TXTFC);
 }
 
 /**
@@ -1824,7 +1824,7 @@ __STATIC_INLINE void LL_SPI_ClearFlag_TXTF(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_UDR(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_UDRC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_UDRC);
 }
 
 /**
@@ -1835,7 +1835,7 @@ __STATIC_INLINE void LL_SPI_ClearFlag_UDR(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_OVR(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_OVRC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_OVRC);
 }
 
 /**
@@ -1846,7 +1846,7 @@ __STATIC_INLINE void LL_SPI_ClearFlag_OVR(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_CRCERR(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_CRCEC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_CRCEC);
 }
 
 /**
@@ -1857,7 +1857,7 @@ __STATIC_INLINE void LL_SPI_ClearFlag_CRCERR(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_MODF(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_MODFC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_MODFC);
 }
 
 /**
@@ -1868,7 +1868,7 @@ __STATIC_INLINE void LL_SPI_ClearFlag_MODF(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_FRE(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_TIFREC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_TIFREC);
 }
 
 /**
@@ -1879,7 +1879,7 @@ __STATIC_INLINE void LL_SPI_ClearFlag_FRE(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_SUSP(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_SUSPC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_SUSPC);
 }
 
 /**

--- a/stm32cube/stm32h5xx/drivers/include/stm32h5xx_ll_spi.h
+++ b/stm32cube/stm32h5xx/drivers/include/stm32h5xx_ll_spi.h
@@ -1891,6 +1891,17 @@ __STATIC_INLINE void LL_SPI_ClearFlag_SUSP(SPI_TypeDef *SPIx)
   */
 
 /**
+  * @brief  Enable IT by setting corresponding bit in IER register
+  * @param  SPIx SPI Instance
+  * @param  EnableBits Enable bits
+  * @retval None
+  */
+__STATIC_INLINE void LL_SPI_EnableIT(SPI_TypeDef *SPIx, uint32_t EnableBits)
+{
+  SET_BIT(SPIx->IER, EnableBits);
+}
+
+/**
   * @brief  Enable Rx Packet available IT
   * @rmtoll IER          RXPIE         LL_SPI_EnableIT_RXP
   * @param  SPIx SPI Instance
@@ -1998,6 +2009,17 @@ __STATIC_INLINE void LL_SPI_EnableIT_FRE(SPI_TypeDef *SPIx)
 __STATIC_INLINE void LL_SPI_EnableIT_MODF(SPI_TypeDef *SPIx)
 {
   SET_BIT(SPIx->IER, SPI_IER_MODFIE);
+}
+
+/**
+  * @brief  Disable IT by setting corresponding bit in IER register
+  * @param  SPIx SPI Instance
+  * @param  DisableBits Disable bits
+  * @retval None
+  */
+__STATIC_INLINE void LL_SPI_DisableIT(SPI_TypeDef *SPIx, uint32_t DisableBits)
+{
+  CLEAR_BIT(SPIx->IER, DisableBits);
 }
 
 /**

--- a/stm32cube/stm32h7xx/drivers/include/stm32h7xx_ll_spi.h
+++ b/stm32cube/stm32h7xx/drivers/include/stm32h7xx_ll_spi.h
@@ -1870,6 +1870,17 @@ __STATIC_INLINE uint32_t LL_SPI_GetRxFIFOPackingLevel(SPI_TypeDef *SPIx)
 }
 
 /**
+  * @brief  Clear interrupt/status flag by setting corresponding bit in IFCR register
+  * @param  SPIx SPI Instance
+  * @param  ClearBits Clear bits
+  * @retval None
+  */
+__STATIC_INLINE void LL_SPI_ClearFlag(SPI_TypeDef *SPIx, uint32_t ClearBits)
+{
+  WRITE_REG(SPIx->IFCR, ClearBits);
+}
+
+/**
   * @brief  Clear End Of Transfer flag
   * @rmtoll IFCR         EOTC          LL_SPI_ClearFlag_EOT
   * @param  SPIx SPI Instance

--- a/stm32cube/stm32h7xx/drivers/include/stm32h7xx_ll_spi.h
+++ b/stm32cube/stm32h7xx/drivers/include/stm32h7xx_ll_spi.h
@@ -1977,6 +1977,17 @@ __STATIC_INLINE void LL_SPI_ClearFlag_SUSP(SPI_TypeDef *SPIx)
   */
 
 /**
+  * @brief  Enable IT by setting corresponding bit in IER register
+  * @param  SPIx SPI Instance
+  * @param  EnableBits Enable bits
+  * @retval None
+  */
+__STATIC_INLINE void LL_SPI_EnableIT(SPI_TypeDef *SPIx, uint32_t EnableBits)
+{
+  SET_BIT(SPIx->IER, EnableBits);
+}
+
+/**
   * @brief  Enable Rx Packet available IT
   * @rmtoll IER          RXPIE         LL_SPI_EnableIT_RXP
   * @param  SPIx SPI Instance
@@ -2095,6 +2106,17 @@ __STATIC_INLINE void LL_SPI_EnableIT_MODF(SPI_TypeDef *SPIx)
 __STATIC_INLINE void LL_SPI_EnableIT_TSER(SPI_TypeDef *SPIx)
 {
   SET_BIT(SPIx->IER, SPI_IER_TSERFIE);
+}
+
+/**
+  * @brief  Disable IT by setting corresponding bit in IER register
+  * @param  SPIx SPI Instance
+  * @param  DisableBits Disable bits
+  * @retval None
+  */
+__STATIC_INLINE void LL_SPI_DisableIT(SPI_TypeDef *SPIx, uint32_t DisableBits)
+{
+  CLEAR_BIT(SPIx->IER, DisableBits);
 }
 
 /**

--- a/stm32cube/stm32h7xx/drivers/include/stm32h7xx_ll_spi.h
+++ b/stm32cube/stm32h7xx/drivers/include/stm32h7xx_ll_spi.h
@@ -1877,7 +1877,7 @@ __STATIC_INLINE uint32_t LL_SPI_GetRxFIFOPackingLevel(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_EOT(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_EOTC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_EOTC);
 }
 
 /**
@@ -1888,7 +1888,7 @@ __STATIC_INLINE void LL_SPI_ClearFlag_EOT(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_TXTF(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_TXTFC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_TXTFC);
 }
 
 /**
@@ -1899,7 +1899,7 @@ __STATIC_INLINE void LL_SPI_ClearFlag_TXTF(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_UDR(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_UDRC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_UDRC);
 }
 
 /**
@@ -1910,7 +1910,7 @@ __STATIC_INLINE void LL_SPI_ClearFlag_UDR(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_OVR(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_OVRC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_OVRC);
 }
 
 /**
@@ -1921,7 +1921,7 @@ __STATIC_INLINE void LL_SPI_ClearFlag_OVR(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_CRCERR(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_CRCEC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_CRCEC);
 }
 
 /**
@@ -1932,7 +1932,7 @@ __STATIC_INLINE void LL_SPI_ClearFlag_CRCERR(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_MODF(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_MODFC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_MODFC);
 }
 
 /**
@@ -1943,7 +1943,7 @@ __STATIC_INLINE void LL_SPI_ClearFlag_MODF(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_FRE(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_TIFREC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_TIFREC);
 }
 
 /**
@@ -1954,7 +1954,7 @@ __STATIC_INLINE void LL_SPI_ClearFlag_FRE(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_TSER(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_TSERFC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_TSERFC);
 }
 
 /**
@@ -1965,7 +1965,7 @@ __STATIC_INLINE void LL_SPI_ClearFlag_TSER(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_SUSP(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_SUSPC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_SUSPC);
 }
 
 /**

--- a/stm32cube/stm32mp1xx/drivers/include/stm32mp1xx_ll_spi.h
+++ b/stm32cube/stm32mp1xx/drivers/include/stm32mp1xx_ll_spi.h
@@ -1870,6 +1870,17 @@ __STATIC_INLINE uint32_t LL_SPI_GetRxFIFOPackingLevel(SPI_TypeDef *SPIx)
 }
 
 /**
+  * @brief  Clear interrupt/status flag by setting corresponding bit in IFCR register
+  * @param  SPIx SPI Instance
+  * @param  ClearBits Clear bits
+  * @retval None
+  */
+__STATIC_INLINE void LL_SPI_ClearFlag(SPI_TypeDef *SPIx, uint32_t ClearBits)
+{
+  WRITE_REG(SPIx->IFCR, ClearBits);
+}
+
+/**
   * @brief  Clear End Of Transfer flag
   * @rmtoll IFCR         EOTC          LL_SPI_ClearFlag_EOT
   * @param  SPIx SPI Instance

--- a/stm32cube/stm32mp1xx/drivers/include/stm32mp1xx_ll_spi.h
+++ b/stm32cube/stm32mp1xx/drivers/include/stm32mp1xx_ll_spi.h
@@ -1877,7 +1877,7 @@ __STATIC_INLINE uint32_t LL_SPI_GetRxFIFOPackingLevel(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_EOT(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_EOTC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_EOTC);
 }
 
 /**
@@ -1888,7 +1888,7 @@ __STATIC_INLINE void LL_SPI_ClearFlag_EOT(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_TXTF(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_TXTFC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_TXTFC);
 }
 
 /**
@@ -1899,7 +1899,7 @@ __STATIC_INLINE void LL_SPI_ClearFlag_TXTF(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_UDR(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_UDRC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_UDRC);
 }
 
 /**
@@ -1910,7 +1910,7 @@ __STATIC_INLINE void LL_SPI_ClearFlag_UDR(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_OVR(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_OVRC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_OVRC);
 }
 
 /**
@@ -1921,7 +1921,7 @@ __STATIC_INLINE void LL_SPI_ClearFlag_OVR(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_CRCERR(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_CRCEC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_CRCEC);
 }
 
 /**
@@ -1932,7 +1932,7 @@ __STATIC_INLINE void LL_SPI_ClearFlag_CRCERR(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_MODF(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_MODFC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_MODFC);
 }
 
 /**
@@ -1943,7 +1943,7 @@ __STATIC_INLINE void LL_SPI_ClearFlag_MODF(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_FRE(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_TIFREC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_TIFREC);
 }
 
 /**
@@ -1954,7 +1954,7 @@ __STATIC_INLINE void LL_SPI_ClearFlag_FRE(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_TSER(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_TSERFC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_TSERFC);
 }
 
 /**
@@ -1965,7 +1965,7 @@ __STATIC_INLINE void LL_SPI_ClearFlag_TSER(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_SUSP(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_SUSPC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_SUSPC);
 }
 
 /**

--- a/stm32cube/stm32mp1xx/drivers/include/stm32mp1xx_ll_spi.h
+++ b/stm32cube/stm32mp1xx/drivers/include/stm32mp1xx_ll_spi.h
@@ -1977,6 +1977,17 @@ __STATIC_INLINE void LL_SPI_ClearFlag_SUSP(SPI_TypeDef *SPIx)
   */
 
 /**
+  * @brief  Enable IT by setting corresponding bit in IER register
+  * @param  SPIx SPI Instance
+  * @param  EnableBits Enable bits
+  * @retval None
+  */
+__STATIC_INLINE void LL_SPI_EnableIT(SPI_TypeDef *SPIx, uint32_t EnableBits)
+{
+  SET_BIT(SPIx->IER, EnableBits);
+}
+
+/**
   * @brief  Enable Rx Packet available IT
   * @rmtoll IER          RXPIE         LL_SPI_EnableIT_RXP
   * @param  SPIx SPI Instance
@@ -2084,6 +2095,17 @@ __STATIC_INLINE void LL_SPI_EnableIT_FRE(SPI_TypeDef *SPIx)
 __STATIC_INLINE void LL_SPI_EnableIT_MODF(SPI_TypeDef *SPIx)
 {
   SET_BIT(SPIx->IER, SPI_IER_MODFIE);
+}
+
+/**
+  * @brief  Disable IT by setting corresponding bit in IER register
+  * @param  SPIx SPI Instance
+  * @param  DisableBits Disable bits
+  * @retval None
+  */
+__STATIC_INLINE void LL_SPI_DisableIT(SPI_TypeDef *SPIx, uint32_t DisableBits)
+{
+  CLEAR_BIT(SPIx->IER, DisableBits);
 }
 
 /**

--- a/stm32cube/stm32u5xx/drivers/include/stm32u5xx_ll_spi.h
+++ b/stm32cube/stm32u5xx/drivers/include/stm32u5xx_ll_spi.h
@@ -1976,6 +1976,17 @@ __STATIC_INLINE void LL_SPI_ClearFlag_SUSP(SPI_TypeDef *SPIx)
   */
 
 /**
+  * @brief  Enable IT by setting corresponding bit in IER register
+  * @param  SPIx SPI Instance
+  * @param  EnableBits Enable bits
+  * @retval None
+  */
+__STATIC_INLINE void LL_SPI_EnableIT(SPI_TypeDef *SPIx, uint32_t EnableBits)
+{
+  SET_BIT(SPIx->IER, EnableBits);
+}
+
+/**
   * @brief  Enable Rx Packet available IT
   * @rmtoll IER          RXPIE         LL_SPI_EnableIT_RXP
   * @param  SPIx SPI Instance
@@ -2083,6 +2094,17 @@ __STATIC_INLINE void LL_SPI_EnableIT_FRE(SPI_TypeDef *SPIx)
 __STATIC_INLINE void LL_SPI_EnableIT_MODF(SPI_TypeDef *SPIx)
 {
   SET_BIT(SPIx->IER, SPI_IER_MODFIE);
+}
+
+/**
+  * @brief  Disable IT by setting corresponding bit in IER register
+  * @param  SPIx SPI Instance
+  * @param  DisableBits Disable bits
+  * @retval None
+  */
+__STATIC_INLINE void LL_SPI_DisableIT(SPI_TypeDef *SPIx, uint32_t DisableBits)
+{
+  CLEAR_BIT(SPIx->IER, DisableBits);
 }
 
 /**

--- a/stm32cube/stm32u5xx/drivers/include/stm32u5xx_ll_spi.h
+++ b/stm32cube/stm32u5xx/drivers/include/stm32u5xx_ll_spi.h
@@ -1887,7 +1887,7 @@ __STATIC_INLINE uint32_t LL_SPI_GetRxFIFOPackingLevel(const SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_EOT(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_EOTC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_EOTC);
 }
 
 /**
@@ -1898,7 +1898,7 @@ __STATIC_INLINE void LL_SPI_ClearFlag_EOT(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_TXTF(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_TXTFC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_TXTFC);
 }
 
 /**
@@ -1909,7 +1909,7 @@ __STATIC_INLINE void LL_SPI_ClearFlag_TXTF(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_UDR(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_UDRC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_UDRC);
 }
 
 /**
@@ -1920,7 +1920,7 @@ __STATIC_INLINE void LL_SPI_ClearFlag_UDR(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_OVR(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_OVRC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_OVRC);
 }
 
 /**
@@ -1931,7 +1931,7 @@ __STATIC_INLINE void LL_SPI_ClearFlag_OVR(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_CRCERR(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_CRCEC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_CRCEC);
 }
 
 /**
@@ -1942,7 +1942,7 @@ __STATIC_INLINE void LL_SPI_ClearFlag_CRCERR(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_MODF(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_MODFC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_MODFC);
 }
 
 /**
@@ -1953,7 +1953,7 @@ __STATIC_INLINE void LL_SPI_ClearFlag_MODF(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_FRE(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_TIFREC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_TIFREC);
 }
 
 /**
@@ -1964,7 +1964,7 @@ __STATIC_INLINE void LL_SPI_ClearFlag_FRE(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_SUSP(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_SUSPC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_SUSPC);
 }
 
 /**

--- a/stm32cube/stm32u5xx/drivers/include/stm32u5xx_ll_spi.h
+++ b/stm32cube/stm32u5xx/drivers/include/stm32u5xx_ll_spi.h
@@ -1880,6 +1880,17 @@ __STATIC_INLINE uint32_t LL_SPI_GetRxFIFOPackingLevel(const SPI_TypeDef *SPIx)
 }
 
 /**
+  * @brief  Clear interrupt/status flag by setting corresponding bit in IFCR register
+  * @param  SPIx SPI Instance
+  * @param  ClearBits Clear bits
+  * @retval None
+  */
+__STATIC_INLINE void LL_SPI_ClearFlag(SPI_TypeDef *SPIx, uint32_t ClearBits)
+{
+  WRITE_REG(SPIx->IFCR, ClearBits);
+}
+
+/**
   * @brief  Clear End Of Transfer flag
   * @rmtoll IFCR         EOTC          LL_SPI_ClearFlag_EOT
   * @param  SPIx SPI Instance

--- a/stm32cube/stm32wbaxx/drivers/include/stm32wbaxx_ll_spi.h
+++ b/stm32cube/stm32wbaxx/drivers/include/stm32wbaxx_ll_spi.h
@@ -1973,6 +1973,17 @@ __STATIC_INLINE void LL_SPI_ClearFlag_SUSP(SPI_TypeDef *SPIx)
   */
 
 /**
+  * @brief  Enable IT by setting corresponding bit in IER register
+  * @param  SPIx SPI Instance
+  * @param  EnableBits Enable bits
+  * @retval None
+  */
+__STATIC_INLINE void LL_SPI_EnableIT(SPI_TypeDef *SPIx, uint32_t EnableBits)
+{
+  SET_BIT(SPIx->IER, EnableBits);
+}
+
+/**
   * @brief  Enable Rx Packet available IT
   * @rmtoll IER          RXPIE         LL_SPI_EnableIT_RXP
   * @param  SPIx SPI Instance
@@ -2080,6 +2091,17 @@ __STATIC_INLINE void LL_SPI_EnableIT_FRE(SPI_TypeDef *SPIx)
 __STATIC_INLINE void LL_SPI_EnableIT_MODF(SPI_TypeDef *SPIx)
 {
   SET_BIT(SPIx->IER, SPI_IER_MODFIE);
+}
+
+/**
+  * @brief  Disable IT by setting corresponding bit in IER register
+  * @param  SPIx SPI Instance
+  * @param  DisableBits Disable bits
+  * @retval None
+  */
+__STATIC_INLINE void LL_SPI_DisableIT(SPI_TypeDef *SPIx, uint32_t DisableBits)
+{
+  CLEAR_BIT(SPIx->IER, DisableBits);
 }
 
 /**

--- a/stm32cube/stm32wbaxx/drivers/include/stm32wbaxx_ll_spi.h
+++ b/stm32cube/stm32wbaxx/drivers/include/stm32wbaxx_ll_spi.h
@@ -1877,6 +1877,17 @@ __STATIC_INLINE uint32_t LL_SPI_GetRxFIFOPackingLevel(const SPI_TypeDef *SPIx)
 }
 
 /**
+  * @brief  Clear interrupt/status flag by setting corresponding bit in IFCR register
+  * @param  SPIx SPI Instance
+  * @param  ClearBits Clear bits
+  * @retval None
+  */
+__STATIC_INLINE void LL_SPI_ClearFlag(SPI_TypeDef *SPIx, uint32_t ClearBits)
+{
+  WRITE_REG(SPIx->IFCR, ClearBits);
+}
+
+/**
   * @brief  Clear End Of Transfer flag
   * @rmtoll IFCR         EOTC          LL_SPI_ClearFlag_EOT
   * @param  SPIx SPI Instance

--- a/stm32cube/stm32wbaxx/drivers/include/stm32wbaxx_ll_spi.h
+++ b/stm32cube/stm32wbaxx/drivers/include/stm32wbaxx_ll_spi.h
@@ -1884,7 +1884,7 @@ __STATIC_INLINE uint32_t LL_SPI_GetRxFIFOPackingLevel(const SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_EOT(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_EOTC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_EOTC);
 }
 
 /**
@@ -1895,7 +1895,7 @@ __STATIC_INLINE void LL_SPI_ClearFlag_EOT(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_TXTF(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_TXTFC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_TXTFC);
 }
 
 /**
@@ -1906,7 +1906,7 @@ __STATIC_INLINE void LL_SPI_ClearFlag_TXTF(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_UDR(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_UDRC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_UDRC);
 }
 
 /**
@@ -1917,7 +1917,7 @@ __STATIC_INLINE void LL_SPI_ClearFlag_UDR(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_OVR(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_OVRC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_OVRC);
 }
 
 /**
@@ -1928,7 +1928,7 @@ __STATIC_INLINE void LL_SPI_ClearFlag_OVR(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_CRCERR(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_CRCEC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_CRCEC);
 }
 
 /**
@@ -1939,7 +1939,7 @@ __STATIC_INLINE void LL_SPI_ClearFlag_CRCERR(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_MODF(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_MODFC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_MODFC);
 }
 
 /**
@@ -1950,7 +1950,7 @@ __STATIC_INLINE void LL_SPI_ClearFlag_MODF(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_FRE(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_TIFREC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_TIFREC);
 }
 
 /**
@@ -1961,7 +1961,7 @@ __STATIC_INLINE void LL_SPI_ClearFlag_FRE(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_ClearFlag_SUSP(SPI_TypeDef *SPIx)
 {
-  SET_BIT(SPIx->IFCR, SPI_IFCR_SUSPC);
+  WRITE_REG(SPIx->IFCR, SPI_IFCR_SUSPC);
 }
 
 /**


### PR DESCRIPTION
- add LL_SPI_EnableIT, LL_SPI_DisableIT
This update eliminates the need for individual calls to manipulate interrupt bits.

- use WRITE_REG to clear SPIx->IFCR
This adjustment reduces operations from read/write to write-only.

- add LL_SPI_ClearFlag
This update eliminates the need for individual calls to clear bits.